### PR TITLE
improve nodejs builders and translators

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,8 @@
             export d2nExternalSources=${externalSourcesFor."${system}"}
             export dream2nixWithExternals=${dream2nixFor."${system}".dream2nixWithExternals}
             export d2nExternalSources=$dream2nixWithExternals/external
+
+            echo "\nManually execute 'export dream2nixWithExternals={path to your dream2nix checkout}'"
           '';
         });
       };

--- a/src/apps/cli/commands/package.py
+++ b/src/apps/cli/commands/package.py
@@ -306,7 +306,6 @@ class PackageCommand(Command):
             # remove_dependecy(indexed_pkgs, G, cycle[-1][0], cycle[-1][1])
             node_from, node_to = cycle[-1][0], cycle[-1][1]
             G.remove_edge(node_from, node_to)
-            depGraph[node_from].remove(node_to)
             removed_edges.append((node_from, node_to))
         except nx.NetworkXNoCycle:
           continue

--- a/src/builders/nodejs/granular/fix-package-lock.py
+++ b/src/builders/nodejs/granular/fix-package-lock.py
@@ -9,13 +9,23 @@ with open(sys.argv[2]) as f:
   package_json = json.load(f)
 
 changed = False
+
+# delete devDependencies
+if 'devDependencies' in package_json:
+  print(
+    f"Removing devDependencies from package.json",
+    file=sys.stderr
+  )
+  changed = True
+  del package_json['devDependencies']
+
 if 'dependencies' in package_json:
   for pname, version in package_json['dependencies'].items():
     if actual_deps[pname] != package_json['dependencies'][pname]:
       package_json['dependencies'][pname] = actual_deps[pname]
       changed = True
       print(
-        f"WARNING: replacing malformed version '{version}' for dependency '{pname}' in package.json",
+        f"Replacing loose version '{version}' with '{actual_deps[pname]}' for dependency '{pname}' in package.json",
         file=sys.stderr
       )
 

--- a/src/builders/nodejs/node2nix/default.nix
+++ b/src/builders/nodejs/node2nix/default.nix
@@ -18,16 +18,21 @@
   mainPackageVersion,
   getDependencies,
   getSource,
+  packageVersions,
+
+  # overrides
+  packageOverrides ? {},
   ...
 }@args:
 let
   b = builtins;
 
   getDependencies = name: version:
+    (
     if dependenciesRemoved ? "${name}" && dependenciesRemoved."${name}" ? "${version}" then
       dependenciesRemoved."${name}"."${version}" ++ (args.getDependencies name version)
     else
-      args.getDependencies name version;
+      args.getDependencies name version);
 
   mainPackageKey = "${mainPackageName}#${mainPackageVersion}";
 
@@ -40,30 +45,56 @@ let
     or (throw "Could not find nodejs version '${nodejsVersion}' in pkgs");
 
   node2nixEnv = node2nix nodejs;
+
+  # allSources =
+  #   lib.mapAttrs
+  #     (packageName: versions:
+  #       lib.genAttrs versions
+  #         (version: {
+  #           inherit packageName version;
+  #           name = utils.sanitizeDerivationName packageName;
+  #           src = getSource packageName version;
+  #           dependencies =
+  #             # b.trace "current package: ${packageName}#${version}"
+  #             lib.forEach
+  #               (lib.filter
+  #                 (dep: (! builtins.elem dep mainPackageDependencies))
+  #                 (getDependencies packageName version))
+  #               (dep:
+  #                 # b.trace "accessing allSources.${dep.name}.${dep.version}"
+  #                 b.trace "${dep.name}#${dep.version}"
+  #                 allSources."${dep.name}"."${dep.version}"
+  #               );
+  #         }))
+  #     packageVersions;
+
+  makeSource = packageName: version: prevDeps:
+    rec {
+      inherit packageName version;
+      name = utils.sanitizeDerivationName packageName;
+      src = getSource packageName version;
+      dependencies =
+        let
+          parentDeps = prevDeps ++ depsFiltered;
+          depsFiltered =
+            (lib.filter
+            (dep:
+              ! b.elem dep prevDeps)
+            (getDependencies packageName version));
+        in
+          lib.forEach
+            depsFiltered
+            (dep: makeSource dep.name dep.version parentDeps);
+    };
   
   node2nixDependencies =
-    let
-      makeSource = packageName: version:
-        {
-          inherit packageName version;
-          name = utils.sanitizeDerivationName packageName;
-          src = getSource packageName version;
-          dependencies =
-            lib.forEach
-              (lib.filter
-                (dep: ! builtins.elem dep mainPackageDependencies)
-                (getDependencies packageName version))
-              (dep:
-                makeSource dep.name dep.version
-              );
-        };
-    in
-      lib.forEach
-        mainPackageDependencies
-        (dep: makeSource dep.name dep.version);
+    lib.forEach
+      mainPackageDependencies
+      (dep: makeSource dep.name dep.version mainPackageDependencies);
+      # (dep: allSources."${dep.name}"."${dep.version}");
 
   callNode2Nix = funcName: args:
