### PR TITLE
Support impure translation via flakes (no more CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ There are different ways how dream2nix can be invoked (CLI, flake, In-tree, IFD)
   outputs = { self, dream2nix }@inputs:
     let
       dream2nix = inputs.dream2nix.lib.init {
-        # either just specify systems
+        # modify according to your supported systems
         systems = [ "x86_64-linux" ];
-        # ...or alternatively specify your own nixpkgs
-        # pkgs = ...;
+        config.projectRoot = ./. ;
       };
-    in dream2nix.riseAndShine {
+    in dream2nix.makeFlakeOutputs {
       source = ./.;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "dream2nix: A generic framework for 2nix tools";
+  description = "A framework for 2nix tools";
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
@@ -76,7 +76,7 @@
       });
 
       # An interface to access files of external projects.
-      # This implementation aceeses the flake inputs directly,
+      # This implementation accesses the flake inputs directly,
       # but if dream2nix is used without flakes, it defaults
       # to another implementation of that function which
       # uses the installed external paths instead (see default.nix)
@@ -117,9 +117,9 @@
         // (forAllSystems (system: pkgs:
           import ./src {
             inherit
+              externalPaths
               externalSources
               lib
-              overridesDirs
               pkgs
             ;
           }

--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -269,11 +269,6 @@ class AddCommand(Command):
       packages_root = config['packagesDir']
     else:
       packages_root = './.'
-    if not os.path.isdir(packages_root):
-      print(
-        f"Packages direcotry {packages_root} does not exist. Please create.",
-        file=sys.stderr,
-      )
     return packages_root
 
   def format_lock_str(self, lock):

--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -63,6 +63,7 @@ class AddCommand(Command):
     ),
     option("force", None, "override existing files", flag=True),
     option("no-default-nix", None, "create default.nix", flag=True),
+    option("invalidation-hash", None, "invalidation hash to attach", flag=False),
   ]
 
   def handle(self):
@@ -383,6 +384,7 @@ class AddCommand(Command):
       ) + [
         f"--arg {n}={v}" for n, v in specified_extra_args.items()
       ])
+    lock['_generic']['invalidationHash'] = self.option('invalidation-hash')
 
   def calc_outputs(self, main_package_dir_name, packages_root):
     if self.option('target'):
