### PR TITLE
Webpack build support

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -782,6 +782,15 @@ in
       };
     };
 
+    webpack-cli = {
+      remove-webpack-check = {
+        _condition = satisfiesSemver "^4.9.0";
+        patches = [
+          ./webpack-cli/remove-webpack-check.patch
+        ];
+      };
+    };
+
     # TODO: Maybe should replace binaries with the ones from nixpkgs
     "7zip-bin" = {
       patch-binaries = {

--- a/overrides/nodejs/webpack-cli/remove-webpack-check.patch
+++ b/overrides/nodejs/webpack-cli/remove-webpack-check.patch
@@ -1,12 +1,12 @@
-diff --git a/packages/webpack-cli/bin/cli.js b/packages/webpack-cli/bin/cli.js
---- a/bin/cli.js
-+++ b/bin/cli.js
-@@ -21,7 +21,7 @@ if (!process.env.WEBPACK_CLI_SKIP_IMPORT_LOCAL) {
+diff --git a/packages/webpack-cli/src/webpack-cli.ts b/packages/webpack-cli/src/webpack-cli.ts
+--- a/lib/webpack-cli.js
++++ b/lib/webpack-cli.js
+@@ -342,7 +342,7 @@
+           continue;
+         }
  
- process.title = "webpack";
+-        let skipInstallation = false;
++        let skipInstallation = true;
  
--if (utils.packageExists("webpack")) {
-+if (true) {
-     runCLI(process.argv, originalModuleCompile);
- } else {
-     const { promptInstallation, logger, colors } = utils;
+         // Allow to use `./path/to/webpack.js` outside `node_modules`
+         if (dependency === WEBPACK_PACKAGE && fs.existsSync(WEBPACK_PACKAGE)) {


### PR DESCRIPTION
Webpack is currently broken with dream2nix builds, due to the lack of a patch for the webpack-cli among other necessary modifications.

I've managed to get something working here: 
https://github.com/marigold-dev/deku/pull/579

It required a patch to the webpack-cli (attached)

&& wrapping webpack: 
```nix
nodejs-package = self.packages.${system}.package-name

patched-webpack = nodejs-package.dependencies.webpack.overrideAttrs (_: {
          postFixup = ''
            wrapProgram $out/bin/webpack \
            --set NODE_PATH ${nodejs-package}/lib/node_modules/package-name/node_modules:$NODE_PATH
          '';
});
```

&& a similar webpack.config.js to this (credit to @d4hines)
https://github.com/marigold-dev/deku/blob/main/src/tezos_interop/webpack.config.js

**Note**: exposing certain packages to the ``NODE_PATH`` may be also necessary in-case of importing certain dependencies.
in the case of deku, I added 
``{nodejs-package.dependencies."@taquito/taquito"}/lib/node_modules/@taquito/taquito/node_modules`` to it as well

Not sure where to go with this, hence it being a draft.