### PR TITLE
Improve nodejs translators and API of builders

### DIFF
--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -451,4 +451,4 @@ class AddCommand(Command):
     print(f"Created {output}/dream-lock.json")
 
     if config['isRepo']:
-      sp.run(f"git add -N {output}".split())
+      sp.run(["git", "add", "-N", output])

--- a/src/apps/cli/utils.py
+++ b/src/apps/cli/utils.py
@@ -33,7 +33,16 @@ with open(os.environ.get("dream2nixConfig")) as f:
 def checkLockJSON(lock):
   lock_schema_raw=open(dream2nix_src+"/specifications/dream-lock-schema.json").read()
   lock_schema=json.loads(lock_schema_raw)
-  validate(lock, schema=lock_schema)
+  try:
+    validate(lock, schema=lock_schema)
+  except:
+    print(
+      "Error in lock. Dumping for debugging at ./dream-lock.json.fail",
+      file=sys.stderr,
+    )
+    with open("./dream-lock.json.fail", 'w') as f:
+      json.dump(lock, f, indent=2)
+    raise
 
 
 def callNixFunction(function_path, **kwargs):

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -137,6 +137,19 @@ let
 
             export sourceRoot="$nodeModules/$packageName"
 
+            # sometimes tarballs do not end with .tar.??
+            unpackFallback(){
+              local fn="$1"
+
+              if [[ "$fn" == *tarball ]]; then
+                tar xf "$fn"
+              else
+                return 1
+              fi
+            }
+
+            unpackCmdHooks+=(unpackFallback)
+
             unpackFile $src
 
             # Make the base dir in which the target dependency resides in first

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -140,12 +140,7 @@ let
             # sometimes tarballs do not end with .tar.??
             unpackFallback(){
               local fn="$1"
-
-              if [[ "$fn" == *tarball ]]; then
-                tar xf "$fn"
-              else
-                return 1
-              fi
+              tar xf "$fn"
             }
 
             unpackCmdHooks+=(unpackFallback)

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -267,9 +267,9 @@ let
             # execute install command
             if [ -n "$buildScript" ]; then
               if [ -f "$buildScript" ]; then
-                exec $buildScript
+                $buildScript
               else
-                echo "$buildScript" | bash
+                eval "$buildScript"
               fi
             # by default, only for top level packages, `npm run build` is executed
             elif [ -n "$runBuild" ] && [ "$(jq '.scripts.build' ./package.json)" != "null" ]; then
@@ -308,12 +308,6 @@ let
         });
     in
       pkg;
-      # apply packageOverrides to current derivation
-      # (utils.applyOverridesToPackage {
-      #   inherit outputs pkg;
-      #   conditionalOverrides = packageOverrides;
-      #   pname = name;
-      # });
 
 in
 outputs

--- a/src/builders/nodejs/granular/fix-package.py
+++ b/src/builders/nodejs/granular/fix-package.py
@@ -27,9 +27,11 @@ if 'os' in package_json:
 
 # replace version
 # If it is a github dependency referred by revision,
-# we can not rely on the version inside the package.json
+# we can not rely on the version inside the package.json.
+# In case of an 'unknown' version coming from the dream lock,
+# do not  override the version from package.json
 version = os.environ.get("version")
