### PR TITLE
fix(translator/cargo-lock): prioritize workspaceToml for path dependencies

### DIFF
--- a/src/builders/rust/vendor.nix
+++ b/src/builders/rust/vendor.nix
@@ -132,7 +132,7 @@ in rec {
       " \\\n"
       (
         l.mapAttrsToList
-        (rel: abs: "--replace '${rel}' '${abs}'")
+        (rel: abs: "--replace '\"${rel}\"' '\"${abs}\"'")
         subsystemAttrs.replacePathsWithAbsolute
       );
   in ''

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -262,19 +262,19 @@ in {
                   rootName = null;
                   rootVersion = null;
                 }
-              else if nonWorkspaceToml != null
-              then
-                dlib.construct.pathSource {
-                  path = "${rootSource}/${nonWorkspaceToml.relPath}";
-                  rootName = null;
-                  rootVersion = null;
-                }
               else if workspaceToml != null
               then
                 dlib.construct.pathSource {
                   path = workspaceToml.relPath;
                   rootName = package.name;
                   rootVersion = package.version;
+                }
+              else if nonWorkspaceToml != null
+              then
+                dlib.construct.pathSource {
+                  path = "${rootSource}/${nonWorkspaceToml.relPath}";
+                  rootName = null;
+                  rootVersion = null;
                 }
               else throw "could not find crate ${dependencyObject.name}";
 


### PR DESCRIPTION
This fixes an issue with the `workspaceToml` that was found not being used, and instead the `nonWorkspaceToml` being used, which causes `getRoot` to return `null` for `pname` and `version` because `nonWorkspaceToml`s do not have roots.

EDIT: also added a small fix for path replacement accidentally replacing features