### PR TITLE
fix(rust): handle git source vendoring properly

### DIFF
--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -12,6 +12,7 @@
   getCyclicDependencies,
   getDependencies,
   getSource,
+  getSourceSpec,
   produceDerivation,
 
   ...

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -52,6 +52,8 @@ let
         (source: "ln -s ${source.path} $out/${source.name}")
         sources
        }
+
+      ls -l $out
     '';
 
   buildPackage = pname: version:
@@ -60,10 +62,10 @@ let
       inherit pname version src;
 
       postUnpack = ''
-        ln -s ${vendorPackageDependencies pname version} ./${src.name}/nix-vendor
+        ln -s ${vendorPackageDependencies pname version} ./nix-vendor
       '';
 
-      cargoVendorDir = "nix-vendor";
+      cargoVendorDir = "../nix-vendor";
     });
 in
 rec {

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -30,6 +30,26 @@ let
       direct ++ (l.map (dep: getAllTransitiveDependencies dep.name dep.version) direct)
     ));
 
+  # TODO: this is shared between the translator and this builder
+  # we should dedup this somehow (maybe put in a common library for Rust subsystem?)
+  recurseFiles = path:
+    l.flatten (
+      l.mapAttrsToList
+      (n: v: if v == "directory" then recurseFiles "${path}/${n}" else "${path}/${n}")
+      (l.readDir path)
+    );
+  getAllFiles = dirs: l.flatten (l.map recurseFiles dirs);
+  getCargoTomlPaths = l.filter (path: l.baseNameOf path == "Cargo.toml");
+  getCargoTomls = l.map (path: { inherit path; value = l.fromTOML (l.readFile path); });
+  getCargoPackages = l.filter (toml: l.hasAttrByPath [ "package" "name" ] toml.value);
+  findCratePath = cargoPackages: name:
+    l.dirOf (
+      l.findFirst
+      (toml: toml.value.package.name == name)
+      (throw "could not find crate ${name}")
+      cargoPackages
+    ).path;
+  
   # TODO: implement a user option that will make the vendoring
   # copy sources instead of symlinking them. This can be useful
   # for some Rust packages that modify their own dependencies
@@ -38,10 +58,19 @@ let
     let
       deps = getAllTransitiveDependencies pname version;
 
-      makeSource = dep: {
-        name = "${dep.name}-${dep.version}";
-        path = getSource dep.name dep.version;
-      };
+      makeSource = dep:
+        let
+          # These locate the actual path of the crate in the source...
+          # This is important because git dependencies may or may not be in a
+          # workspace with complex crate hierarchies. This can locate the crate
+          # accurately using Cargo.toml files.
+          srcPath = getSource dep.name dep.version;
+          cargoPackages = l.pipe [ srcPath ] [ getAllFiles getCargoTomlPaths getCargoTomls getCargoPackages ];
+          path = findCratePath cargoPackages dep.name;
+        in {
+          name = "${dep.name}-${dep.version}";
+          inherit path;
+        };
       sources = l.map makeSource deps;
     in
     pkgs.runCommand "vendor-${pname}-${version}" {} ''

--- a/src/default.nix
+++ b/src/default.nix
@@ -302,6 +302,7 @@ let
 
           inherit (dreamLockInterface)
             subsystemAttrs
+            getSourceSpec
             getDependencies
             getCyclicDependencies
             mainPackageName

--- a/src/specifications/subsystems/rust/dream.lock.example.json
+++ b/src/specifications/subsystems/rust/dream.lock.example.json
@@ -3,10 +3,6 @@
     "packages": [
       { "name": "ripgrep", "version": "13.0.0" }
     ],
