### PR TITLE
dream-lock: support multiple top-level packages

### DIFF
--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -373,7 +373,6 @@ class AddCommand(Command):
 
   def extend_with_translator_info(self, lock, specified_extra_args, translator):
     t = translator
-    lock['_generic']['translatedBy'] = f"{t['subsystem']}.{t['type']}.{t['name']}"
     lock['_generic']['translatorParams'] = " ".join(
       [
         '--translator',

--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -181,12 +181,12 @@ class AddCommand(Command):
       self.translate_from_source(specified_extra_args, sourcePath, translators)
 
     # get package name and version from lock
-    mainPackageName = lock['_generic']['mainPackageName']
-    mainPackageVersion = lock['_generic']['mainPackageVersion']
+    defaultPackage = lock['_generic']['defaultPackage']
+    defaultPackageVersion = lock['_generic']['packages'][defaultPackage]
 
     # calculate output directory and attribute name
     main_package_dir_name = self.define_attribute_name(
-      mainPackageName,
+      defaultPackage,
       existing_names,
     )
 
@@ -200,7 +200,7 @@ class AddCommand(Command):
     self.extend_with_translator_info(lock, specified_extra_args, translator)
 
     # add main package source
-    self.add_main_source(lock, mainPackageName, mainPackageVersion, sourceSpec)
+    self.add_main_source(lock, defaultPackage, defaultPackageVersion, sourceSpec)
 
     # clean up dependency graph
     if 'dependencies' in lock['_generic']:
@@ -354,7 +354,7 @@ class AddCommand(Command):
         lock['cyclicDependencies'][n_name][n_ver].append(removed)
       print(cycles_text)
 
-  def add_main_source(self, lock, mainPackageName, mainPackageVersion, sourceSpec):
+  def add_main_source(self, lock, defaultPackage, defaultPackageVersion, sourceSpec):
     mainSource = sourceSpec.copy()
     if not mainSource:
       mainSource = dict(
@@ -364,12 +364,12 @@ class AddCommand(Command):
       for key in ['pname', 'version']:
         if key in mainSource:
           del mainSource[key]
-    if mainPackageName not in lock['sources']:
-      lock['sources'][mainPackageName] = {
-        mainPackageVersion: mainSource
+    if defaultPackage not in lock['sources']:
+      lock['sources'][defaultPackage] = {
+        defaultPackageVersion: mainSource
       }
     else:
-      lock['sources'][mainPackageName][mainPackageVersion] = mainSource
+      lock['sources'][defaultPackage][defaultPackageVersion] = mainSource
 
   def extend_with_translator_info(self, lock, specified_extra_args, translator):
     t = translator
@@ -422,14 +422,14 @@ class AddCommand(Command):
     output = os.path.realpath(output)
     return filesToCreate, output
 
-  def define_attribute_name(self, mainPackageName, existing_names):
+  def define_attribute_name(self, defaultPackage, existing_names):
     # only respect --atttribute-name option for main package
     if not existing_names:
       attributeName = self.option('attribute-name')
       if attributeName:
         return attributeName
 
-    attributeName = mainPackageName.strip('@').replace('/', '-')
+    attributeName = defaultPackage.strip('@').replace('/', '-')
 
     if attributeName in existing_names:
       attributeName = attributeName + '-subpackage'
@@ -619,10 +619,10 @@ class AddCommand(Command):
         print(f"fetching source defined via existing dream-lock.json")
         with open(sourcePath) as f:
           sourceDreamLock = json.load(f)
-        sourceMainPackageName = sourceDreamLock['_generic']['mainPackageName']
-        sourceMainPackageVersion = sourceDreamLock['_generic']['mainPackageVersion']
+        sourceDefaultPackage = sourceDreamLock['_generic']['defaultPackage']
+        sourceDefaultPackageVersion = sourceDreamLock['_generic']['packages'][sourceDefaultPackage]
         sourceSpec = \
-          sourceDreamLock['sources'][sourceMainPackageName][sourceMainPackageVersion]
+          sourceDreamLock['sources'][sourceDefaultPackage][sourceDefaultPackageVersion]
         sourcePath = \
           buildNixFunction("fetchers.fetchSource", source=sourceSpec, extract=True)
     return sourcePath, sourceSpec

--- a/src/apps/cli/commands/update.py
+++ b/src/apps/cli/commands/update.py
@@ -64,7 +64,8 @@ class UpdateCommand(Command):
     print(f"updater module is: {updater}")
 
     # find new version
-    old_version = lock['_generic']['mainPackageVersion']
+    oldPackage = lock['_generic']['defaultPackage']
+    old_version = lock['_generic']['packages'][oldPackage]
     version = self.option('to-version')
     if not version:
       update_script = buildNixFunction(
@@ -78,19 +79,19 @@ class UpdateCommand(Command):
 
     cli_py = os.path.abspath(f"{__file__}/../../cli.py")
     # delete the hash
-    mainPackageName = lock['_generic']['mainPackageName']
-    mainPackageVersion = lock['_generic']['mainPackageVersion']
-    mainPackageSource = lock['sources'][mainPackageName][mainPackageVersion]
+    defaultPackage = lock['_generic']['defaultPackage']
+    defaultPackageVersion = lock['_generic']['packages'][defaultPackage]
+    mainPackageSource = lock['sources'][defaultPackage][defaultPackageVersion]
     mainPackageSource.update(dict(
-      pname = mainPackageName,
-      version = mainPackageVersion,
+      pname = defaultPackage,
+      version = defaultPackageVersion,
     ))
     updatedSourceSpec = callNixFunction(
       "fetchers.updateSource",
       source=mainPackageSource,
       newVersion=version,
     )
-    lock['sources'][mainPackageName][mainPackageVersion] = updatedSourceSpec
+    lock['sources'][defaultPackage][defaultPackageVersion] = updatedSourceSpec
     with tempfile.NamedTemporaryFile("w", suffix="dream-lock.json") as tmpDreamLock:
       json.dump(lock, tmpDreamLock, indent=2)
       tmpDreamLock.seek(0)  # flushes write cache

--- a/src/apps/cli/default.nix
+++ b/src/apps/cli/default.nix
@@ -46,8 +46,8 @@ in
       sourcePathRelative,
     }:
     let
-      mainPackageName = dreamLock._generic.mainPackageName;
-      mainPackageVersion = dreamLock._generic.mainPackageVersion;
+      defaultPackage = dreamLock._generic.defaultPackage;
+      defaultPackageVersion = dreamLock._generic.packages."${defaultPackage}";
     in
     ''
       {
@@ -63,9 +63,9 @@ in
 
       dream2nix.riseAndShine {
         source = ./dream-lock.json;
-        ${lib.optionalString (dreamLock.sources."${mainPackageName}"."${mainPackageVersion}".type == "unknown") ''
+        ${lib.optionalString (dreamLock.sources."${defaultPackage}"."${defaultPackageVersion}".type == "unknown") ''
           sourceOverrides = oldSources: {
-              "${mainPackageName}"."${mainPackageVersion}" = ./${sourcePathRelative};
+              "${defaultPackage}"."${defaultPackageVersion}" = ./${sourcePathRelative};
             };
         ''}
       }

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -26,8 +26,8 @@
 
   # Attributes
   subsystemAttrs,       # attrset
-  mainPackageName,      # string
-  mainPackageVersion,   # string
+  defaultPackageName,      # string
+  defaultPackageVersion,   # string
 
   # attrset of pname -> versions,
   # where versions is a list of version strings
@@ -55,8 +55,8 @@ let
   nodejsVersion = subsystemAttrs.nodejsVersion;
 
   isMainPackage = name: version:
-    name == mainPackageName
-    && version == mainPackageVersion;
+    name == defaultPackageName
+    && version == defaultPackageVersion;
 
   nodejs =
     if args ? nodejs then
@@ -70,7 +70,7 @@ let
     mv node-* $out
   '';
 
-  defaultPackage = packages."${mainPackageName}"."${mainPackageVersion}";
+  defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
 
   packages =
     lib.mapAttrs

--- a/src/builders/nodejs/node2nix/default.nix
+++ b/src/builders/nodejs/node2nix/default.nix
@@ -13,8 +13,8 @@
 
 {
   subsystemAttrs,
-  mainPackageName,
-  mainPackageVersion,
+  defaultPackageName,
+  defaultPackageVersion,
   getCyclicDependencies,
   getDependencies,
   getSource,
@@ -31,9 +31,9 @@ let
     (args.getDependencies name version)
     ++ (args.getCyclicDependencies name version);
 
-  mainPackageKey = "${mainPackageName}#${mainPackageVersion}";
+  mainPackageKey = "${defaultPackageName}#${defaultPackageVersion}";
 
-  mainPackageDependencies = getAllDependencies mainPackageName mainPackageVersion;
+  mainPackageDependencies = getAllDependencies defaultPackageName defaultPackageVersion;
 
   nodejsVersion = subsystemAttrs.nodejsVersion;
 
@@ -62,7 +62,7 @@ let
           depsFiltered
           (dep: makeSource dep.name dep.version parentDeps);
     };
-  
+
   node2nixDependencies =
     lib.forEach
       mainPackageDependencies
@@ -72,27 +72,27 @@ let
   callNode2Nix = funcName: args:
     node2nixEnv."${funcName}" (rec {
       name = utils.sanitizeDerivationName packageName;
-      packageName = mainPackageName;
-      version = mainPackageVersion;
+      packageName = defaultPackageName;
+      version = defaultPackageVersion;
       dependencies = node2nixDependencies;
       production = true;
       bypassCache = true;
       reconstructLock = true;
-      src = getSource mainPackageName mainPackageVersion;
+      src = getSource defaultPackageName defaultPackageVersion;
     }
     // args);
 
 in
 rec {
 
-  packages."${mainPackageName}"."${mainPackageVersion}" = defaultPackage;
+  packages."${defaultPackageName}"."${defaultPackageVersion}" = defaultPackage;
 
   defaultPackage =
     let
       pkg = callNode2Nix "buildNodePackage" {};
     in
-      utils.applyOverridesToPackage packageOverrides pkg mainPackageName;
+      utils.applyOverridesToPackage packageOverrides pkg defaultPackageName;
 
   devShell = callNode2Nix "buildNodeShell" {};
-    
+
 }

--- a/src/builders/python/simple-builder/default.nix
+++ b/src/builders/python/simple-builder/default.nix
@@ -20,16 +20,16 @@ let
     else
       python.pkgs.buildPythonPackage;
 
-  mainPackageName = dreamLock._generic.mainPackageName;
+  defaultPackage = dreamLock._generic.defaultPackage;
 
   packageName =
-    if mainPackageName == null then
+    if defaultPackage == null then
       if dreamLock._subsystem.application then
         "application"
       else
         "environment"
     else
-      mainPackageName;
+      defaultPackage;
 
   defaultPackage = buildFunc {
     name = packageName;
@@ -37,7 +37,7 @@ let
     buildInputs = pkgs.pythonManylinuxPackages.manylinux1;
     nativeBuildInputs = [ pkgs.autoPatchelfHook python.pkgs.wheelUnpackHook ];
     unpackPhase = ''
-      mkdir dist 
+      mkdir dist
       for file in ${builtins.toString (lib.attrValues fetchedSources)}; do
         # pick right most element of path
         fname=''${file##*/}

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -7,8 +7,8 @@
 
 {
   subsystemAttrs,
-  mainPackageName,
-  mainPackageVersion,
+  defaultPackageName,
+  defaultPackageVersion,
   getCyclicDependencies,
   getDependencies,
   getSource,
@@ -89,7 +89,7 @@ let
         sources
        }
     '';
-  
+
   # Generates a shell script that writes git vendor entries to .cargo/config.
   writeGitVendorEntries =
     let
@@ -120,7 +120,7 @@ let
       '';
 
       cargoVendorDir = "../nix-vendor";
-      
+
       preBuild = ''
         ${writeGitVendorEntries}
       '';
@@ -137,5 +137,5 @@ rec {
       }) subsystemAttrs.packages
     );
 
-  defaultPackage = packages."${mainPackageName}"."${mainPackageVersion}";
+  defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
 }

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -13,6 +13,7 @@
   getDependencies,
   getSource,
   getSourceSpec,
+  packages,
   produceDerivation,
 
   ...
@@ -128,14 +129,9 @@ let
 in
 rec {
   packages =
-    l.listToAttrs (
-      l.map ({ name, version }: {
-        inherit name;
-        value = {
-          ${version} = buildPackage name version;
-        };
-      }) subsystemAttrs.packages
-    );
+    l.mapAttrs
+      (name: version: buildPackage name version)
+      args.packages;
 
-  defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
+  defaultPackage = packages."${defaultPackageName}";
 }

--- a/src/default.nix
+++ b/src/default.nix
@@ -162,9 +162,9 @@ let
         else
           args.fetcher;
 
-      fetched = fetcher {
-        mainPackageName = dreamLock._generic.mainPackageName;
-        mainPackageVersion = dreamLock._generic.mainPackageVersion;
+      fetched = fetcher rec {
+        defaultPackage = dreamLock._generic.defaultPackage;
+        defaultPackageVersion = dreamLock._generic.packages."${defaultPackage}";
         sources = dreamLock'.sources;
         sourcesAggregatedHash = dreamLock'._generic.sourcesAggregatedHash;
       };
@@ -219,12 +219,17 @@ let
           inputDirectories = [ source ];
         });
 
-      dreamLock = lib.recursiveUpdate dreamLock' {
-        sources."${dreamLock'._generic.mainPackageName}"."${dreamLock'._generic.mainPackageVersion}" = {
-          type = "path";
-          path = "${source}";
-        };
-      };
+      dreamLock =
+        let
+          defaultPackage = dreamLock'._generic.defaultPackage;
+          defaultPackageVersion = dreamLock'._generic.packages."${defaultPackage}";
+        in
+          lib.recursiveUpdate dreamLock' {
+            sources."${defaultPackage}"."${defaultPackageVersion}" = {
+              type = "path";
+              path = "${source}";
+            };
+          };
 
     in
       dreamLock;
@@ -305,8 +310,9 @@ let
             getSourceSpec
             getDependencies
             getCyclicDependencies
-            mainPackageName
-            mainPackageVersion
+            defaultPackageName
+            defaultPackageVersion
+            packages
             packageVersions
           ;
 

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -8,8 +8,8 @@
 }:
 {
   # sources attrset from dream lock
-  mainPackageName,
-  mainPackageVersion,
+  defaultPackage,
+  defaultPackageVersion,
   sources,
   ...
 }:
@@ -31,7 +31,7 @@ let
                 source.path
               # assume path relative to main package source
               else
-                "${fetchedSources."${mainPackageName}"."${mainPackageVersion}"}/${source.path}"
+                "${fetchedSources."${defaultPackage}"."${defaultPackageVersion}"}/${source.path}"
             else if fetchers.fetchers ? "${source.type}" then
               fetchSource {
                 source = source // {

--- a/src/specifications/dream-lock-example.json
+++ b/src/specifications/dream-lock-example.json
@@ -1,12 +1,13 @@
 {
   "_generic": {
-    "_subsystem": "python",
-    "translatedBy": "python.impure.pip",
+    "subsystem": "python",
+    "defaultPackage": "requests",
     "translatorArgs": "",
-    "mainPackageName": "requests",
-    "mainPackageVersion": "1.2.3"
+    "packages": {
+      "requests": "1.2.3"
+    }
   },
-  
+
   "_subsystem": {
     "pythonAttr": "python38",
     "sourceFormats": {
@@ -14,11 +15,11 @@
       "certifi": "wheel"
     }
   },
-  
+
   "cyclicDependencies": {
-    
+
   },
-  
+
   "dependencies": {
     "requests": [
       "certifi"

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -153,9 +153,13 @@
     "_generic": {
       "type": "object",
       "properties": {
-        "_subsystem": { "type": "string" },
-        "producedBy": { "type": "string" }
-      }
+        "defaultPackage": { "type": ["string", "null"] },
+        "packages": { "type": "array" },
+        "sourcesAggregatedHash":  { "type": ["string", "null"] },
+        "subsystem": { "type": "string" },
+        "translatorParams":  { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
     },
 
     "_subsystem": {

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -154,7 +154,7 @@
       "type": "object",
       "properties": {
         "defaultPackage": { "type": ["string", "null"] },
-        "packages": { "type": "array" },
+        "packages": { "type": "object" },
         "sourcesAggregatedHash":  { "type": ["string", "null"] },
         "subsystem": { "type": "string" },
         "translatorParams":  { "type": ["string", "null"] }

--- a/src/specifications/subsystems/rust/dream.lock.example.json
+++ b/src/specifications/subsystems/rust/dream.lock.example.json
@@ -1,8 +1,5 @@
 {
   "_subsystem": {
-    "packages": [
-      { "name": "ripgrep", "version": "13.0.0" }
-    ],
     "gitSources": [
       {
         "url": "https://github.com/rust-random/rand.git",

--- a/src/templates/builders/default.nix
+++ b/src/templates/builders/default.nix
@@ -21,8 +21,8 @@
 
   # Attributes
   subsystemAttrs,       # attrset
-  mainPackageName,      # string
-  mainPackageVersion,   # string
+  defaultPackageName,      # string
+  defaultPackageVersion,   # string
 
   # attrset of pname -> versions,
   # where versions is a list of version strings
@@ -46,7 +46,7 @@ let
   b = builtins;
 
   # the main package
-  defaultPackage = packages."${mainPackageName}"."${mainPackageVersion}";
+  defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
 
   # manage pakcages in attrset to prevent duplicated evaluation
   packages =
@@ -72,9 +72,9 @@ let
             map
               (dep: packages."${dep.name}"."${dep.version}")
               (getDependencies name version);
-          
+
           # Implement build phases
-          
+
         };
     in
       # apply packageOverrides to current derivation

--- a/src/templates/translators/pure.nix
+++ b/src/templates/translators/pure.nix
@@ -48,9 +48,9 @@
           # transformed into a flat list.
           inputData = ;
 
-          mainPackageName = ;
+          defaultPackageName = ;
 
-          mainPackageVersion = ;
+          defaultPackageVersion = ;
 
           mainPackageDependencies =
             lib.mapAttrsToList

--- a/src/translators/go/impure/gomod2nix/translate.nix
+++ b/src/translators/go/impure/gomod2nix/translate.nix
@@ -24,13 +24,13 @@ let
 
         inputData = parsed;
 
-        mainPackageName =
+        defaultPackage =
           let
             firstLine = (b.elemAt (lib.splitString "\n" (b.readFile "${cwd}/go.mod")) 0);
           in
             lib.last (lib.splitString "/" (b.elemAt (lib.splitString " " firstLine) 1));
 
-        mainPackageVersion = "unknown";
+        packages."${defaultPackage}" = "unknown";
 
         subsystemName = "go";
 

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -112,7 +112,7 @@
         # values
         inputData = packageLockWithPinnedVersions;
 
-        mainPackageName =
+        defaultPackage =
           if name != "{automatic}" then
             name
           else
@@ -121,7 +121,7 @@
               + "Please specify extra argument 'name'"
             ));
 
-        mainPackageVersion = parsed.version or "unknown";
+        packages."${defaultPackage}" = parsed.version or "unknown";
 
         mainPackageDependencies =
           lib.mapAttrsToList

--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -59,7 +59,7 @@
 
         inputData = parsedLock;
 
-        mainPackageName =
+        defaultPackage =
           if name != "{automatic}" then
             name
           else
@@ -68,7 +68,7 @@
               + "Please specify extra argument 'name'"
             ));
 
-        mainPackageVersion = packageJSON.version or "unknown";
+        packages."${defaultPackage}" = packageJSON.version or "unknown";
 
         subsystemName = "nodejs";
 

--- a/src/translators/python/impure/pip/generate-dream-lock.py
+++ b/src/translators/python/impure/pip/generate-dream-lock.py
@@ -59,9 +59,10 @@ def main():
     sources={},
     _generic={
       "subsystem": "python",
-      "mainPackageName": os.environ.get('NAME'),
-      "mainPackageVersion": os.environ.get('VERSION'),
-
+      "defaultPackage": os.environ.get('NAME'),
+      "packages": {
+        os.environ.get('NAME'): os.environ.get('VERSION'),
+      },
       "sourcesAggregatedHash": None,
     },
     _subsystem={

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -103,7 +103,7 @@
         name = toml.package.name;
         version = toml.package.version or (l.warn "no version found in Cargo.toml for ${name}, defaulting to unknown" "unknown");
       };
-      
+
       # Parses a git source, taken straight from nixpkgs.
       parseGitSource = src:
         let
@@ -149,9 +149,9 @@
           # transformed into a flat list.
           inputData = parsedDeps;
 
-          mainPackageName = package.name;
+          defaultPackage = package.name;
 
-          mainPackageVersion = package.version;
+          packages."${defaultPackage}" = package.version;
 
           mainPackageDependencies =
             let

--- a/src/utils/translator.nix
+++ b/src/utils/translator.nix
@@ -243,7 +243,6 @@ let
                 ;
                 subsystem = subsystemName;
                 sourcesAggregatedHash = null;
-                translator = translatorName;
               };
 
             # build system specific attributes

--- a/src/utils/translator.nix
+++ b/src/utils/translator.nix
@@ -48,9 +48,9 @@ let
         {
           # values
           inputData,
-          mainPackageName,
-          mainPackageVersion,
+          defaultPackage,
           mainPackageDependencies,
+          packages,
           subsystemName,
           subsystemAttrs,
           translatorName,
@@ -119,8 +119,8 @@ let
                   allDependencies);
             in
               depGraph // {
-                "${mainPackageName}" = depGraph."${mainPackageName}" or {} // {
-                  "${mainPackageVersion}" = mainPackageDependencies;
+                "${defaultPackage}" = depGraph."${defaultPackage}" or {} // {
+                  "${packages."${defaultPackage}"}" = mainPackageDependencies;
                 };
               };
 
@@ -200,7 +200,7 @@ let
 
               cyclesList =
                 findCycles
-                  (utils.nameVersionPair mainPackageName mainPackageVersion)
+                  (utils.nameVersionPair defaultPackage packages."${defaultPackage}")
                   {}
                   [];
             in
@@ -238,8 +238,8 @@ let
             _generic =
               {
                 inherit
-                  mainPackageName
-                  mainPackageVersion
+                  defaultPackage
+                  packages
                 ;
                 subsystem = subsystemName;
                 sourcesAggregatedHash = null;


### PR DESCRIPTION
This changes the structure of the dream-lock.json to support a list of top level packages instead of a single top level package.
Despite these changes, some parts of the framework still depend on `defaultPackage` not being null or unset.
That means there is still some work left to, but from here on we can smoothly transition away from enforcing a `defaultPackage`.

removed dream-lock fields:
  - translator (currently covered by translatorParams)
  - translatedBy (currently covered by translatorParams)
  - mainPackageName
  - mainPackageVersion

added dream-lock fields:
  - defaultPackage  (equivalent to old `mainPackageName`)
  - packages

Other changes done on the rust subsytem:
 - fix a bug in the rust translator where the path `path-like` sources was wrong whenever the path length is greater 1.
(example ripgrep).
 - process only one input directory (scenarios with several input dirs are not yet really supported by the framework and this will be refined through #76 anyways)

@yusdacra Could you review the rust changes?