### PR TITLE
Fix(cli): process a default value that returns empty

### DIFF
--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -540,7 +540,7 @@ class AddCommand(Command):
               print(f"Leave empty for default ({arg['default']})")
             while True:
               specified_extra_args[arg_name] = self.ask(f"{arg_name}:", arg.get('default'))
-              if specified_extra_args[arg_name]:
+              if specified_extra_args[arg_name] or not arg.get('default'):
                 break
     return specified_extra_args
 


### PR DESCRIPTION
In the CLI, if no value is provided for the input the default is supposed to be selected. But if the default value returned from the translator is an empty string, the ask will infinitely recurse. I'm a bit rusty on Python so apologies if this method isn't sufficient! 

Example:
```
Please specify 'npmArgs': Additional arguments for npm
Example values: --force
Leave empty for default ()
npmArgs: 
npmArgs: 
npmArgs: 
npmArgs:
```
