### PR TITLE
Initial stab at extensible subsystems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,8 @@
 
     lib = nixpkgs.lib;
 
-    # dream2nix lib (system independent utils)
-    dlib = import ./src/lib {inherit lib;};
+    # # dream2nix lib (system independent utils)
+    # dlib = import ./src/lib {inherit lib;};
 
     supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
@@ -137,7 +137,7 @@
     dream2nixFor = forAllSystems (system: pkgs:
       import ./src rec {
         externalDir = externalDirFor."${system}";
-        inherit dlib externalPaths externalSources lib pkgs;
+        inherit externalPaths externalSources lib pkgs;
         config = {
           inherit overridesDirs;
         };
@@ -167,7 +167,7 @@
     # Produces flake-like output schema.
     lib =
       (import ./src/lib.nix {
-        inherit dlib externalPaths externalSources overridesDirs lib;
+        inherit externalPaths externalSources overridesDirs lib;
         nixpkgsSrc = "${nixpkgs}";
       })
       # system specific dream2nix library

--- a/src/builders/default.nix
+++ b/src/builders/default.nix
@@ -1,28 +1,54 @@
 {
+  config,
+  dlib,
   builders,
   callPackageDream,
   ...
-}: {
-  python = rec {
-    default = simpleBuilder;
+}: let
+  l = dlib.lib;
 
-    simpleBuilder = callPackageDream ./python/simple-builder {};
+  builtinBuilders = {
+    python = rec {
+      default = simpleBuilder;
+
+      simpleBuilder = callPackageDream ./python/simple-builder {};
+    };
+
+    nodejs = rec {
+      default = granular;
+
+      node2nix = callPackageDream ./nodejs/node2nix {};
+
+      granular = callPackageDream ./nodejs/granular {inherit builders;};
+    };
+
+    rust = rec {
+      default = buildRustPackage;
+
+      buildRustPackage = callPackageDream ./rust/build-rust-package {};
+
+      # this builder requires IFD!
+      crane = callPackageDream ./rust/crane {};
+    };
   };
 
-  nodejs = rec {
-    default = granular;
+  extendedBuilders = l.mapAttrs (name: subsystem:
+      let
+        default      = subsystem.default or null;
+        instantiated = l.mapAttrsToList
+            (name: builder:
+              let
+                value = callPackageDream builder {};
+              in
+                (if default == builder
+                   then [ { inherit name value; } { name = "default"; inherit value; } ]
+                   else [ { inherit name value; } ]))
+            subsystem;
+      in
+        l.listToAttrs (l.flatten instantiated))
+    config.builders or {};
 
-    node2nix = callPackageDream ./nodejs/node2nix {};
-
-    granular = callPackageDream ./nodejs/granular {inherit builders;};
-  };
-
-  rust = rec {
-    default = buildRustPackage;
-
-    buildRustPackage = callPackageDream ./rust/build-rust-package {};
-
-    # this builder requires IFD!
-    crane = callPackageDream ./rust/crane {};
-  };
-}
+  allBuilders = builtinBuilders // extendedBuilders;
+in
+  allBuilders
+  

--- a/src/fetchers/default.nix
+++ b/src/fetchers/default.nix
@@ -1,6 +1,6 @@
 {
+  config,
   lib,
-  # dream2nix
   callPackageDream,
   dlib,
   ...
@@ -8,10 +8,10 @@
   b = builtins;
   callFetcher = file: args: callPackageDream file args;
 in rec {
-  fetchers = lib.genAttrs (dlib.dirNames ./.) (
-    name:
-      callFetcher (./. + "/${name}") {}
-  );
+  fetchers' = (lib.genAttrs (dlib.dirNames ../.) (name: ./. + "/${name}"))
+    // (config.fetchers or {});
+
+  fetchers = lib.mapAttrs (name: pathOrModule: callFetcher pathOrModule {}) fetchers';
 
   defaultFetcher = callPackageDream ./default-fetcher.nix {inherit fetchers fetchSource;};
 

--- a/src/fetchers/http/default.nix
+++ b/src/fetchers/http/default.nix
@@ -37,6 +37,6 @@
         source = drvSanitized;
       };
     in
-      extracted;
+      drvSanitized;
   };
 }

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -2,7 +2,7 @@
 # (allows to generate outputs for several systems)
 # follows flake output schema
 {
-  dlib,
+  # dlib,
   nixpkgsSrc,
   lib,
   overridesDirs,
@@ -13,9 +13,9 @@
 
   l = lib // builtins;
 
-  dream2nixForSystem = config: system: pkgs:
+  dream2nixForSystem = dlib: config: system: pkgs:
     import ./default.nix
-    {inherit config externalPaths externalSources pkgs;};
+    {inherit dlib config externalPaths externalSources pkgs;};
 
   # TODO: design output schema for cross compiled packages
   makePkgsKey = pkgs: let
@@ -56,27 +56,29 @@
     pkgs ? null,
     systems ? [],
     config ? {},
-  } @ argsInit: let
-    config' = (import ./utils/config.nix).loadConfig argsInit.config or {};
+  }: let
+    config' = (import ./utils/config.nix).loadConfig config;
 
