### PR TITLE
refactor(translator/cargo-lock): dont add name and version to crates-io source

### DIFF
--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -305,8 +305,6 @@ in {
 
             crates-io = dependencyObject: {
               type = "crates-io";
-              name = dependencyObject.name;
-              version = dependencyObject.version;
               hash = dependencyObject.checksum or (getChecksum dependencyObject);
             };
           };


### PR DESCRIPTION
…because they are no longer needed.