-if package_json['version'] != version:
+if version not in ["unknown", package_json['version']]:
   print(
     "WARNING: The version of this package defined by its package.json "
     "doesn't match the version expected by dream2nix."

--- a/src/templates/builders/default.nix
+++ b/src/templates/builders/default.nix
@@ -28,10 +28,11 @@
   # where versions is a list of version strings
   packageVersions,
 
-  # Overrides
-  # Those must be applied by the builder to each individual derivation
-  # using `utils.applyOverridesToPackage`
-  packageOverrides ? {},
+  # function which applies overrides to a package
+  # It must be applied by the builder to each individual derivation
+  # Example:
+  #   produceDerivation name (mkDerivation {...})
+  produceDerivation,
 
   # Custom Options: (parametrize builder behavior)
   # These can be passed by the user via `builderArgs`.

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -25,9 +25,11 @@
 
       dev = ! noDev;
 
+      inputDir = lib.elemAt inputDirectories 0;
+
       packageLock =
         if inputDirectories != [] then
-          "${lib.elemAt inputDirectories 0}/package-lock.json"
+          "${inputDir}/package-lock.json"
         else
           lib.elemAt inputFiles 0;
 
@@ -43,8 +45,20 @@
       getVersion = dependencyObject:
         if identifyGitSource dependencyObject then
           "0.0.0-rc.${b.substring 0 8 (utils.parseGitUrl dependencyObject.version).rev}"
+        else if lib.hasPrefix "file:" dependencyObject.version then
+          let
+            path = getPath dependencyObject;
+          in
+            (b.fromJSON
+              (b.readFile "${inputDir}/${path}/package.json")
+            ).version
+        else if lib.hasPrefix "https://" dependencyObject.version then
+          "unknown"
         else
           dependencyObject.version;
+
+      getPath = dependencyObject:
+        lib.removePrefix "file:" dependencyObject.version;
       
       pinVersions = dependencies: parentScopeDeps:
         lib.mapAttrs
@@ -132,6 +146,8 @@
         getSourceType = dependencyObject:
           if identifyGitSource dependencyObject then
             "git"
+          else if lib.hasPrefix "file:" dependencyObject.version then
+            "path"
           else
             "http";
         
@@ -141,10 +157,23 @@
             utils.parseGitUrl dependencyObject.version;
 
           http = dependencyObject:
+            if lib.hasPrefix "https://" dependencyObject.version then
+              rec {
+                version = getVersion dependencyObject;
+                url = dependencyObject.version;
+                hash = dependencyObject.integrity;
+              }
+            else
+              rec {
+                version = getVersion dependencyObject;
+                url = dependencyObject.resolved;
+                hash = dependencyObject.integrity;
+              };
+
+          path = dependencyObject:
             rec {
-              version = dependencyObject.version;
-              url = dependencyObject.resolved;
-              hash = dependencyObject.integrity;
+              version = getVersion dependencyObject;
+              path = getPath dependencyObject;
             };
         };
 

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -83,9 +83,15 @@
       
       packageLockWithPinnedVersions = pinVersions parsedDependencies parsedDependencies;
 
+      createMissingSource = name: version:
+        {
+          type = "http";
+          url = "https://registry.npmjs.org/${name}/-/${name}-${version}.tgz";
+        };
+
     in
 
