### PR TITLE
electron: fix darwin build

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -288,17 +288,23 @@ in
     in {
       add-binary = {
         overrideAttrs = old: {
-          postPatch = ''
-            cp -r ${getElectronFor "${old.version}"}/lib/electron ./dist
-            chmod -R +w ./dist
-            echo -n $version > ./dist/version
-            echo -n "electron" > ./path.txt
-          '';
+          postPatch =
+            if pkgs.stdenv.isLinux
+            then ''
+              cp -r ${getElectronFor "${old.version}"}/lib/electron ./dist
+              chmod -R +w ./dist
+              echo -n $version > ./dist/version
+              echo -n "electron" > ./path.txt
+            ''
+            else "";
 
-          postFixup = ''
-            mkdir -p $out/lib
-            ln -s $(realpath ./dist) $out/lib/electron
-          '';
+          postFixup =
+            if pkgs.stdenv.isLinux
+            then ''
+              mkdir -p $out/lib
+              ln -s $(realpath ./dist) $out/lib/electron
+            ''
+            else "";
         };
       };
     };

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -139,13 +139,22 @@
 
   # Only executed for electron based packages.
   # Creates an executable script under /bin starting the electron app
-  electron-wrap = ''
-    mkdir -p $out/bin
-    makeWrapper \
-      $electronDist/electron \
-      $out/bin/$(basename "$packageName") \
-      --add-flags "$(realpath $electronAppDir)"
-  '';
+  electron-wrap =
+    if pkgs.stdenv.isLinux
+    then ''
+      mkdir -p $out/bin
+      makeWrapper \
+        $electronDist/electron \
+        $out/bin/$(basename "$packageName") \
+        --add-flags "$(realpath $electronAppDir)"
+    ''
+    else ''
+      mkdir -p $out/bin
+      makeWrapper \
+        $electronDist/Electron.app/Contents/MacOS/Electron \
+        $out/bin/$(basename "$packageName") \
+        --add-flags "$(realpath $electronAppDir)"
+    '';
 
   # Generates a derivation for a specific package name + version
   makePackage = name: version: let


### PR DESCRIPTION
I'm not sure how to disable it, but it looks like by default the evaluation on darwin is impure for electron.
the the resulting directory looks exactly right, and the only thing to do is change the electron wrapper.
Let me know if that works for you.

electron is working, just showing a `Electron could not be found. No hard resets for you!` warning before running