-    "gitDeps": [
-      { "name": "rand", "version": "0.8.4" },
-      { "name": "rand", "version": "0.7.3" }
-    ],
     "gitSources": [
       {
         "url": "https://github.com/rust-random/rand.git",

--- a/src/specifications/subsystems/rust/dream.lock.example.json
+++ b/src/specifications/subsystems/rust/dream.lock.example.json
@@ -2,6 +2,24 @@
   "_subsystem": {
     "packages": [
       { "name": "ripgrep", "version": "13.0.0" }
+    ],
+    "gitDeps": [
+      { "name": "rand", "version": "0.8.4" },
+      { "name": "rand", "version": "0.7.3" }
+    ],
+    "gitSources": [
+      {
+        "url": "https://github.com/rust-random/rand.git",
+        "sha": "19404d68764ed08513131f82157e2ccad69dcf83",
+        "type": "branch",
+        "value": "master"
+      },
+      {
+        "url": "https://github.com/rust-random/rand.git",
+        "sha": "074cb6a997f91db653f8a53c755ddc07495ab429",
+        "type": "tag",
+        "value": "0.7.3"
+      }
     ]
   }
 }

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -171,7 +171,9 @@
           #   ./src/specifications/{subsystem}
           subsystemAttrs = rec {
             packages = l.map (toml: { inherit (toml.value.package) name version; }) cargoPackages;
-            gitSources = l.unique (l.map (dep: parseGitSource dep.source) gitDeps);
+            gitSources = let
+              gitDeps = l.filter (dep: (getSourceTypeFrom dep) == "git") parsedDeps;
+            in l.unique (l.map (dep: parseGitSource dep.source) gitDeps);
           };
 
           # FUNCTIONS

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -171,7 +171,6 @@
           #   ./src/specifications/{subsystem}
           subsystemAttrs = rec {
             packages = l.map (toml: { inherit (toml.value.package) name version; }) cargoPackages;
-            gitDeps = l.filter (dep: (getSourceTypeFrom dep) == "git") parsedDeps;
             gitSources = l.unique (l.map (dep: parseGitSource dep.source) gitDeps);
           };
 

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -201,12 +201,12 @@
             path = dependencyObject:
               let
                 findCratePath = name:
-                  l.dirOf (
+                  l.baseNameOf (l.dirOf (
                     l.findFirst
                     (toml: toml.value.package.name == name)
                     (throw "could not find crate ${name}")
                     cargoPackages
-                  ).path;
+                  ).path);
               in
               {
                 path = findCratePath dependencyObject.name;

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -103,6 +103,33 @@
         name = toml.package.name;
         version = toml.package.version or (l.warn "no version found in Cargo.toml for ${name}, defaulting to unknown" "unknown");
       };
+      
+      # Parses a git source, taken straight from nixpkgs.
+      parseGitSource = src:
+        let
+          parts = builtins.match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
+          type = builtins.elemAt parts 2; # rev, tag or branch
+          value = builtins.elemAt parts 3;
+        in
+          if parts == null then null
+          else {
+            url = builtins.elemAt parts 0;
+            sha = builtins.elemAt parts 4;
+          } // lib.optionalAttrs (type != null) { inherit type value; };
+
+      # Extracts a source type from a dependency.
+      getSourceTypeFrom = dependencyObject:
+        let checkType = type: l.hasPrefix "${type}+" dependencyObject.source; in
+        if !(l.hasAttr "source" dependencyObject)
+        then "path"
+        else if checkType "git" then
+          "git"
+        else if checkType "registry" then
+          if dependencyObject.source == "registry+https://github.com/rust-lang/crates.io-index"
+          then "crates-io"
+          else throw "registries other than crates.io are not supported yet"
+        else
+          throw "unknown or unsupported source type: ${dependencyObject.source}";
     in
 
       utils.simpleTranslate
@@ -142,8 +169,10 @@
           # Extract subsystem specific attributes.
           # The structure of this should be defined in:
           #   ./src/specifications/{subsystem}
-          subsystemAttrs = {
+          subsystemAttrs = rec {
             packages = l.map (toml: { inherit (toml.value.package) name version; }) cargoPackages;
+            gitDeps = l.filter (dep: (getSourceTypeFrom dep) == "git") parsedDeps;
+            gitSources = l.unique (l.map (dep: parseGitSource dep.source) gitDeps);
           };
 
           # FUNCTIONS
@@ -162,18 +191,7 @@
             l.map makeDepNameVersion (dependencyObject.dependencies or [ ]);
 
           # return the source type of a package object
-          getSourceType = dependencyObject:
-            let checkType = type: l.hasPrefix "${type}+" dependencyObject.source; in
-            if !(l.hasAttr "source" dependencyObject)
-            then "path"
-            else if checkType "git" then
-              "git"
-            else if checkType "registry" then
-              if dependencyObject.source == "registry+https://github.com/rust-lang/crates.io-index"
-              then "crates-io"
-              else throw "registries other than crates.io are not supported yet"
-            else
-              throw "unknown or unsupported source type: ${dependencyObject.source}";
+          getSourceType = getSourceTypeFrom;
 
           # An attrset of constructor functions.
           # Given a dependency object and a source type, construct the
@@ -195,18 +213,11 @@
 
             git = dependencyObject:
               let
-                source = dependencyObject.source;
-
-                extractRevision = source: l.last (l.splitString "#" source);
-                extractRepoUrl = source:
-                  let
-                    splitted = l.head (l.splitString "?" source);
-                    split = l.substring 4 (l.stringLength splitted) splitted;
-                  in l.head (l.splitString "#" split);
+                parsed = parseGitSource dependencyObject.source;
               in
               {
-                url = extractRepoUrl source;
-                rev = extractRevision source;
+                url = parsed.url;
+                rev = parsed.sha;
               };
 
             crates-io = dependencyObject:

--- a/src/utils/dream-lock.nix
+++ b/src/utils/dream-lock.nix
@@ -77,6 +77,9 @@ let
 
       cyclicDependencies = lock.cyclicDependencies;
 
+      getSourceSpec = pname: version:
+        sources."${pname}"."${version}" or {};
+      
       getDependencies = pname: version:
         b.filter
           (dep: ! b.elem dep cyclicDependencies."${pname}"."${version}" or [])
@@ -96,6 +99,7 @@ let
             subsystemAttrs
             getCyclicDependencies
             getDependencies
+            getSourceSpec
             packageVersions
             subDreamLocks
           ;

--- a/src/utils/dream-lock.nix
+++ b/src/utils/dream-lock.nix
@@ -78,7 +78,9 @@ let
       cyclicDependencies = lock.cyclicDependencies;
 
       getSourceSpec = pname: version:
-        sources."${pname}"."${version}" or {};
+        sources."${pname}"."${version}" or (
+          throw "The source spec for ${pname}#${version} is not defined in lockfile."
+        );
       
       getDependencies = pname: version:
         b.filter


### PR DESCRIPTION
Before, git sources weren't vendored properly. This PR:
- writes vendor entries to .cargo/config before building
- writes .cargo-checksum in vendored sources for git deps
- handles workspace git dependencies where the crates are in subdirectories
- copies sources instead of symlinking them so we can write the cargo checksums