### PR TITLE
don't mv ../.cargo/config if it doesn't exist

### DIFF
--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -43,7 +43,9 @@
 
       preConfigure = ''
         mkdir -p $CARGO_HOME
-        mv ../.cargo/config $CARGO_HOME/config.toml
+        if [ -f ../.cargo/config ]; then
+          mv ../.cargo/config $CARGO_HOME/config.toml
+        fi
         ${writeGitVendorEntries}
         ${replacePaths}
       '';


### PR DESCRIPTION
I have dream2nix complaining about missing `../.cargo/config` and I don't know if it's the right fix but it seems ok