### PR TITLE
Resolve `path` sources relative to the source root

### DIFF
--- a/examples/path-example/flake.lock
+++ b/examples/path-example/flake.lock
@@ -1,0 +1,210 @@
+{
+  "nodes": {
+    "alejandra": {
+      "inputs": {
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1648332543,
+        "narHash": "sha256-9FWmFNLCOp4y0I8Yb4GvgGXxtDq3nBDSTI9qyCi2LJ4=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "5cbb3486c7959646f452830c0a223edc5db5b951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644785799,
+        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "crane": "crane",
+        "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "gomod2nix": "gomod2nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "node2nix": "node2nix",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1651844867,
+        "narHash": "sha256-a+bAmmeIudRVY23ZkEB5W5xJumBY3ydsiDIGN/56NmQ=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "e5d0e9cdb00695b0b63d1f52ff3b39c0e3035fe3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-utils-pre-commit": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627572165,
+        "narHash": "sha256-MFpwnkvQpauj799b4QTBJQFEddbD02+Ln5k92QyHOSk=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634711045,
+        "narHash": "sha256-m5A2Ty88NChLyFhXucECj6+AuiMZPHXNbw+9Kcs7F6Y=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "4433f74a97b94b596fa6cd9b9c0402104aceef5d",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645433236,
+        "narHash": "sha256-4va4MvJ076XyPp5h8sm5eMQvCrJ6yZAbBmyw95dGyw4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "node2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634916276,
+        "narHash": "sha256-lov2b/8ydYjq+MhKQugmWV2lFnq35AU5RTRBTfLq7B4=",
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "rev": "644e90c0304038a446ed53efc97e9eb1e2831e71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632969109,
+        "narHash": "sha256-jPDclkkiAy5m2gGLBlKgH+lQtbF7tL4XxBrbSzw+Ioc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.21.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "dream2nix",
+          "flake-utils-pre-commit"
+        ],
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/path-example/flake.nix
+++ b/examples/path-example/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+  } @ inp: let
+    dream2nix = inp.dream2nix.lib2.init {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+    };
+  in
+    (dream2nix.makeFlakeOutputs {
+      source = ./.;
+      settings = [
+      ];
+    })
+    // {
+      checks = self.packages;
+    };
+}

--- a/examples/path-example/package.json
+++ b/examples/path-example/package.json
@@ -1,0 +1,5 @@
+{
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/examples/path-example/packages/cli/bin/cli.js
+++ b/examples/path-example/packages/cli/bin/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const { getHello } = require("lib");
+
+console.log(getHello());

--- a/examples/path-example/packages/cli/package.json
+++ b/examples/path-example/packages/cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cli",
+  "version": "1.0.0",
+  "bin": {
+    "cli": "bin/cli.js"
+  },
+  "dependencies": {
+    "lib": "^1.0.0"
+  }
+}

--- a/examples/path-example/packages/lib/package.json
+++ b/examples/path-example/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lib",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+
+  }
+}

--- a/examples/path-example/packages/lib/src/main.js
+++ b/examples/path-example/packages/lib/src/main.js
@@ -1,0 +1,3 @@
+const getHello = () => "Salve, mundus!";
+
+module.exports = { getHello };

