### PR TITLE
feat(translator/cargo-lock): use discoveredProjects to find dependencies that are outside of a packages source

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -537,7 +537,7 @@
       (proj: let
         translator = getTranslator proj.subsystem proj.translator;
         dreamLock' = translator.translate {
-          inherit source tree;
+          inherit source tree discoveredProjects;
           project = proj;
         };
         dreamLock =

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -12,18 +12,18 @@
   sources,
   ...
 }: let
-  b = builtins;
+  l = lib // builtins;
 
   fetchedSources =
-    lib.mapAttrs
+    l.mapAttrs
     (name: versions:
-      lib.mapAttrs
+      l.mapAttrs
       (version: source:
         if source.type == "unknown"
         then "unknown"
         else if source.type == "path"
         then
-          if lib.isStorePath source.path
+          if l.isStorePath (l.concatStringsSep "/" (l.take 4 (l.splitString "/" source.path)))
           then source.path
           else if name == source.rootName && version == source.rootVersion
           then throw "source for ${name}@${version} is referencing itself"
@@ -43,7 +43,7 @@
     sources;
 
   overriddenSources =
-    lib.recursiveUpdateUntil
+    l.recursiveUpdateUntil
     (path: l: r: lib.isDerivation l)
     fetchedSources
     (sourceOverrides fetchedSources);

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -51,7 +51,8 @@ in {
     workspaceCargoPackages =
       l.map
       (relPath: readToml "${inputDir}/${relPath}/Cargo.toml")
-      workspaceMembers;
+      # Filter root referencing member, we already parsed this (rootToml)
+      (l.filter (relPath: relPath != ".") workspaceMembers);
 
     # All cargo packages that we will output
     cargoPackages =

--- a/src/utils/translator2.nix
+++ b/src/utils/translator2.nix
@@ -69,7 +69,7 @@
       defaultPackage,
       exportedPackages,
       extractors,
-      extraDependencies ? {},
+      extraDependencies ? [],
       extraObjects ? [],
       keys ? {},
       location ? "",

--- a/tests/examples/default.nix
+++ b/tests/examples/default.nix
@@ -18,7 +18,13 @@ in
     nix
   ]
   ''
-    for dir in $(ls ${examples}); do
+    if [ -n "$1" ]; then
+      examples=$1
+    else
+      examples=$(ls ${examples})
+    fi
+
+    for dir in $examples; do
       echo -e "\ntesting example for $dir"
       mkdir tmp
       cp ${examples}/$dir/* ./tmp/


### PR DESCRIPTION
Resolves #113. This uses `discoveredProjects` to find dependencies that are outside of the `inputDir` passed to the `cargo-lock` translator.

This also reworks how the `cargo-lock` translator finds Cargo packages. Since packages / workspaces discovery is handled by the discoverer now, that is replaced with just finding packages for workspace members if the translator is translating a workspace. This makes everything a lot simpler, and generally should make everything faster (no `recurseFiles`...).

It is currently a draft because there is a bug preventing this from fully working:
```
error: cannot coerce null to a string

       at /nix/store/0ziix5kkds3rkqsjc48bzlnyf5a1y2kw-source/src/fetchers/default-fetcher.nix:30:38:

           29|           then throw "source for ${name}@${version} is referencing itself"
           30|           else "${overriddenSources."${source.rootName}"."${source.rootVersion}"}/${source.path}"
               |                                                        ^
           31|         else if fetchers.fetchers ? "${source.type}"
``` 
this is fixed now. Now it is replaced with:
```
error: value is a string with context while a set was expected
```
for reproducing, run `nix build github:yusdacra/dream2nix-bugs/pr-114#basic-bin`.