### PR TITLE
fix(translator/cargo-lock): use cargoPackages instead of cargoTomls while searching for crates

### DIFF
--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -175,7 +175,7 @@
                   l.findFirst
                   (toml: toml.value.package.name == name)
                   (throw "could not find crate ${name}")
-                  cargoTomls
+                  cargoPackages
                 ).path;
             in
             {


### PR DESCRIPTION
This fixes an issue with `Cargo.toml` files that don't contain packages be picked up by the `findCratePath` function for the `path` source constructor.