--- a/src/default.nix
+++ b/src/default.nix
@@ -200,7 +200,7 @@
   # fetch only sources and do not build
   fetchSources = {
     dreamLock,
-    sourceRoot,
+    sourceRoot ? null,
     fetcher ? null,
     extract ? false,
     sourceOverrides ? oldSources: {},
@@ -342,7 +342,7 @@
 
   makeOutputsForDreamLock = {
     dreamLock,
-    sourceRoot,
+    sourceRoot ? null,
     builder ? null,
     fetcher ? null,
     inject ? {},

--- a/src/default.nix
+++ b/src/default.nix
@@ -200,6 +200,7 @@
   # fetch only sources and do not build
   fetchSources = {
     dreamLock,
+    sourceRoot,
     fetcher ? null,
     extract ? false,
     sourceOverrides ? oldSources: {},
@@ -213,7 +214,7 @@
       else args.fetcher;
 
     fetched = fetcher rec {
-      inherit sourceOverrides;
+      inherit sourceOverrides sourceRoot;
       defaultPackage = dreamLock._generic.defaultPackage;
       defaultPackageVersion = dreamLock._generic.packages."${defaultPackage}";
       sources = dreamLock'.sources;
@@ -341,6 +342,7 @@
 
   makeOutputsForDreamLock = {
     dreamLock,
+    sourceRoot,
     builder ? null,
     fetcher ? null,
     inject ? {},
@@ -369,7 +371,7 @@
 
     fetchedSources =
       (fetchSources {
-        inherit dreamLock sourceOverrides;
+        inherit dreamLock sourceOverrides sourceRoot;
         fetcher = fetcher';
       })
       .fetchedSources;
@@ -552,6 +554,7 @@
     outputsForProject = proj: let
       outputs = makeOutputsForDreamLock {
         inherit inject packageOverrides;
+        sourceRoot = source;
         builder = proj.builder or null;
         dreamLock = proj.dreamLock;
         sourceOverrides = oldSources:

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -11,7 +11,7 @@
   defaultPackageVersion,
   sourceOverrides,
   sources,
-  sourceRoot,
+  sourceRoot ? null,
   ...
 }: let
   l = lib // builtins;
@@ -27,11 +27,13 @@
         then
           if l.isStorePath (l.concatStringsSep "/" (l.take 4 (l.splitString "/" source.path)))
           then source.path
-          else if l.pathExists (l.traceVal "${sourceRoot}/${source.path}")
-          then "${sourceRoot}/${source.path}"
           else if name == source.rootName && version == source.rootVersion
           then throw "source for ${name}@${version} is referencing itself"
-          else "${overriddenSources."${source.rootName}"."${source.rootVersion}"}/${source.path}"
+          else if source.rootName != null && source.rootVersion != null
+          then "${overriddenSources."${source.rootName}"."${source.rootVersion}"}/${source.path}"
+          else if sourceRoot != null
+          then "${sourceOverrides}/${source.path}"
+          else throw "${name}-${version}: cannot determine path source"
         else if fetchers.fetchers ? "${source.type}"
         then
           fetchSource {

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -11,6 +11,7 @@
   defaultPackageVersion,
   sourceOverrides,
   sources,
+  sourceRoot,
   ...
 }: let
   l = lib // builtins;
@@ -26,6 +27,8 @@
         then
           if l.isStorePath (l.concatStringsSep "/" (l.take 4 (l.splitString "/" source.path)))
           then source.path
+          else if l.pathExists (l.traceVal "${sourceRoot}/${source.path}")
+          then "${sourceRoot}/${source.path}"
           else if name == source.rootName && version == source.rootVersion
           then throw "source for ${name}@${version} is referencing itself"
           else "${overriddenSources."${source.rootName}"."${source.rootVersion}"}/${source.path}"

--- a/src/fetchers/default-fetcher.nix
+++ b/src/fetchers/default-fetcher.nix
@@ -32,7 +32,7 @@
           else if source.rootName != null && source.rootVersion != null
           then "${overriddenSources."${source.rootName}"."${source.rootVersion}"}/${source.path}"
           else if sourceRoot != null
-          then "${sourceOverrides}/${source.path}"
+          then "${sourceRoot}/${source.path}"
           else throw "${name}-${version}: cannot determine path source"
         else if fetchers.fetchers ? "${source.type}"
         then


### PR DESCRIPTION
Changes the built-in path fetcher to resolve relative paths relative to the source root, allowing to build packages from the same repository the lockfile resides in. A test package that doesn't build without those changes and starts building with them was added.