### PR TITLE
esbuild: remove version check

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -370,12 +370,14 @@ in
           };
         in "${esbuild}/bin/esbuild";
       };
-      "add-binary-0.14" = {
+      "add-binary-0.14" = let
+        version = "0.14.38";
+      in {
         _condition = satisfiesSemver "~0.14";
         ESBUILD_BINARY_PATH = let
-          esbuild = pkgs.buildGoModule rec {
+          esbuild = pkgs.buildGoModule {
             pname = "esbuild";
-            version = "0.14.38";
+            inherit version;
 
             src = pkgs.fetchFromGitHub {
               owner = "evanw";
@@ -385,8 +387,22 @@ in
             };
 
             vendorSha256 = "sha256-QPkBR+FscUc3jOvH7olcGUhM6OW4vxawmNJuRQxPuGs=";
+
+            # there is a binary version check when running esbuild that prevents us from running
+            # a semver compatible binary
+            postPatch = ''
+              substituteInPlace cmd/esbuild/main.go --replace \
+                "hostVersion != esbuildVersion" \
+                "false"
+            '';
           };
         in "${esbuild}/bin/esbuild";
+        overrideAttrs = old: {
+          postPatch = ''
+            substituteInPlace lib/main.js --replace \
+              "${old.version}" "${version}"
+          '';
+        };
       };
     };
 


### PR DESCRIPTION
esbuild unfortunately has a version check when you run it.
I've managed to run it successfully today.

feel free to let me know if you don't like the approach