@@ -504,7 +506,7 @@ class AddCommand(Command):
 
     # assume defaults for unspecified extra args
     specified_extra_args.update(
-      {n: (True if v['type'] == 'flag' else v['default']) \
+      {n: (False if v['type'] == 'flag' else v['default']) \
         for n, v in translator['extraArgs'].items() \
         if n not in specified_extra_args}
     )

--- a/src/apps/cli/default.nix
+++ b/src/apps/cli/default.nix
@@ -61,7 +61,7 @@ in
               ''') {},
       }:
 
-      dream2nix.riseAndShine {
+      dream2nix.makeOutputs {
         source = ./dream-lock.json;
         ${lib.optionalString (dreamLock.sources."${defaultPackage}"."${defaultPackageVersion}".type == "unknown") ''
           sourceOverrides = oldSources: {

--- a/src/default.nix
+++ b/src/default.nix
@@ -356,8 +356,12 @@ let
         formattedOutputs;
 
 
+  riseAndShine = throw ''
+    Use makeOutputs instead of riseAndShine.
+  '';
+
   # produce outputs for a dream-lock or a source
-  riseAndShine =
+  makeOutputs =
     {
       source,  # source tree or dream-lock
       builder ? null,
@@ -390,7 +394,7 @@ let
       builderOutputsSub =
         b.mapAttrs
           (dirName: dreamLock:
-            riseAndShine
+            makeOutputs
               (args // {source = dreamLock.lock; }))
           dreamLockInterface.subDreamLocks;
 
@@ -457,6 +461,7 @@ in
     dream2nixWithExternals
     fetchers
     fetchSources
+    makeOutputs
     riseAndShine
     translators
     updaters

--- a/src/default.nix
+++ b/src/default.nix
@@ -15,9 +15,9 @@
 
   # default to empty dream2nix config
   config ?
-    # if called via CLI, load cnfig via env
-    if builtins ? getEnv && builtins.getEnv "d2nConfigFile" != "" then
-      builtins.toPath (builtins.getEnv "d2nConfigFile")
+    # if called via CLI, load config via env
+    if builtins ? getEnv && builtins.getEnv "dream2nixConfig" != "" then
+      builtins.toPath (builtins.getEnv "dream2nixConfig")
     # load from default directory
     else
       {},

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -90,10 +90,12 @@ let
     in
       {
 
-        riseAndShine = rArgs: riseAndShineFunc
+        riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
+
+        makeFlakeOutputs = mArgs: makeFlakeOutputsFunc
           (
             { inherit config pkgs systems; }
-            // rArgs
+            // mArgs
           );
 
         apps =
@@ -108,7 +110,7 @@ let
 
       };
 
-  riseAndShineFunc =
+  makeFlakeOutputsFunc =
     {
       pname,
       pkgs ? null,
@@ -157,7 +159,7 @@ let
                 && dreamLock.lock._generic.invalidationHash or "" == invalidationHash;
 
               result = translator: args:
-                dream2nix.riseAndShine (argsForward // args // {
+                dream2nix.makeOutputs (argsForward // args // {
                   # TODO: this triggers the translator finding routine a second time
                   translator = translatorFound.name;
                 });
@@ -247,5 +249,6 @@ let
 in
 {
   inherit init;
-  riseAndShine = riseAndShineFunc;
+  riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
+  makeFlakeOutpus = makeFlakeOutputsFunc;
 }

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -154,6 +154,7 @@
       "type": "object",
       "properties": {
         "defaultPackage": { "type": ["string", "null"] },
+        "invalidationHash": { "type": ["string", "null"] },
         "packages": { "type": "object" },
         "sourcesAggregatedHash":  { "type": ["string", "null"] },
         "subsystem": { "type": "string" },

--- a/src/utils/config.nix
+++ b/src/utils/config.nix
@@ -23,7 +23,7 @@ let
       defaults =  {
         overridesDirs = [];
         packagesDir = "./packages";
-        projectRoot = throw "projectRoot not specified in dream2nix config";
+        projectRoot = "./.";
         repoName = null;
       };
     in

--- a/src/utils/config.nix
+++ b/src/utils/config.nix
@@ -22,7 +22,7 @@ let
       config = loadAttrs configInput;
       defaults =  {
         overridesDirs = [];
-        packagesDir = null;
+        packagesDir = "./packages";
         projectRoot = throw "projectRoot not specified in dream2nix config";
         repoName = null;
       };

--- a/src/utils/config.nix
+++ b/src/utils/config.nix
@@ -23,7 +23,8 @@ let
       defaults =  {
         overridesDirs = [];
         packagesDir = null;
-        repoName = "this repo";
+        projectRoot = throw "projectRoot not specified in dream2nix config";
+        repoName = null;
       };
     in
       defaults // config;

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -211,6 +211,8 @@ rec {
       []
       ''
         ${apps.cli.program} add ${source} \
+          --force \
+          --no-default-nix \
           --translator ${translator} \
           --packages-root $WORKDIR/${packagesDir} \
           ${lib.concatStringsSep " \\\n"

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -209,7 +209,7 @@ rec {
       ${source}
       ${translator}
       ${b.toString
-        (lib.mapAttrsToList (k: v: "${k}=${v}") translatorArgs)}
+        (lib.mapAttrsToList (k: v: "${k}=${b.toString v}") translatorArgs)}
     '';
 
   # a script that produces and dumps the dream-lock json for a given source
@@ -234,7 +234,7 @@ rec {
           --packages-root $WORKDIR/${packagesDir} \
           ${lib.concatStringsSep " \\\n"
             (lib.mapAttrsToList
-              (key: val: "--arg ${key}=${val}")
+              (key: val: "--arg ${key}=${b.toString val}")
               translatorArgs)}
       '';
 }

--- a/src/utils/dream-lock.nix
+++ b/src/utils/dream-lock.nix
@@ -128,7 +128,7 @@ let
         The source for ${pname}#${version} is not defined.
         This can be fixed via an override. Example:
         ```
-          dream2nix.riseAndShine {
+          dream2nix.make[Flake]Outputs {
             ...
             sourceOverrides = oldSources: {
               "${pname}"."${version}" = builtins.fetchurl { ... };

--- a/tests/pure/projects.nix
+++ b/tests/pure/projects.nix
@@ -14,7 +14,7 @@ let
       cmds,
     }:
     let
-      outputs = dream2nix.riseAndShine {
+      outputs = dream2nix.makeOutputs {
         inherit source;
       };
       commandsToRun = cmds outputs;


### PR DESCRIPTION
With this, there is only one recommended way of using dream2nix which is through the flake shown in the readme.

Until now, using dream2nix via the flake was only possible if the project could be translated via a `pure` translator. Using the `impure` translation required the user to mess with the CLI.
With this patch, there will be a flakes based UX also for `impure` translation.

If a project requires impure translation, nix evaluation will error out with a hint for the user to run `nix run .#resolve` first to generate the dream-lock.json.

Also for projects using pure translation, `nix run .#resolve` will still generate the `dream-lock.json` file to increase evaluation performance in the future.

Other changes:
  - Add the capability of selecting the `translator` and `translatorArgs` declaratively thorugh the flakes API. There is now only one source of truth which is what is declared in the flake
  - rename `riseAndShine` -> `make[Flake]Outputs` (let's be professional)



Example for prettier (nodejs):
```nix
# flake.nix
{
  inputs.dream2nix.url = "github:nix-community/dream2nix";
  inputs.src_prettier = { flake = false; url = "github:prettier/prettier/2.4.1"; };

  outputs = { self, dream2nix, src_prettier, }@inputs:
    let
      dream2nix = inputs.dream2nix.lib.init {
        systems = [ "x86_64-linux" ];
        config.projectRoot = ./. ;
      };
    in dream2nix.makeFlakeOutputs {
      source = src_prettier;
      pname = "prettier";

      # optional
      # enforce impure package-json translator
      translator = "package-json";
      translatorArgs = {
        nodejs = 16;
      };
    };
}

```