### PR TITLE
fix: use name attr before workspace path

### DIFF
--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -291,8 +291,9 @@
 
         workspaceDependendencies =
           l.mapAttrsToList
-          (wsName: wsJson: {
-            name = wsName;
+          (wsPath: wsJson: {
+            # If the name attr doesn't exist, use the relative path as name
+            name = wsJson.name or wsPath;
             version = wsJson.version or "unknown";
           })
           workspacesPackageJson;

--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -289,7 +289,7 @@
           })
           packageJsonDeps;
 
-        workspaceDependendencies =
+        workspaceDependencies =
           l.mapAttrsToList
           (wsPath: wsJson: {
             # If the name attr doesn't exist, use the relative path as name
@@ -301,7 +301,7 @@
         {
           name = defaultPackage;
           version = packageJson.version or "unknown";
-          dependencies = defaultPackageDependencies ++ workspaceDependendencies;
+          dependencies = defaultPackageDependencies ++ workspaceDependencies;
         }
       ];
 


### PR DESCRIPTION
I was having the following error:
```
error: attribute 'packages/subpackage' missing

       at /nix/store/89qhl4fvd5g806ja3dd3rsyrvj3qxyhw-source/src/utils/translator2.nix:159:15:

          152|             children =
          153|               depGraphWithFakeRoot."${node.name}"."${node.version}";
             |               ^
          154|
```

Here's a test `package.json`:
```
  {
    "name": "test2",
    "version": "1.0.0",
    "private": true,
    "workspaces": {
      "packages": [
        "packages/subpackage"
      ]
    },
    "dependencies": {
      "typescript": "^4.6.2"
    }
  }
```
and `packages/subpackage/package.json`:
```
  {
    "name": "some-name",
    "version": "1.0.0",
    "private": true,
    "dependencies": {
      "type-detect": "^4.0.8"
    }
  }
```

It appears `workspaceDependencies` always took the workspace's relative path instead of checking if the json has the name attribute first.