-      utils.simpleTranslate translatorName {
+      utils.simpleTranslate translatorName rec {
         # values
         inputData = packageLockWithPinnedVersions;
 
@@ -161,6 +167,13 @@
               rec {
                 version = getVersion dependencyObject;
                 url = dependencyObject.version;
+                hash = dependencyObject.integrity;
+              }
+            else if dependencyObject.resolved == false then
+              (createMissingSource
+                (getName dependencyObject)
+                (getVersion dependencyObject))
+              // {
                 hash = dependencyObject.integrity;
               }
             else

--- a/src/utils/override.nix
+++ b/src/utils/override.nix
@@ -159,7 +159,7 @@ let
                     if b.length applicableFuncs == 0 then
                       "overrideAttrs"
                     else if b.length applicableFuncs > 1 then
-                      throwErrorUnclearAttributeOverride Hpname condOverride._name attrName
+                      throwErrorUnclearAttributeOverride pname condOverride._name attrName
                     else
                       b.elemAt applicableFuncs 0;
 

--- a/src/utils/override.nix
+++ b/src/utils/override.nix
@@ -54,19 +54,32 @@ let
       ```
     '';
 
-  applyOverridesToPackage = conditionalOverrides: pkg: pname:
-    # if ! conditionalOverrides ? "${pname}" then
-    #   pkg
-    # else
-      
+  getOverrideFunctionArgs = function:
+    let
+      funcArgs = lib.functionArgs function;
+    in
+      if funcArgs != {} then
+        b.attrNames funcArgs
+      else
+        (
+          function (old: {passthru.funcArgs = lib.attrNames old;})
+        ).funcArgs;
+
+  applyOverridesToPackage =
+    {
+      conditionalOverrides,
+      pkg,
+      pname,
+      packages,
+    }:
       let
 
         # if condition is unset, it will be assumed true
         evalCondition = condOverride: pkg:
-            if condOverride ? _condition then
-              condOverride._condition pkg
-            else
-              true;
+          if condOverride ? _condition then
+            condOverride._condition pkg
+          else
+            true;
 
         # filter the overrides by the package name and conditions
         overridesToApply =
@@ -88,7 +101,9 @@ let
 
             overridesListForPackage =
               lib.mapAttrsToList
-                (_name: data: data // { inherit _name; })
+                (_name: data:
+                  data // { inherit _name; }
+                )
                 overridesForPackage;
           in
             (lib.filter
@@ -97,10 +112,10 @@ let
 
         # apply single attribute override
         applySingleAttributeOverride = oldVal: functionOrValue:
-           if b.isFunction functionOrValue then
-              functionOrValue oldVal
-            else
-              functionOrValue;
+          if b.isFunction functionOrValue then
+            functionOrValue oldVal
+          else
+            functionOrValue;
 
         # helper to apply one conditional override
         # the condition is not evaluated anymore here
@@ -128,7 +143,7 @@ let
               let
                 availableFunctions =
                   lib.mapAttrs
-                    (funcName: func: lib.attrNames (lib.functionArgs func))
+                    (funcName: func: getOverrideFunctionArgs func)
                     (lib.filterAttrs
                       (funcName: func: lib.hasPrefix "override" funcName)
                       base_derivation);
@@ -143,8 +158,8 @@ let
                   in
                     if b.length applicableFuncs == 0 then
                       "overrideAttrs"
-                    else if b.length applicableFuncs >= 1 then
-                      throwErrorUnclearAttributeOverride pname condOverride._name attrName
+                    else if b.length applicableFuncs > 1 then
+                      throwErrorUnclearAttributeOverride Hpname condOverride._name attrName
                     else
                       b.elemAt applicableFuncs 0;
 
@@ -175,12 +190,12 @@ let
                       updateAttrsFuncs))
               base_derivation
               (overrideFuncs ++ singleArgOverrideFuncs);
-      in
-        # apply the overrides to the given pkg
-        (lib.foldl
-          (pkg: condOverride: applyOneOverride pkg condOverride)
-          pkg
-          overridesToApply);
+        in
+          # apply the overrides to the given pkg
+          (lib.foldl
+            (pkg: condOverride: applyOneOverride pkg condOverride)
+            pkg
+            overridesToApply);
 
 in
 {

--- a/src/utils/parsing.nix
+++ b/src/utils/parsing.nix
@@ -7,26 +7,41 @@ let
   b = builtins;
 
   identifyGitUrl = url:
-    lib.hasPrefix "git+" url;
+    lib.hasPrefix "git+" url
+    || b.match ''^github:.*/.*#.*'' url != null;
 
   parseGitUrl = url:
     let
-      splitUrlRev = lib.splitString "#" url;
-      rev = lib.last splitUrlRev;
-      urlOnly = lib.head splitUrlRev;
+      githubMatch = b.match ''^github:(.*)/(.*)#(.*)$'' url;
     in
-      if lib.hasPrefix "git+ssh://" urlOnly then
-        {
-          inherit rev;
-          url = "https://${(lib.last (lib.splitString "@" url))}";
-        }
-      else if lib.hasPrefix "git+https://" urlOnly then
-        {
-          inherit rev;
-          url = lib.removePrefix "git+" urlOnly;
-        }
+      if githubMatch != null then
+        let
+          owner = b.elemAt githubMatch 0;
+          repo = b.elemAt githubMatch 1;
+          rev = b.elemAt githubMatch 2;
+        in
+          {
+            url = "https://github.com/${owner}/${repo}";
+            inherit rev;
+          }
       else
-        throw "Cannot parse git url: ${url}";
+        let
+          splitUrlRev = lib.splitString "#" url;
+          rev = lib.last splitUrlRev;
+          urlOnly = lib.head splitUrlRev;
+        in
+          if lib.hasPrefix "git+ssh://" urlOnly then
+            {
+              inherit rev;
+              url = "https://${(lib.last (lib.splitString "@" url))}";
+            }
+          else if lib.hasPrefix "git+https://" urlOnly then
+            {
+              inherit rev;
+              url = lib.removePrefix "git+" urlOnly;
+            }
+          else
+            throw "Cannot parse git url: ${url}";
 
 
 in


### PR DESCRIPTION
Done:
  - handle more ways of dependency references in package-lock.json
  - handle `github:` git urls.
  - simplify applying overrides in builder by introducing new helper `produceDerivation`
  - fix: $buildScript execution