### PR TITLE
use one nixpkgs instance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       forAllSystems = f: lib.genAttrs supportedSystems (system:
-        f system (import nixpkgs { inherit system; overlays = [ self.overlay ]; })
+        f system nixpkgs.legacyPackages.${system}
       );
 
       # To use dream2nix in non-flake + non-IFD enabled repos, the source code of dream2nix
@@ -113,14 +113,6 @@
 
     in
       {
-        # overlay with flakes enabled nix
-        # (all of dream2nix cli dependends on nix ^2.4)
-        overlay = final: prev: {
-          nix = prev.writeScriptBin "nix" ''
-            ${final.nixUnstable}/bin/nix --option experimental-features "nix-command flakes" "$@"
-          '';
-        };
-
         # System independent dream2nix api.
         # Similar to drem2nixFor but will require 'system(s)' or 'pkgs' as an argument.
         # Produces flake-like output schema.

--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -12,7 +12,7 @@ import networkx as nx
 from cleo import Command, argument, option
 
 from utils import config, dream2nix_src, checkLockJSON, list_translators_for_source, strip_hashes_from_lock
-from nix_ffi import callNixFunction, buildNixFunction, buildNixAttribute
+from nix_ffi import nix, callNixFunction, buildNixFunction, buildNixAttribute
 
 
 class AddCommand(Command):
@@ -294,12 +294,9 @@ class AddCommand(Command):
     with open(outputDreamLock, 'w') as f:
       json.dump(lock, f, indent=2)
     # compute FOD hash of aggregated sources
-    proc = sp.run(
-      [
-        "nix", "build", "--impure", "-L", "--show-trace", "--expr",
-        f"(import {dream2nix_src} {{}}).fetchSources {{ dreamLock = {outputDreamLock}; }}"
-      ],
-      capture_output=True,
+    proc = nix(
+      "build", "--impure", "-L", "--show-trace", "--expr",
+      f"(import {dream2nix_src} {{}}).fetchSources {{ dreamLock = {outputDreamLock}; }}"
     )
     # read the output hash from the failed build log
     match = re.search(r"FOD_HASH=(.*=)", proc.stderr.decode())

--- a/src/default.nix
+++ b/src/default.nix
@@ -7,12 +7,7 @@
   pkgs ? import <nixpkgs> {},
   dlib ? import ./lib { inherit lib; },
   lib ? pkgs.lib,
-
-  # the dream2nix cli depends on some nix 2.4 features
-  nix ? pkgs.writeScriptBin "nix" ''
-    #!${pkgs.bash}/bin/bash
-    ${pkgs.nixUnstable}/bin/nix --option experimental-features "nix-command flakes" "$@"
-  '',
+  nix ? pkgs.nix,
 
   # default to empty dream2nix config
   config ?


### PR DESCRIPTION
Push the nix configuration into the CLI so we don't need the overlay,
and so we don't need to create another instance of nixpkgs.

This also means that the python CLI can be executed directly as long as
the user has a recent-enough version of nix and make iterations a bit
faster.

For more details, see
https://zimbatm.com/notes/1000-instances-of-nixpkgs

TODO: the PR needs testing