-    config =
+    finalConfig =
       config'
       // {
         overridesDirs = args.overridesDirs ++ config'.overridesDirs;
       };
 
+    dlib = import ./lib {inherit lib; config = finalConfig;};
+
     allPkgs = makeNixpkgs pkgs systems;
 
     forAllSystems = f: lib.mapAttrs f allPkgs;
 
-    dream2nixFor = forAllSystems (dream2nixForSystem config);
+    dream2nixFor = forAllSystems (dream2nixForSystem dlib finalConfig);
   in {
     riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
 
     makeFlakeOutputs = mArgs:
       makeFlakeOutputsFunc
       (
-        {inherit config pkgs systems;}
+        {inherit dlib pkgs systems; config = finalConfig;}
         // mArgs
       );
 
@@ -92,6 +94,7 @@
   };
 
   makeFlakeOutputsFunc = {
+    dlib ? import ./lib {inherit config lib;},
     config ? {},
     inject ? {},
     pname ? throw "Please pass `pname` to makeFlakeOutputs",
@@ -104,10 +107,13 @@
     translator ? null,
     translatorArgs ? {},
   } @ args: let
-    config = args.config or ((import ./utils/config.nix).loadConfig {});
+    finalConfig = (import ./utils/config.nix).loadConfig config;
     allPkgs = makeNixpkgs pkgs systems;
     forAllSystems = f: b.mapAttrs f allPkgs;
