### PR TITLE
fix(translator/cargo-lock): dont assume parsed.type exists, use `or null`

### DIFF
--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -286,9 +286,9 @@ in {
             git = dependencyObject: let
               parsed = parseGitSource dependencyObject.source;
               maybeRef =
-                if parsed.type == "branch"
+                if parsed.type or null == "branch"
                 then {ref = "refs/heads/${parsed.value}";}
-                else if parsed.type == "tag"
+                else if parsed.type or null == "tag"
                 then {ref = "refs/tags/${parsed.value}";}
                 else {};
             in


### PR DESCRIPTION
Fixes an issue with the `cargo-lock` translator. Apparently the tests didn't catch this. Should probably add a test with a crate that has git dependencies.