### PR TITLE
Parse unquoted strings in yarn.lock

### DIFF
--- a/src/translators/nodejs/pure/yarn-lock/parser.nix
+++ b/src/translators/nodejs/pure/yarn-lock/parser.nix
@@ -36,7 +36,7 @@ rec {
 
   singleDependency = bind (skipThen (string "    ") (alt quotedString unquotedString)) (parsed_dependency:
     skipThen (string " ") (
-      bind quotedString (parsed_version:
+      bind (alt quotedString unquotedString) (parsed_version:
         pure { "${parsed_dependency}" = parsed_version; }
       )
     )


### PR DESCRIPTION
Sometimes there will be unquoted strings (eg: latest) in dependecy
positions. They are resolved elsewhere but results in a parse error.