### PR TITLE
fix(translator/cargo-lock): fix some bugs regarding source entry parsing and getting checksums

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -611,6 +611,7 @@ in {
     translators
     updaters
     utils
+    makeOutputsForDreamLock
     ;
 
   inherit

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -80,6 +80,13 @@ in {
     # Parse Cargo.lock and extract dependencies
     parsedLock = projectTree.files."Cargo.lock".tomlContent;
     parsedDeps = parsedLock.package;
+
+    # Gets a checksum from the [metadata] table of the lockfile
+    getChecksum = dep: let
+      key = "checksum ${dep.name} ${dep.version} (${dep.source})";
+    in
+      parsedLock.metadata."${key}";
+
     # This parses a "package-name version" entry in the "dependencies"
     # field of a dependency in Cargo.lock
     makeDepNameVersion = entry: let
@@ -288,7 +295,7 @@ in {
               type = "crates-io";
               name = dependencyObject.name;
               version = dependencyObject.version;
-              hash = dependencyObject.checksum;
+              hash = dependencyObject.checksum or (getChecksum dependencyObject);
             };
           };
         in

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -87,7 +87,7 @@ in {
       name = l.head parsed;
       maybeVersion =
         if l.length parsed > 1
-        then l.last parsed
+        then l.elemAt parsed 1
         else null;
     in {
       inherit name;


### PR DESCRIPTION
This also exposes `makeOutputsForDreamLock`, which i use on https://github.com/yusdacra/dream2nix-crates-io.