-    dream2nixFor = forAllSystems (dream2nixForSystem config);
+    dream2nixFor = forAllSystems (
+      dream2nixForSystem
+      dlib
+      finalConfig);
 
     getInvalidationHash = project:
       dlib.calcInvalidationHash {
@@ -208,7 +214,7 @@
   in
     flakeOutputs;
 in {
-  inherit dlib init;
+  inherit init;
   riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
   makeFlakeOutputs = makeFlakeOutputsFunc;
 }

--- a/src/lib/construct.nix
+++ b/src/lib/construct.nix
@@ -1,5 +1,5 @@
 # constructors to have at least some kind of `type` safety
-{lib}: {
+{ config, lib }: {
   discoveredProject = {
     name,
     relPath,

--- a/src/lib/default.nix
+++ b/src/lib/default.nix
@@ -7,6 +7,8 @@
 
   # exported attributes
   dlib = {
+    lib = l;
+
     inherit
       calcInvalidationHash
       callViaEnv
@@ -37,9 +39,9 @@
   };
 
   # other libs
-  construct = import ./construct.nix {inherit lib;};
+  construct   = import ./construct.nix {inherit config lib;};
   discoverers = import ../discoverers {inherit config dlib lib;};
-  translators = import ./translators.nix {inherit dlib lib;};
+  translators = import ./translators.nix {inherit config dlib lib;};
 
   simpleTranslate2 =
     (import ./simpleTranslate2.nix {inherit dlib lib;}).simpleTranslate2;

--- a/src/lib/translators.nix
+++ b/src/lib/translators.nix
@@ -1,4 +1,5 @@
 {
+  config,
   dlib,
   lib,
 }: let
@@ -6,24 +7,26 @@
 
   # INTERNAL
 
-  subsystems = dlib.dirNames ../translators;
+  subsystems = (l.genAttrs (dlib.dirNames ../translators) (subsystem: ../translators + "/${subsystem}"))
+    // (config.translators or {});
 
   translatorTypes = ["impure" "ifd" "pure"];
 
   # attrset of: subsystem -> translator-type -> (function subsystem translator-type)
   mkTranslatorsSet = function:
-    l.genAttrs
-    (dlib.dirNames ../translators)
-    (subsystem: let
+    l.mapAttrs
+    (subsystemName: subsystem: let
       availableTypes =
         l.filter
-        (type: l.pathExists (../translators + "/${subsystem}/${type}"))
+        (type: if l.isPath subsystem  then (l.pathExists "${subsystem}/${type}")
+          else if l.isAttrs subsystem then subsystem ? ${type}
+          else throw "Translator can be a path or an attrset, but instead was ${l.typeOf subsystem}")
         translatorTypes;
 
       translatorsForTypes =
         l.genAttrs
         availableTypes
-        (transType: function subsystem transType);
+        (transType: function subsystemName subsystem transType);
     in
       translatorsForTypes
       // {
@@ -32,7 +35,8 @@
           (a: b: a // b)
           {}
           (l.attrValues translatorsForTypes);
-      });
+      })
+      subsystems;
 
   # flat list of all translators sorted by priority (pure translators first)
   translatorsList = let
@@ -50,8 +54,8 @@
     (a: b: (prio a) < (prio b))
     list;
 
-  callTranslator = subsystem: type: name: file: args: let
-    translatorModule = import file {
+  callTranslator = subsystem: type: name: mkModule: args: let
+    translatorModule = mkModule {
       inherit dlib lib;
     };
   in
@@ -64,19 +68,25 @@
 
   # attrset of: subsystem -> translator-type -> translator
   translators = mkTranslatorsSet (
-    subsystem: type: let
-      translatorNames =
-        dlib.dirNames (../translators + "/${subsystem}/${type}");
+    # subsystem can be a path or an attrset 
+    subsystemName: subsystem: type: let
+      translatorNames = if l.isPath subsystem then dlib.dirNames "${subsystem}/${type}"
+        else if l.isAttrs subsystem then l.attrNames (subsystem.${type} or {})
+        # TODO: it would be sensible for translator leafs to be either functions or paths
+        else throw "Translator can be a path or an attrset, but instead was ${l.typeOf subsystem}";
 
       translatorsLoaded =
         l.genAttrs
         translatorNames
         (translatorName:
           callTranslator
-          subsystem
+          subsystemName
           type
           translatorName
-          (../translators + "/${subsystem}/${type}/${translatorName}")
+          (     if l.isPath subsystem then (import "${subsystem}/${type}/${translatorName}")
+           else if l.isAttrs subsystem then subsystem.${type}.${translatorName}
+           # TODO: it would be sensible for translator leafs to be either functions or paths
+           else throw "Translator can be a path or an attrset, but instead was ${l.typeOf subsystem}")
           {});
     in
       l.filterAttrs


### PR DESCRIPTION
Hi, I come bearing actual discussion material regarding allowing `dream2nix` to be extended from outside.
This is the least amount of changes that allowed me to specify new discoverers, translators, fetchers and builders using the `config` attribute. Right now this is pretty un-fancy – for example it would be tedious to combine multiple extensions together, as you would have to manually merge attrsets together. An overlay-based mechanism, with each extension providing an overlay adding language-subsystem-specific functionality would probably make more sense, but wanted to keep it as simple as possible and have really no idea how much changes would be required to accommodate that.

Now, I don't quite understand what I'm doing here, so some changes might've been unnecessary or better accomplished another way – for example I had to push down the `dlib` like that and thread `config` through more places, because otherwise I ended up with translators that alternatively had the specified config or not, probably closing over different things – but hopefully at least better explains what I thought `dream2nix` being extensible might be useful and could be a starting port for a discussion.
 
Here's a repo using it to get a barebones Ruby subystem running to show it actually works:
https://github.com/jaen/iwai