### PR TITLE
Add darwin to architecture list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
       lib = nixpkgs.lib;
 
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       forAllSystems = f: lib.genAttrs supportedSystems (system:
         f system (import nixpkgs { inherit system; overlays = [ self.overlay ]; })


### PR DESCRIPTION
I'm using `aarch64-darwin`. This allows me to run the `dream2nix` cli.