### PR TITLE
Another round of rust fixes

### DIFF
--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -40,7 +40,7 @@
 
       preConfigure = ''
         mkdir -p $CARGO_HOME
-        mv /build/.cargo/config $CARGO_HOME/config.toml
+        mv ../.cargo/config $CARGO_HOME/config.toml
         ${vendoring.writeGitVendorEntries "vendored-sources"}
         ${vendoring.replaceRelativePathsWithAbsolute}
       '';

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -2,7 +2,7 @@
   lib,
   pkgs,
   ...
-}: {
+} @ topArgs: {
   subsystemAttrs,
   defaultPackageName,
   defaultPackageVersion,
@@ -16,12 +16,15 @@
 } @ args: let
   l = lib // builtins;
 
-  utils = import ../utils.nix args;
-  vendoring = import ../vendor.nix (args // {inherit lib pkgs utils;});
+  utils = import ../utils.nix (args // topArgs);
+  vendoring = import ../vendor.nix (args // topArgs);
 
   buildPackage = pname: version: let
     src = utils.getRootSource pname version;
-    vendorDir = vendoring.vendorDependencies pname version;
+    vendorDir = vendoring.vendoredDependencies;
+    replacePaths =
+      utils.replaceRelativePathsWithAbsolute subsystemAttrs.relPathReplacements;
+    writeGitVendorEntries = vendoring.writeGitVendorEntries "vendored-sources";
 
     cargoBuildFlags = "--package ${pname}";
   in
@@ -41,8 +44,8 @@
       preConfigure = ''
         mkdir -p $CARGO_HOME
         mv ../.cargo/config $CARGO_HOME/config.toml
-        ${vendoring.writeGitVendorEntries "vendored-sources"}
-        ${vendoring.replaceRelativePathsWithAbsolute}
+        ${writeGitVendorEntries}
+        ${replacePaths}
       '';
     });
 in rec {

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -32,7 +32,7 @@
       inherit pname version src;
 
       cargoBuildFlags = cargoBuildFlags;
-      cargoCheckFlags = cargoBuildFlags;
+      cargoTestFlags = cargoBuildFlags;
 
       cargoVendorDir = "../nix-vendor";
 

--- a/src/builders/rust/utils.nix
+++ b/src/builders/rust/utils.nix
@@ -2,10 +2,30 @@
   getSourceSpec,
   getSource,
   getRoot,
+  lib,
   ...
-}: rec {
+}: let
+  l = lib // builtins;
+in rec {
+  # Gets the root source for a package
   getRootSource = pname: version: let
     root = getRoot pname version;
   in
     getSource root.pname root.version;
+
+  # Generates a script that replaces relative path dependency paths with absolute
+  # ones, if the path dependency isn't in the source dream2nix provides
+  replaceRelativePathsWithAbsolute = paths: let
+    replacements =
+      l.concatStringsSep
+      " \\\n"
+      (
+        l.mapAttrsToList
+        (rel: abs: "--replace '\"${rel}\"' '\"${abs}\"'")
+        paths
+      );
+  in ''
+    substituteInPlace ./Cargo.toml \
+      ${replacements}
+  '';
 }

--- a/src/default.nix
+++ b/src/default.nix
@@ -289,6 +289,7 @@
         inherit
           buildPackageWithOtherBuilder
           produceDerivation
+          dreamLock
           ;
 
         inherit


### PR DESCRIPTION
- don't hardcode a path to `/build` in `buildRustPackage` (breaks builds on mac)
- vendor all dependencies in the Cargo.lock and use that in builds, this fixes issues with cargo complaining about unvendored dependencies (should fix #129)
- organize some code better