### PR TITLE
feature: support multiple packages per source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,9 +158,23 @@
             export NIX_PATH=nixpkgs=${nixpkgs}
             export d2nExternalDir=${externalDirFor."${system}"}
             export dream2nixWithExternals=${dream2nixFor."${system}".dream2nixWithExternals}
-            export d2nOverridesDirs=${./overrides}
 
-            echo -e "\nManually execute 'export dream2nixWithExternals={path to your dream2nix checkout}'"
+            if [ -e ./overrides ]; then
+              export d2nOverridesDir=$(realpath ./overrides)
+            else
+              export d2nOverridesDir=${./overrides}
+              echo -e "\nManually execute 'export d2nOverridesDir={path to your dream2nix overrides dir}'"
+            fi
+
+            if [ -e ../dream2nix ]; then
+              export dream2nixWithExternals=$(realpath ./src)
+            else
+              export dream2nixWithExternals=${./src}
+              echo -e "\nManually execute 'export dream2nixWithExternals={path to your dream2nix checkout}'"
+            fi
+
+
+
           '';
         });
 

--- a/src/apps/cli/default.nix
+++ b/src/apps/cli/default.nix
@@ -62,7 +62,7 @@ in
       }:
 
       dream2nix.riseAndShine {
-        dreamLock = ./dream-lock.json;
+        source = ./dream-lock.json;
         ${lib.optionalString (dreamLock.sources."${mainPackageName}"."${mainPackageVersion}".type == "unknown") ''
           sourceOverrides = oldSources: {
               "${mainPackageName}"."${mainPackageVersion}" = ./${sourcePathRelative};

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -185,14 +185,12 @@
               }
             else
               rec {
-                version = getVersion dependencyObject;
                 url = dependencyObject.resolved;
                 hash = dependencyObject.integrity;
               };
 
           path = dependencyObject:
             rec {
-              version = getVersion dependencyObject;
               path = getPath dependencyObject;
             };
         };

--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -191,11 +191,10 @@
               if b.length githubUrlInfos == 7 then
                 let
                   rev = lib.elemAt githubUrlInfos 6;
-                  version = dependencyObject.version;
                 in
                   {
                     url = "https://github.com/${owner}/${repo}";
-                    inherit rev version;
+                    inherit rev;
                   }
               else if b.length githubUrlInfos == 5 then
                 let
@@ -215,13 +214,11 @@
         path = dependencyObject:
           if lib.hasInfix "@link:" dependencyObject.yarnName then
             {
-              version = dependencyObject.version;
               path =
                 lib.last (lib.splitString "@link:" dependencyObject.yarnName);
             }
           else if lib.hasInfix "@file:" dependencyObject.yarnName then
             {
-              version = dependencyObject.version;
               path =
               lib.last (lib.splitString "@file:" dependencyObject.yarnName);
             }
@@ -231,7 +228,6 @@
         http = dependencyObject:
           {
             type = "http";
-            version = dependencyObject.version;
             hash =
               if dependencyObject ? integrity then
                 dependencyObject.integrity

--- a/src/utils/config.nix
+++ b/src/utils/config.nix
@@ -15,7 +15,7 @@ let
       input
     else
       throw "input for loadAttrs must be json file or string or attrs";
-  
+
   # load dream2nix config extending with defaults
   loadConfig = configInput:
     let

--- a/src/utils/override.nix
+++ b/src/utils/override.nix
@@ -70,7 +70,7 @@ let
       conditionalOverrides,
       pkg,
       pname,
-      packages,
+      outputs,
     }:
       let
 
@@ -113,7 +113,13 @@ let
         # apply single attribute override
         applySingleAttributeOverride = oldVal: functionOrValue:
           if b.isFunction functionOrValue then
-            functionOrValue oldVal
+            if lib.functionArgs functionOrValue == {} then
+              functionOrValue oldVal
+            else
+              functionOrValue {
+                old = oldVal;
+                inherit outputs;
+              }
           else
             functionOrValue;
 
@@ -167,7 +173,7 @@ let
                   lib.filterAttrs
                     (n: v: ! lib.hasPrefix "override" n && ! lib.hasPrefix "_" n)
                     condOverride;
-              
+
               in
                 lib.mapAttrsToList
                     (attrName: funcOrValue: {


### PR DESCRIPTION
This adds basic support for handling projects that contain multiple sources of translatable metadata.
For example nodjs projects which contain multiple `package-lock.json` files in different directories can now be handled.

The CLI now accepts multiple source arguments. The first one will be the main project. All other sources will be translated into sub-directories aside the main `dream-lock.json`.
