### PR TITLE
fix(rust): fix source replacement config write for crane

### DIFF
--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -40,11 +40,15 @@ let
 
       cargoVendorDir = "../nix-vendor";
 
+      CARGO_HOME = "/build/.cargo-home";
+
       postUnpack = ''
         ln -s ${vendorDir} ./nix-vendor
       '';
 
-      preBuild = ''
+      preConfigure = ''
+        mkdir -p $CARGO_HOME
+        mv /build/.cargo/config $CARGO_HOME/config.toml
         ${vendoring.writeGitVendorEntries "vendored-sources"}
       '';
     });

--- a/src/builders/rust/vendor.nix
+++ b/src/builders/rust/vendor.nix
@@ -55,8 +55,8 @@ in rec {
         '';
       entries = l.map makeEntry subsystemAttrs.gitSources;
     in ''
-      mkdir -p ../.cargo/ && touch ../.cargo/config
-      cat >> ../.cargo/config <<EOF
+      mkdir -p $CARGO_HOME && touch $CARGO_HOME/config.toml
+      cat >> $CARGO_HOME/config.toml <<EOF
       ${l.concatStringsSep "\n" entries}
       EOF
     '';


### PR DESCRIPTION
This fixes some source replacement config issues that were happening with crane. It also makes behaviour more consistent across buildRustPackage and crane since now they both write configs to `CARGO_HOME`. The old behaviour was incorrect for `crane`, and so I have changed it to work for both. I chose to do it like this after reading [this comment](https://github.com/ipetkov/crane/blob/master/pkgs/configureCargoVendoredDepsHook.sh#L5-L10) from crane source.