### PR TITLE
7zip fix darwin build

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -730,6 +730,7 @@ in
     # TODO: Maybe should replace binaries with the ones from nixpkgs
     "7zip-bin" = {
       patch-binaries = {
+        _condition = _pkg: !pkgs.stdenv.isDarwin;
         nativeBuildInputs = old:
           old
           ++ [


### PR DESCRIPTION
7zip just doesn't build on darwin.
here is the failure
```
 > automatically fixing dependencies for ELF files
       > /nix/store/m7jxsbvwvkw2zdvlqqqqdbcvr14cp6an-auto-patchelf-hook/nix-support/setup-hook: line 333: -l: command not found
```
looking into the file here is what there is
```
       segmentHeaders="$(LANG=C $READELF -l "$file")"
```
readelf doesn't seem to exist on darwin, so this step is probably not possible at all.