### PR TITLE
Recursive translation of sub-projects in CLI via `--sub-dirs`

### DIFF
--- a/src/apps/cli/utils.py
+++ b/src/apps/cli/utils.py
@@ -46,13 +46,17 @@ def checkLockJSON(lock):
     raise
 
 
+# Returns a mapping from (sub-)directories to translators.
+# Translators are sorted by compatibility
 def list_translators_for_source(sourcePath):
-  translatorsList = callNixFunction(
-    "translators.translatorsForInput",
+  translators_dict = callNixFunction(
+    "translators.translatorsForInputRecursive",
     inputDirectories=[sourcePath],
-    inputFiles=[],
   )
-  return list(sorted(translatorsList, key=lambda t: t['compatible']))
+  for path, translators_list in translators_dict.copy().items():
+    translators_dict[path] = \
+      list(sorted(translators_list, key=lambda t: t['compatible']))
+  return translators_dict
 
 
 def strip_hashes_from_lock(lock):

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -363,7 +363,9 @@ let
             python $installDeps
 
             # add bin path entries collected by python script
-            export PATH="$PATH:$(cat $TMP/ADD_BIN_PATH)"
+            if [ -e $TMP/ADD_BIN_PATH ]; then
+              export PATH="$PATH:$(cat $TMP/ADD_BIN_PATH)"
+            fi
 
             # add dependencies to NODE_PATH
             export NODE_PATH="$NODE_PATH:$nodeModules/$packageName/node_modules"
@@ -407,6 +409,7 @@ let
 
           # Symlinks executables and manual pages to correct directories
           installPhase = ''
+            runHook preInstall
 
             echo "Symlinking exectuables to /bin"
             if [ -d "$nodeModules/.bin" ]
@@ -434,6 +437,8 @@ let
             if [ -n "$electronHeaders" ]; then
               ${electron-wrap}
             fi
+
+            runHook postInstall
           '';
         });
     in

--- a/src/builders/nodejs/granular/fix-package.py
+++ b/src/builders/nodejs/granular/fix-package.py
@@ -31,12 +31,12 @@ if 'os' in package_json:
 # In case of an 'unknown' version coming from the dream lock,
 # do not  override the version from package.json
 version = os.environ.get("version")
-if version not in ["unknown", package_json['version']]:
+if version not in ["unknown", package_json.get('version')]:
   print(
     "WARNING: The version of this package defined by its package.json "
     "doesn't match the version expected by dream2nix."
     "\n  -> Replacing version in package.json: "
-    f"{package_json['version']} -> {version}",
+    f"{package_json.get('version')} -> {version}",
     file=sys.stderr
   )
   changed = True
@@ -78,7 +78,7 @@ if 'bin' in package_json and package_json['bin']:
     sourceDir = os.path.dirname(source)
     # create parent dir
     pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
-    
+
     dest = os.path.relpath(bin, sourceDir)
     print(f"dest: {dest}; source: {source}")
     os.symlink(dest, source)

--- a/src/translators/go/impure/gomod2nix/translate.nix
+++ b/src/translators/go/impure/gomod2nix/translate.nix
@@ -64,7 +64,6 @@ let
           git = dependencyObject:
             {
               type = "git";
-              version = getVersion dependencyObject;
               hash = dependencyObject.fetch.sha256;
               url = dependencyObject.fetch.url;
               rev = dependencyObject.fetch.rev;

--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -93,6 +93,8 @@
             (
               packageJSON.dependencies or {}
               //
+              packageJSON.optionalDependencies or {}
+              //
               (lib.optionalAttrs dev (packageJSON.devDependencies or {}))
               //
               (lib.optionalAttrs peer (packageJSON.peerDependencies or {}))
@@ -115,9 +117,13 @@
             lib.head (lib.splitString "@https://" dependencyObject.yarnName)
           else
             let
-              version = lib.last (lib.splitString "@" dependencyObject.yarnName);
+              split = lib.splitString "@" dependencyObject.yarnName;
+              version = lib.last split;
             in
-              lib.removeSuffix "@${version}" dependencyObject.yarnName;
+              if lib.hasPrefix "@" dependencyObject.yarnName then
+                lib.removeSuffix "@${version}" dependencyObject.yarnName
+              else
+                lib.head split;
 
         getVersion = dependencyObject:
           dependencyObject.version;
@@ -234,7 +240,7 @@
             else if lib.hasInfix "@file:" dependencyObject.yarnName then
               {
                 path =
-                lib.last (lib.splitString "@file:" dependencyObject.yarnName);
+                  lib.last (lib.splitString "@file:" dependencyObject.yarnName);
               }
             else
               throw "unknown path format ${b.toJSON dependencyObject}";

--- a/src/utils/translator.nix
+++ b/src/utils/translator.nix
@@ -61,7 +61,8 @@ let
           getVersion,
           getSourceType,
           sourceConstructors,
-          createMissingSource ? (name: version: { type = "unknown"; }),
+          createMissingSource ?
+            (name: version: throw "Cannot find source for ${name}:${version}"),
           getDependencies ? null,
           getOriginalID ? null,
           mainPackageSource ? { type = "unknown"; },


### PR DESCRIPTION
This adds a `--sub-dirs` flag to the CLI.
It simplifies translation of projects containing several sources of translatable metadata.
This is suitable if the a project contains several sub projects which can be translated independently.
An example would be a project which contains more than one lock-file.