### PR TITLE
fix(rust): dont use hardcoded CARGO_HOME to /build

### DIFF
--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -40,10 +40,9 @@ let
 
       cargoVendorDir = "../nix-vendor";
 
-      CARGO_HOME = "/build/.cargo-home";
-
       postUnpack = ''
         ln -s ${vendorDir} ./nix-vendor
+        export CARGO_HOME=$(pwd)/.cargo_home
       '';
 
       preConfigure = ''

--- a/src/builders/rust/crane/default.nix
+++ b/src/builders/rust/crane/default.nix
@@ -32,15 +32,16 @@ let
     let
       src = utils.getRootSource pname version;
       cargoVendorDir = vendoring.vendorDependencies pname version;
+      postUnpack = ''
+        export CARGO_HOME=$(pwd)/.cargo_home
+      '';
       preConfigure = ''
         ${vendoring.writeGitVendorEntries "nix-sources"}
       '';
       # The deps-only derivation will use this as a prefix to the `pname`
       depsNameSuffix = "-deps";
-      # Set CARGO_HOME to /build because we write our .cargo/config there
-      CARGO_HOME = "/build/.cargo_home";
 
-      common = {inherit pname version src cargoVendorDir preConfigure CARGO_HOME;};
+      common = {inherit pname version src cargoVendorDir preConfigure postUnpack;};
 
       depsArgs = common // { pnameSuffix = depsNameSuffix; };
       deps = produceDerivation "${pname}${depsNameSuffix}" (crane.buildDepsOnly depsArgs);


### PR DESCRIPTION
Using hardcoded `/build` apparently causes some issues on darwin (?) (https://github.com/helix-editor/helix/pull/1758#issuecomment-1059903449). So this attempts to fix it by setting `CARGO_HOME` in a hook instead of hardcoding it in derivation.

~~Draft until it gets confirmed this actually fixes the issue. It doesn't seem to break anything for me (nix-cargo-integration tests pass fine) so it should be a welcome improvement anyways.~~ seems to fix that error!