-    node2nixEnv."${funcName}" rec {
+    node2nixEnv."${funcName}" (rec {
       name = utils.sanitizeDerivationName packageName;
       packageName = mainPackageName;
       version = mainPackageVersion;
@@ -81,13 +112,19 @@ let
       reconstructLock = true;
       src = getSource mainPackageName mainPackageVersion;
     }
-    // args;
+    // args);
 
 in
 {
 
-  package = callNode2Nix "buildNodePackage" {};
+  package =
+    let
+      pkg = callNode2Nix "buildNodePackage" {};
+    in
+      utils.applyOverridesToPackage packageOverrides pkg mainPackageName;
 
   shell = callNode2Nix "buildNodeShell" {};
+
+  # inherit allSources;
     
 }

--- a/src/fetchers/combined-fetcher.nix
+++ b/src/fetchers/combined-fetcher.nix
@@ -35,9 +35,13 @@ let
                 passthru.originalArgs = args;
               })).originalArgs
 
+            # handle path sources
+            else if lib.isString fetched then
+              "ignore"
+
             # handle unknown sources
             else if fetched == "unknown" then
-              "unknown"
+              "ignore"
 
             # error out on unknown source types
             else
@@ -48,7 +52,7 @@ let
           )
           defaultFetched;
     in
-      lib.filterAttrs (pname: fetcherArgs: fetcherArgs != "unknown") FODArgsAll';
+      lib.filterAttrs (pname: fetcherArgs: fetcherArgs != "ignore") FODArgsAll';
 
   # convert arbitrary types to string, like nix does with derivation arguments
   toString = x:

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -8,6 +8,8 @@
 }:
 {
   # sources attrset from generic lock
+  mainPackageName,
+  mainPackageVersion,
   sources,
   ...
 }:
@@ -28,6 +30,8 @@ let
                   "${pname}#${version}"
                   (if source.type == "unknown" then
                     "unknown"
+                  else if source.type == "path" then
+                    "${fetchedSources."${mainPackageName}#${mainPackageVersion}"}/${source.path}"
                   else if fetchers.fetchers ? "${source.type}" then
                     fetchSource { inherit source; }
                   else throw "unsupported source type '${source.type}'")

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -21,17 +21,12 @@
                     "github",
                     "gitlab",
                     "path",
-                    "pypi-sdist"
+                    "pypi-sdist",
+                    "unknown"
                   ]
                 }
               },
               "allOf": [
-                {
-                  "if": {
-                    "properties": { "type": { "const": "unknown" } }
-                  },
-                  "then": { "properties": {} }
-                },
                 {
                   "if": {
                     "properties": { "type": { "const": "fetchurl" } }
@@ -101,6 +96,18 @@
                       "type": { "type": "string" }
                     },
                     "required": ["type", "pname"],
+                    "additionalProperties": false
+                  }
+                },
+                {
+                  "if": {
+                    "properties": { "type": { "const": "unknown" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "type": { "type": "string" }
+                    },
+                    "required": ["type"],
                     "additionalProperties": false
                   }
                 }

--- a/src/translators/default.nix
+++ b/src/translators/default.nix
@@ -14,6 +14,8 @@
 }: 
 let
 
+  b = builtins;
+
   lib = pkgs.lib;
 
   callTranslator = subsystem: type: name: file: args: 
@@ -111,7 +113,7 @@ let
         if def.type == "flag" then
           false
         else
-          def.default
+          def.default or null
       )
       specialArgsDef;
 

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -108,6 +108,16 @@ rec {
   
   sanitizeDerivationName = name:
     lib.replaceStrings [ "@" "/" ] [ "__at__" "__slash__" ] name;
-  
+
+  keyToNameVersion = key:
+    let
+      split = lib.splitString "#" key;
+      name = b.elemAt split 0;
+      version = b.elemAt split 1;
+    in
+      { inherit name version; };
+
+  nameVersionToKey = nameVersion:
+    "${nameVersion.name}#${nameVersion.version}";
 
 }


### PR DESCRIPTION
  - add buildPackageWithOtherBuilder helper
  - do not delete cyclic dependencies by default
  - always delete devDependencies in package.json
  - fix handling of source type `path`
  - yarn-lock: handle missing name
  - update utils.dreamLock interface
  - add `createMissingSource` capability to simpleTranslator