### PR TITLE
feat: pass version and pname to fetchers

### DIFF
--- a/src/fetchers/crates-io/default.nix
+++ b/src/fetchers/crates-io/default.nix
@@ -8,10 +8,7 @@
 }:
 {
 
-  inputs = [
-    "pname"
-    "version"
-  ];
+  inputs = [ "pname" "version" ];
 
   versionField = "version";
 

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -34,8 +34,7 @@ let
                 "${fetchedSources."${mainPackageName}"."${mainPackageVersion}"}/${source.path}"
             else if fetchers.fetchers ? "${source.type}" then
               fetchSource {
-                inherit source;
-                dependencyInfo = {
+                source = source // {
                   pname = name;
                   inherit version;
                 };

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -33,7 +33,13 @@ let
               else
                 "${fetchedSources."${mainPackageName}"."${mainPackageVersion}"}/${source.path}"
             else if fetchers.fetchers ? "${source.type}" then
-              fetchSource { inherit source; sourceVersion = version; }
+              fetchSource {
+                inherit source;
+                dependencyInfo = {
+                  pname = name;
+                  inherit version;
+                };
+              }
             else throw "unsupported source type '${source.type}'")
           versions)
       sources;

--- a/src/fetchers/default.nix
+++ b/src/fetchers/default.nix
@@ -42,7 +42,7 @@ rec {
           '' false
           else true
         ) args;
-      argsKeep = overrideWarning [ "name" "version" ] args;
+      argsKeep = overrideWarning [ "pname" "version" ] args;
       fetcherOutputs = fetcher.outputs (argsKeep // dependencyInfo);
     in
       argsKeep

--- a/src/fetchers/npm/default.nix
+++ b/src/fetchers/npm/default.nix
@@ -7,14 +7,10 @@
   ...
 }:
 {
-
-  inputs = [
-    "pname"
-    "version"
-  ];
-
+  inputs = [ "pname" "version" ];
+  
   versionField = "version";
-
+  
   # defaultUpdater = "";
 
   outputs = { pname, version, }@inp:

--- a/src/fetchers/pypi-sdist/default.nix
+++ b/src/fetchers/pypi-sdist/default.nix
@@ -7,10 +7,7 @@
 }:
 {
 
-  inputs = [
-    "pname"
-    "version"
-  ];
+  inputs = [ "pname" "version" ];
 
   versionField = "version";
 

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -82,13 +82,11 @@
                   },
                   "then": {
                     "properties": {
-                      "pname": { "type": "string" },
-                      "version": { "type": "string" },
                       "hash": { "type": "string" },
                       "type": { "type": "string" },
                       "dir": { "type": "string" }
                     },
-                    "required": ["type", "pname"],
+                    "required": ["type"],
                     "additionalProperties": false
                   }
                 },
@@ -112,13 +110,11 @@
                   },
                   "then": {
                     "properties": {
-                      "pname": { "type": "string" },
-                      "version": { "type": "string" },
                       "hash": { "type": "string" },
                       "type": { "type": "string" },
                       "dir": { "type": "string" }
                     },
-                    "required": ["type", "pname"],
+                    "required": ["type"],
                     "additionalProperties": false
                   }
                 },
@@ -128,12 +124,10 @@
                   },
                   "then": {
                     "properties": {
-                      "pname": { "type": "string" },
-                      "version": { "type": "string" },
                       "hash": { "type": "string" },
                       "type": { "type": "string" }
                     },
-                    "required": ["type", "pname"],
+                    "required": ["type"],
                     "additionalProperties": false
                   }
                 },

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -200,8 +200,6 @@
             
           crates-io = dependencyObject:
             {
-              pname = dependencyObject.name;
-              version = dependencyObject.version;
               hash = dependencyObject.checksum;
             };
         };

--- a/src/utils/translator.nix
+++ b/src/utils/translator.nix
@@ -52,22 +52,28 @@ let
         serializedPackagesList;
 
       sources = b.foldl'
-        (result: pkgData: lib.recursiveUpdate result {
-          "${getName pkgData}" =
-            let pkgVersion = getVersion pkgData; in {
-              "${pkgVersion}" =
-                let
-                  type = getSourceType pkgData;
-                  constructedArgs =
-                    (sourceConstructors."${type}" pkgData)
-                    // {
-                      inherit type;
-                      version = pkgVersion;
-                   };
-                in
-                  fetchers.constructSource constructedArgs;
-            };
-        })
+        (result: pkgData:
+        let
+          pkgName = getName pkgData;
+          pkgVersion = getVersion pkgData;
+        in lib.recursiveUpdate result {
+            "${pkgName}" = {
+                "${pkgVersion}" =
+                  let
+                    type = getSourceType pkgData;
+                    constructedArgs =
+                      (sourceConstructors."${type}" pkgData)
+                      // {
+                        inherit type;
+                        dependencyInfo = {
+                          pname = pkgName;
+                          version = pkgVersion;
+                        };
+                     };
+                  in
+                    fetchers.constructSource constructedArgs;
+              };
+           })
         {}
         serializedPackagesList;
 


### PR DESCRIPTION
This PR changes fetcher interface so that both version and pname are now passed to fetchers. This is useful since we can drop `pname` and `version` from source constructors, and it makes the lock have less duplicated data. It also adds warnings if a source constructor uses `pname` and `version` fields, since they will be overrided by dream2nix.