### PR TITLE
feat: implement cargo-toml impure translator for rust subsystem

### DIFF
--- a/examples/no-cargo-lock-example/dream2nix-packages/rand/dream-lock.json
+++ b/examples/no-cargo-lock-example/dream2nix-packages/rand/dream-lock.json
@@ -1,0 +1,338 @@
+{
+  "_generic": {
+    "defaultPackage": "rand",
+    "invalidationHash": "a05b4e6ab6a187131c8b7c1b4ba182daedb1a3def823654dc46a5e478950304b",
+    "location": "",
+    "packages": {
+      "rand": "0.8.5",
+      "rand_chacha": "0.3.1",
+      "rand_core": "0.6.4",
+      "rand_distr": "0.4.3",
+      "rand_pcg": "0.3.1"
+    },
+    "sourcesAggregatedHash": null,
+    "subsystem": "rust"
+  },
+  "_subsystem": {
+    "gitSources": [],
+    "relPathReplacements": {}
+  },
+  "cyclicDependencies": {},
+  "dependencies": {
+    "average": {
+      "0.13.1": [
+        [ "easy-cast", "0.4.4" ],
+        [ "float-ord", "0.3.2" ],
+        [ "num-traits", "0.2.15" ]
+      ]
+    },
+    "bincode": {
+      "1.3.3": [
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "easy-cast": {
+      "0.4.4": [
+        [ "libm", "0.2.2" ]
+      ]
+    },
+    "getrandom": {
+      "0.2.6": [
+        [ "cfg-if", "1.0.0" ],
+        [ "libc", "0.2.126" ],
+        [ "wasi", "0.10.2+wasi-snapshot-preview1" ]
+      ]
+    },
+    "log": {
+      "0.4.17": [
+        [ "cfg-if", "1.0.0" ]
+      ]
+    },
+    "num-traits": {
+      "0.2.15": [
+        [ "autocfg", "1.1.0" ],
+        [ "libm", "0.2.2" ]
+      ]
+    },
+    "packed_simd_2": {
+      "0.3.7": [
+        [ "cfg-if", "1.0.0" ],
+        [ "libm", "0.1.4" ]
+      ]
+    },
+    "proc-macro2": {
+      "1.0.39": [
+        [ "unicode-ident", "1.0.0" ]
+      ]
+    },
+    "quote": {
+      "1.0.18": [
+        [ "proc-macro2", "1.0.39" ]
+      ]
+    },
+    "rand": {
+      "0.8.5": [
+        [ "bincode", "1.3.3" ],
+        [ "libc", "0.2.126" ],
+        [ "log", "0.4.17" ],
+        [ "packed_simd_2", "0.3.7" ],
+        [ "rand_chacha", "0.3.1" ],
+        [ "rand_core", "0.6.4" ],
+        [ "rand_pcg", "0.3.1" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "rand_chacha": {
+      "0.3.1": [
+        [ "ppv-lite86", "0.2.16" ],
+        [ "rand_core", "0.6.4" ],
+        [ "serde", "1.0.137" ],
+        [ "serde_json", "1.0.81" ]
+      ]
+    },
+    "rand_core": {
+      "0.6.4": [
+        [ "getrandom", "0.2.6" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "rand_distr": {
+      "0.4.3": [
+        [ "average", "0.13.1" ],
+        [ "num-traits", "0.2.15" ],
+        [ "rand", "0.8.5" ],
+        [ "rand_pcg", "0.3.1" ],
+        [ "serde", "1.0.137" ],
+        [ "special", "0.8.1" ]
+      ]
+    },
+    "rand_pcg": {
+      "0.3.1": [
+        [ "bincode", "1.3.3" ],
+        [ "rand_core", "0.6.4" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "serde": {
+      "1.0.137": [
+        [ "serde_derive", "1.0.137" ]
+      ]
+    },
+    "serde_derive": {
+      "1.0.137": [
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "syn", "1.0.95" ]
+      ]
+    },
+    "serde_json": {
+      "1.0.81": [
+        [ "itoa", "1.0.2" ],
+        [ "ryu", "1.0.10" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "special": {
+      "0.8.1": [
+        [ "libc", "0.2.126" ]
+      ]
+    },
+    "syn": {
+      "1.0.95": [
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "unicode-ident", "1.0.0" ]
+      ]
+    }
+  },
+  "sources": {
+    "autocfg": {
+      "1.1.0": {
+        "hash": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+        "type": "crates-io"
+      }
+    },
+    "average": {
+      "0.13.1": {
+        "hash": "843ec791d3f24503bbf72bbd5e49a3ab4dbb4bcd0a8ef6b0c908efa73caa27b1",
+        "type": "crates-io"
+      }
+    },
+    "bincode": {
+      "1.3.3": {
+        "hash": "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad",
+        "type": "crates-io"
+      }
+    },
+    "cfg-if": {
+      "1.0.0": {
+        "hash": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "type": "crates-io"
+      }
+    },
+    "easy-cast": {
+      "0.4.4": {
+        "hash": "4bd102ee8c418348759919b83b81cdbdc933ffe29740b903df448b4bafaa348e",
+        "type": "crates-io"
+      }
+    },
+    "float-ord": {
+      "0.3.2": {
+        "hash": "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d",
+        "type": "crates-io"
+      }
+    },
+    "getrandom": {
+      "0.2.6": {
+        "hash": "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad",
+        "type": "crates-io"
+      }
+    },
+    "itoa": {
+      "1.0.2": {
+        "hash": "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d",
+        "type": "crates-io"
+      }
+    },
+    "libc": {
+      "0.2.126": {
+        "hash": "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836",
+        "type": "crates-io"
+      }
+    },
+    "libm": {
+      "0.1.4": {
+        "hash": "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a",
+        "type": "crates-io"
+      },
+      "0.2.2": {
+        "hash": "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db",
+        "type": "crates-io"
+      }
+    },
+    "log": {
+      "0.4.17": {
+        "hash": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+        "type": "crates-io"
+      }
+    },
+    "num-traits": {
+      "0.2.15": {
+        "hash": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+        "type": "crates-io"
+      }
+    },
+    "packed_simd_2": {
+      "0.3.7": {
+        "hash": "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6",
+        "type": "crates-io"
+      }
+    },
+    "ppv-lite86": {
+      "0.2.16": {
+        "hash": "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872",
+        "type": "crates-io"
+      }
+    },
+    "proc-macro2": {
+      "1.0.39": {
+        "hash": "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f",
+        "type": "crates-io"
+      }
+    },
+    "quote": {
+      "1.0.18": {
+        "hash": "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1",
+        "type": "crates-io"
+      }
+    },
+    "rand": {
+      "0.8.5": {
+        "path": "",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rand_chacha": {
+      "0.3.1": {
+        "path": "rand_chacha",
+        "rootName": "rand",
+        "rootVersion": "0.8.5",
+        "type": "path"
+      }
+    },
+    "rand_core": {
+      "0.6.4": {
+        "path": "rand_core",
+        "rootName": "rand",
+        "rootVersion": "0.8.5",
+        "type": "path"
+      }
+    },
+    "rand_distr": {
+      "0.4.3": {
+        "path": "rand_distr",
+        "rootName": "rand",
+        "rootVersion": "0.8.5",
+        "type": "path"
+      }
+    },
+    "rand_pcg": {
+      "0.3.1": {
+        "path": "rand_pcg",
+        "rootName": "rand",
+        "rootVersion": "0.8.5",
+        "type": "path"
+      }
+    },
+    "ryu": {
+      "1.0.10": {
+        "hash": "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695",
+        "type": "crates-io"
+      }
+    },
+    "serde": {
+      "1.0.137": {
+        "hash": "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1",
+        "type": "crates-io"
+      }
+    },
+    "serde_derive": {
+      "1.0.137": {
+        "hash": "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be",
+        "type": "crates-io"
+      }
+    },
+    "serde_json": {
+      "1.0.81": {
+        "hash": "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c",
+        "type": "crates-io"
+      }
+    },
+    "special": {
+      "0.8.1": {
+        "hash": "24a65e074159b75dcf173a4733ab2188baac24967b5c8ec9ed87ae15fcbc7636",
+        "type": "crates-io"
+      }
+    },
+    "syn": {
+      "1.0.95": {
+        "hash": "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942",
+        "type": "crates-io"
+      }
+    },
+    "unicode-ident": {
+      "1.0.0": {
+        "hash": "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee",
+        "type": "crates-io"
+      }
+    },
+    "wasi": {
+      "0.10.2+wasi-snapshot-preview1": {
+        "hash": "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6",
+        "type": "crates-io"
+      }
+    }
+  }
+}

--- a/examples/no-cargo-lock-example/dream2nix-packages/rand/rand_distr/benches/dream-lock.json
+++ b/examples/no-cargo-lock-example/dream2nix-packages/rand/rand_distr/benches/dream-lock.json
@@ -13,7 +13,7 @@
     "gitSources": [],
     "relPathReplacements": {
       "../": "rand_distr",
-      "../../": "/tmp/tmp.OU1zbDABYe",
+      "../../": "/tmp/tmp.rgdTVGDUYJ",
       "../../rand_pcg/": "rand_pcg"
     }
   },

--- a/examples/no-cargo-lock-example/dream2nix-packages/rand/rand_distr/benches/dream-lock.json
+++ b/examples/no-cargo-lock-example/dream2nix-packages/rand/rand_distr/benches/dream-lock.json
@@ -1,0 +1,831 @@
+{
+  "_generic": {
+    "defaultPackage": "benches",
+    "invalidationHash": "8c253c6833913fad65e0013c2683a839a57d9422fbfa1937995ce203d20a7f06",
+    "location": "rand_distr/benches",
+    "packages": {
+      "benches": "0.0.0"
+    },
+    "sourcesAggregatedHash": null,
+    "subsystem": "rust"
+  },
+  "_subsystem": {
+    "gitSources": [],
+    "relPathReplacements": {
+      "../": "rand_distr",
+      "../../": "/tmp/tmp.OU1zbDABYe",
+      "../../rand_pcg/": "rand_pcg"
+    }
+  },
+  "cyclicDependencies": {},
+  "dependencies": {
+    "atty": {
+      "0.2.14": [
+        [ "hermit-abi", "0.1.19" ],
+        [ "libc", "0.2.126" ],
+        [ "winapi", "0.3.9" ]
+      ]
+    },
+    "benches": {
+      "0.0.0": [
+        [ "criterion", "0.3.5" ],
+        [ "criterion-cycles-per-byte", "0.1.2" ],
+        [ "rand", "0.8.5" ],
+        [ "rand_distr", "0.4.3" ],
+        [ "rand_pcg", "0.3.1" ]
+      ]
+    },
+    "bstr": {
+      "0.2.17": [
+        [ "lazy_static", "1.4.0" ],
+        [ "memchr", "2.5.0" ],
+        [ "regex-automata", "0.1.10" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "cast": {
+      "0.2.7": [
+        [ "rustc_version", "0.4.0" ]
+      ]
+    },
+    "clap": {
+      "2.34.0": [
+        [ "bitflags", "1.3.2" ],
+        [ "textwrap", "0.11.0" ],
+        [ "unicode-width", "0.1.9" ]
+      ]
+    },
+    "criterion": {
+      "0.3.5": [
+        [ "atty", "0.2.14" ],
+        [ "cast", "0.2.7" ],
+        [ "clap", "2.34.0" ],
+        [ "criterion-plot", "0.4.4" ],
+        [ "csv", "1.1.6" ],
+        [ "itertools", "0.10.3" ],
+        [ "lazy_static", "1.4.0" ],
+        [ "num-traits", "0.2.15" ],
+        [ "oorandom", "11.1.3" ],
+        [ "plotters", "0.3.1" ],
+        [ "rayon", "1.5.3" ],
+        [ "regex", "1.5.5" ],
+        [ "serde", "1.0.137" ],
+        [ "serde_cbor", "0.11.2" ],
+        [ "serde_derive", "1.0.137" ],
+        [ "serde_json", "1.0.81" ],
+        [ "tinytemplate", "1.2.1" ],
+        [ "walkdir", "2.3.2" ]
+      ]
+    },
+    "criterion-cycles-per-byte": {
+      "0.1.2": [
+        [ "criterion", "0.3.5" ]
+      ]
+    },
+    "criterion-plot": {
+      "0.4.4": [
+        [ "cast", "0.2.7" ],
+        [ "itertools", "0.10.3" ]
+      ]
+    },
+    "crossbeam-channel": {
+      "0.5.4": [
+        [ "cfg-if", "1.0.0" ],
+        [ "crossbeam-utils", "0.8.8" ]
+      ]
+    },
+    "crossbeam-deque": {
+      "0.8.1": [
+        [ "cfg-if", "1.0.0" ],
+        [ "crossbeam-epoch", "0.9.8" ],
+        [ "crossbeam-utils", "0.8.8" ]
+      ]
+    },
+    "crossbeam-epoch": {
+      "0.9.8": [
+        [ "autocfg", "1.1.0" ],
+        [ "cfg-if", "1.0.0" ],
+        [ "crossbeam-utils", "0.8.8" ],
+        [ "lazy_static", "1.4.0" ],
+        [ "memoffset", "0.6.5" ],
+        [ "scopeguard", "1.1.0" ]
+      ]
+    },
+    "crossbeam-utils": {
+      "0.8.8": [
+        [ "cfg-if", "1.0.0" ],
+        [ "lazy_static", "1.4.0" ]
+      ]
+    },
+    "csv": {
+      "1.1.6": [
+        [ "bstr", "0.2.17" ],
+        [ "csv-core", "0.1.10" ],
+        [ "itoa", "0.4.8" ],
+        [ "ryu", "1.0.10" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "csv-core": {
+      "0.1.10": [
+        [ "memchr", "2.5.0" ]
+      ]
+    },
+    "getrandom": {
+      "0.2.6": [
+        [ "cfg-if", "1.0.0" ],
+        [ "libc", "0.2.126" ],
+        [ "wasi", "0.10.2+wasi-snapshot-preview1" ]
+      ]
+    },
+    "hermit-abi": {
+      "0.1.19": [
+        [ "libc", "0.2.126" ]
+      ]
+    },
+    "itertools": {
+      "0.10.3": [
+        [ "either", "1.6.1" ]
+      ]
+    },
+    "js-sys": {
+      "0.3.57": [
+        [ "wasm-bindgen", "0.2.80" ]
+      ]
+    },
+    "log": {
+      "0.4.17": [
+        [ "cfg-if", "1.0.0" ]
+      ]
+    },
+    "memoffset": {
+      "0.6.5": [
+        [ "autocfg", "1.1.0" ]
+      ]
+    },
+    "num-traits": {
+      "0.2.15": [
+        [ "autocfg", "1.1.0" ],
+        [ "libm", "0.2.2" ]
+      ]
+    },
+    "num_cpus": {
+      "1.13.1": [
+        [ "hermit-abi", "0.1.19" ],
+        [ "libc", "0.2.126" ]
+      ]
+    },
+    "plotters": {
+      "0.3.1": [
+        [ "num-traits", "0.2.15" ],
+        [ "plotters-backend", "0.3.2" ],
+        [ "plotters-svg", "0.3.1" ],
+        [ "wasm-bindgen", "0.2.80" ],
+        [ "web-sys", "0.3.57" ]
+      ]
+    },
+    "plotters-svg": {
+      "0.3.1": [
+        [ "plotters-backend", "0.3.2" ]
+      ]
+    },
+    "proc-macro2": {
+      "1.0.39": [
+        [ "unicode-ident", "1.0.0" ]
+      ]
+    },
+    "quote": {
+      "1.0.18": [
+        [ "proc-macro2", "1.0.39" ]
+      ]
+    },
+    "rand": {
+      "0.8.5": [
+        [ "libc", "0.2.126" ],
+        [ "rand_chacha", "0.3.1" ],
+        [ "rand_core", "0.6.4" ]
+      ]
+    },
+    "rand_chacha": {
+      "0.3.1": [
+        [ "ppv-lite86", "0.2.16" ],
+        [ "rand_core", "0.6.4" ]
+      ]
+    },
+    "rand_core": {
+      "0.6.4": [
+        [ "getrandom", "0.2.6" ]
+      ]
+    },
+    "rand_distr": {
+      "0.4.3": [
+        [ "num-traits", "0.2.15" ],
+        [ "rand", "0.8.5" ]
+      ]
+    },
+    "rand_pcg": {
+      "0.3.1": [
+        [ "rand_core", "0.6.4" ]
+      ]
+    },
+    "rayon": {
+      "1.5.3": [
+        [ "autocfg", "1.1.0" ],
+        [ "crossbeam-deque", "0.8.1" ],
+        [ "either", "1.6.1" ],
+        [ "rayon-core", "1.9.3" ]
+      ]
+    },
+    "rayon-core": {
+      "1.9.3": [
+        [ "crossbeam-channel", "0.5.4" ],
+        [ "crossbeam-deque", "0.8.1" ],
+        [ "crossbeam-utils", "0.8.8" ],
+        [ "num_cpus", "1.13.1" ]
+      ]
+    },
+    "regex": {
+      "1.5.5": [
+        [ "regex-syntax", "0.6.25" ]
+      ]
+    },
+    "rustc_version": {
+      "0.4.0": [
+        [ "semver", "1.0.9" ]
+      ]
+    },
+    "same-file": {
+      "1.0.6": [
+        [ "winapi-util", "0.1.5" ]
+      ]
+    },
+    "serde_cbor": {
+      "0.11.2": [
+        [ "half", "1.8.2" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "serde_derive": {
+      "1.0.137": [
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "syn", "1.0.95" ]
+      ]
+    },
+    "serde_json": {
+      "1.0.81": [
+        [ "itoa", "1.0.2" ],
+        [ "ryu", "1.0.10" ],
+        [ "serde", "1.0.137" ]
+      ]
+    },
+    "syn": {
+      "1.0.95": [
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "unicode-ident", "1.0.0" ]
+      ]
+    },
+    "textwrap": {
+      "0.11.0": [
+        [ "unicode-width", "0.1.9" ]
+      ]
+    },
+    "tinytemplate": {
+      "1.2.1": [
+        [ "serde", "1.0.137" ],
+        [ "serde_json", "1.0.81" ]
+      ]
+    },
+    "walkdir": {
+      "2.3.2": [
+        [ "same-file", "1.0.6" ],
+        [ "winapi", "0.3.9" ],
+        [ "winapi-util", "0.1.5" ]
+      ]
+    },
+    "wasm-bindgen": {
+      "0.2.80": [
+        [ "cfg-if", "1.0.0" ],
+        [ "wasm-bindgen-macro", "0.2.80" ]
+      ]
+    },
+    "wasm-bindgen-backend": {
+      "0.2.80": [
+        [ "bumpalo", "3.9.1" ],
+        [ "lazy_static", "1.4.0" ],
+        [ "log", "0.4.17" ],
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "syn", "1.0.95" ],
+        [ "wasm-bindgen-shared", "0.2.80" ]
+      ]
+    },
+    "wasm-bindgen-macro": {
+      "0.2.80": [
+        [ "quote", "1.0.18" ],
+        [ "wasm-bindgen-macro-support", "0.2.80" ]
+      ]
+    },
+    "wasm-bindgen-macro-support": {
+      "0.2.80": [
+        [ "proc-macro2", "1.0.39" ],
+        [ "quote", "1.0.18" ],
+        [ "syn", "1.0.95" ],
+        [ "wasm-bindgen-backend", "0.2.80" ],
+        [ "wasm-bindgen-shared", "0.2.80" ]
+      ]
+    },
+    "web-sys": {
+      "0.3.57": [
+        [ "js-sys", "0.3.57" ],
+        [ "wasm-bindgen", "0.2.80" ]
+      ]
+    },
+    "winapi": {
+      "0.3.9": [
+        [ "winapi-i686-pc-windows-gnu", "0.4.0" ],
+        [ "winapi-x86_64-pc-windows-gnu", "0.4.0" ]
+      ]
+    },
+    "winapi-util": {
+      "0.1.5": [
+        [ "winapi", "0.3.9" ]
+      ]
+    }
+  },
+  "sources": {
+    "atty": {
+      "0.2.14": {
+        "hash": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+        "type": "crates-io"
+      }
+    },
+    "autocfg": {
+      "1.1.0": {
+        "hash": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+        "type": "crates-io"
+      }
+    },
+    "benches": {
+      "0.0.0": {
+        "path": "rand_distr/benches",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "bitflags": {
+      "1.3.2": {
+        "hash": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "type": "crates-io"
+      }
+    },
+    "bstr": {
+      "0.2.17": {
+        "hash": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
+        "type": "crates-io"
+      }
+    },
+    "bumpalo": {
+      "3.9.1": {
+        "hash": "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899",
+        "type": "crates-io"
+      }
+    },
+    "cast": {
+      "0.2.7": {
+        "hash": "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a",
+        "type": "crates-io"
+      }
+    },
+    "cfg-if": {
+      "1.0.0": {
+        "hash": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "type": "crates-io"
+      }
+    },
+    "clap": {
+      "2.34.0": {
+        "hash": "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c",
+        "type": "crates-io"
+      }
+    },
+    "criterion": {
+      "0.3.5": {
+        "hash": "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10",
+        "type": "crates-io"
+      }
+    },
+    "criterion-cycles-per-byte": {
+      "0.1.2": {
+        "hash": "8d34485a578330c7a91ccf064674f3739a7aebbf3b9d7fd498a6d3e8f7473c96",
+        "type": "crates-io"
+      }
+    },
+    "criterion-plot": {
+      "0.4.4": {
+        "hash": "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57",
+        "type": "crates-io"
+      }
+    },
+    "crossbeam-channel": {
+      "0.5.4": {
+        "hash": "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53",
+        "type": "crates-io"
+      }
+    },
+    "crossbeam-deque": {
+      "0.8.1": {
+        "hash": "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e",
+        "type": "crates-io"
+      }
+    },
+    "crossbeam-epoch": {
+      "0.9.8": {
+        "hash": "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c",
+        "type": "crates-io"
+      }
+    },
+    "crossbeam-utils": {
+      "0.8.8": {
+        "hash": "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38",
+        "type": "crates-io"
+      }
+    },
+    "csv": {
+      "1.1.6": {
+        "hash": "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1",
+        "type": "crates-io"
+      }
+    },
+    "csv-core": {
+      "0.1.10": {
+        "hash": "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90",
+        "type": "crates-io"
+      }
+    },
+    "either": {
+      "1.6.1": {
+        "hash": "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457",
+        "type": "crates-io"
+      }
+    },
+    "getrandom": {
+      "0.2.6": {
+        "hash": "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad",
+        "type": "crates-io"
+      }
+    },
+    "half": {
+      "1.8.2": {
+        "hash": "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7",
+        "type": "crates-io"
+      }
+    },
+    "hermit-abi": {
+      "0.1.19": {
+        "hash": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+        "type": "crates-io"
+      }
+    },
+    "itertools": {
+      "0.10.3": {
+        "hash": "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3",
+        "type": "crates-io"
+      }
+    },
+    "itoa": {
+      "0.4.8": {
+        "hash": "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4",
+        "type": "crates-io"
+      },
+      "1.0.2": {
+        "hash": "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d",
+        "type": "crates-io"
+      }
+    },
+    "js-sys": {
+      "0.3.57": {
+        "hash": "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397",
+        "type": "crates-io"
+      }
+    },
+    "lazy_static": {
+      "1.4.0": {
+        "hash": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        "type": "crates-io"
+      }
+    },
+    "libc": {
+      "0.2.126": {
+        "hash": "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836",
+        "type": "crates-io"
+      }
+    },
+    "libm": {
+      "0.2.2": {
+        "hash": "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db",
+        "type": "crates-io"
+      }
+    },
+    "log": {
+      "0.4.17": {
+        "hash": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+        "type": "crates-io"
+      }
+    },
+    "memchr": {
+      "2.5.0": {
+        "hash": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+        "type": "crates-io"
+      }
+    },
+    "memoffset": {
+      "0.6.5": {
+        "hash": "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce",
+        "type": "crates-io"
+      }
+    },
+    "num-traits": {
+      "0.2.15": {
+        "hash": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+        "type": "crates-io"
+      }
+    },
+    "num_cpus": {
+      "1.13.1": {
+        "hash": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1",
+        "type": "crates-io"
+      }
+    },
+    "oorandom": {
+      "11.1.3": {
+        "hash": "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575",
+        "type": "crates-io"
+      }
+    },
+    "plotters": {
+      "0.3.1": {
+        "hash": "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a",
+        "type": "crates-io"
+      }
+    },
+    "plotters-backend": {
+      "0.3.2": {
+        "hash": "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c",
+        "type": "crates-io"
+      }
+    },
+    "plotters-svg": {
+      "0.3.1": {
+        "hash": "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9",
+        "type": "crates-io"
+      }
+    },
+    "ppv-lite86": {
+      "0.2.16": {
+        "hash": "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872",
+        "type": "crates-io"
+      }
+    },
+    "proc-macro2": {
+      "1.0.39": {
+        "hash": "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f",
+        "type": "crates-io"
+      }
+    },
+    "quote": {
+      "1.0.18": {
+        "hash": "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1",
+        "type": "crates-io"
+      }
+    },
+    "rand": {
+      "0.8.5": {
+        "path": "",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rand_chacha": {
+      "0.3.1": {
+        "path": "rand_chacha",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rand_core": {
+      "0.6.4": {
+        "path": "rand_core",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rand_distr": {
+      "0.4.3": {
+        "path": "rand_distr",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rand_pcg": {
+      "0.3.1": {
+        "path": "rand_pcg",
+        "rootName": null,
+        "rootVersion": null,
+        "type": "path"
+      }
+    },
+    "rayon": {
+      "1.5.3": {
+        "hash": "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d",
+        "type": "crates-io"
+      }
+    },
+    "rayon-core": {
+      "1.9.3": {
+        "hash": "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f",
+        "type": "crates-io"
+      }
+    },
+    "regex": {
+      "1.5.5": {
+        "hash": "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286",
+        "type": "crates-io"
+      }
+    },
+    "regex-automata": {
+      "0.1.10": {
+        "hash": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
+        "type": "crates-io"
+      }
+    },
+    "regex-syntax": {
+      "0.6.25": {
+        "hash": "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b",
+        "type": "crates-io"
+      }
+    },
+    "rustc_version": {
+      "0.4.0": {
+        "hash": "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
+        "type": "crates-io"
+      }
+    },
+    "ryu": {
+      "1.0.10": {
+        "hash": "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695",
+        "type": "crates-io"
+      }
+    },
+    "same-file": {
+      "1.0.6": {
+        "hash": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        "type": "crates-io"
+      }
+    },
+    "scopeguard": {
+      "1.1.0": {
+        "hash": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+        "type": "crates-io"
+      }
+    },
+    "semver": {
+      "1.0.9": {
+        "hash": "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd",
+        "type": "crates-io"
+      }
+    },
+    "serde": {
+      "1.0.137": {
+        "hash": "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1",
+        "type": "crates-io"
+      }
+    },
+    "serde_cbor": {
+      "0.11.2": {
+        "hash": "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5",
+        "type": "crates-io"
+      }
+    },
+    "serde_derive": {
+      "1.0.137": {
+        "hash": "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be",
+        "type": "crates-io"
+      }
+    },
+    "serde_json": {
+      "1.0.81": {
+        "hash": "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c",
+        "type": "crates-io"
+      }
+    },
+    "syn": {
+      "1.0.95": {
+        "hash": "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942",
+        "type": "crates-io"
+      }
+    },
+    "textwrap": {
+      "0.11.0": {
+        "hash": "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
+        "type": "crates-io"
+      }
+    },
+    "tinytemplate": {
+      "1.2.1": {
+        "hash": "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc",
+        "type": "crates-io"
+      }
+    },
+    "unicode-ident": {
+      "1.0.0": {
+        "hash": "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee",
+        "type": "crates-io"
+      }
+    },
+    "unicode-width": {
+      "0.1.9": {
+        "hash": "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973",
+        "type": "crates-io"
+      }
+    },
+    "walkdir": {
+      "2.3.2": {
+        "hash": "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56",
+        "type": "crates-io"
+      }
+    },
+    "wasi": {
+      "0.10.2+wasi-snapshot-preview1": {
+        "hash": "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6",
+        "type": "crates-io"
+      }
+    },
+    "wasm-bindgen": {
+      "0.2.80": {
+        "hash": "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad",
+        "type": "crates-io"
+      }
+    },
+    "wasm-bindgen-backend": {
+      "0.2.80": {
+        "hash": "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4",
+        "type": "crates-io"
+      }
+    },
+    "wasm-bindgen-macro": {
+      "0.2.80": {
+        "hash": "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5",
+        "type": "crates-io"
+      }
+    },
+    "wasm-bindgen-macro-support": {
+      "0.2.80": {
+        "hash": "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b",
+        "type": "crates-io"
+      }
+    },
+    "wasm-bindgen-shared": {
+      "0.2.80": {
+        "hash": "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744",
+        "type": "crates-io"
+      }
+    },
+    "web-sys": {
+      "0.3.57": {
+        "hash": "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283",
+        "type": "crates-io"
+      }
+    },
+    "winapi": {
+      "0.3.9": {
+        "hash": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "type": "crates-io"
+      }
+    },
+    "winapi-i686-pc-windows-gnu": {
+      "0.4.0": {
+        "hash": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "type": "crates-io"
+      }
+    },
+    "winapi-util": {
+      "0.1.5": {
+        "hash": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+        "type": "crates-io"
+      }
+    },
+    "winapi-x86_64-pc-windows-gnu": {
+      "0.4.0": {
+        "hash": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "type": "crates-io"
+      }
+    }
+  }
+}

--- a/examples/no-cargo-lock-example/flake.lock
+++ b/examples/no-cargo-lock-example/flake.lock
@@ -1,0 +1,224 @@
+{
+  "nodes": {
+    "alejandra": {
+      "inputs": {
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646360966,
+        "narHash": "sha256-fJ/WHSU45bMJRDqz9yA3B2lwXtW5DKooU+Pzn13GyZI=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "511c3f6a88b6964e1496fb6f441f4ae5e58bd3ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644785799,
+        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "crane": "crane",
+        "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "gomod2nix": "gomod2nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "node2nix": "node2nix",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-kX/DiojoqxxYcxWgQ6sh4+mSCkA9jeReLmsunvSH4fg=",
+        "path": "../../.",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../.",
+        "type": "path"
+      }
+    },
+    "flake-utils-pre-commit": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627572165,
+        "narHash": "sha256-MFpwnkvQpauj799b4QTBJQFEddbD02+Ln5k92QyHOSk=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634711045,
+        "narHash": "sha256-m5A2Ty88NChLyFhXucECj6+AuiMZPHXNbw+9Kcs7F6Y=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "4433f74a97b94b596fa6cd9b9c0402104aceef5d",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645433236,
+        "narHash": "sha256-4va4MvJ076XyPp5h8sm5eMQvCrJ6yZAbBmyw95dGyw4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "node2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634916276,
+        "narHash": "sha256-lov2b/8ydYjq+MhKQugmWV2lFnq35AU5RTRBTfLq7B4=",
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "rev": "644e90c0304038a446ed53efc97e9eb1e2831e71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632969109,
+        "narHash": "sha256-jPDclkkiAy5m2gGLBlKgH+lQtbF7tL4XxBrbSzw+Ioc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.21.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "dream2nix",
+          "flake-utils-pre-commit"
+        ],
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "src": "src"
+      }
+    },
+    "src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650560038,
+        "narHash": "sha256-17mZuzkHh8ZG68MnU167+qhWcKJstoQtA2hr/GVk3tA=",
+        "owner": "rust-random",
+        "repo": "rand",
+        "rev": "f0f15b5ece4dabca62520bac936970a8b3e25d2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-random",
+        "repo": "rand",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/no-cargo-lock-example/flake.nix
+++ b/examples/no-cargo-lock-example/flake.nix
@@ -17,9 +17,14 @@
   in
     (dream2nix.makeFlakeOutputs {
       source = src;
-      settings = [{builder = "crane";}];
+      settings = [
+        {
+          builder = "crane";
+          translator = "cargo-toml";
+        }
+      ];
     })
     // {
-      #checks.x86_64-linux.rand = self.packages.x86_64-linux.rand;
+      checks.x86_64-linux.rand = self.packages.x86_64-linux.rand;
     };
 }

--- a/examples/no-cargo-lock-example/flake.nix
+++ b/examples/no-cargo-lock-example/flake.nix
@@ -1,0 +1,25 @@
+{
+  inputs = {
+    dream2nix.url = "path:../../.";
+    src.url = "github:rust-random/rand";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp: let
+    dream2nix = inp.dream2nix.lib2.init {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+    };
+  in
+    (dream2nix.makeFlakeOutputs {
+      source = src;
+      settings = [{builder = "crane";}];
+    })
+    // {
+      #checks.x86_64-linux.rand = self.packages.x86_64-linux.rand;
+    };
+}

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -49,6 +49,7 @@
         fi
         ${writeGitVendorEntries}
         ${replacePaths}
+        ${utils.writeCargoLock}
       '';
     });
 in rec {

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -23,7 +23,6 @@
     src = utils.getRootSource pname version;
     vendorDir = vendoring.vendoredDependencies;
     replacePaths = utils.replaceRelativePathsWithAbsolute {
-      inherit src;
       paths = subsystemAttrs.relPathReplacements;
     };
     writeGitVendorEntries = vendoring.writeGitVendorEntries "vendored-sources";

--- a/src/builders/rust/build-rust-package/default.nix
+++ b/src/builders/rust/build-rust-package/default.nix
@@ -22,8 +22,10 @@
   buildPackage = pname: version: let
     src = utils.getRootSource pname version;
     vendorDir = vendoring.vendoredDependencies;
-    replacePaths =
-      utils.replaceRelativePathsWithAbsolute subsystemAttrs.relPathReplacements;
+    replacePaths = utils.replaceRelativePathsWithAbsolute {
+      inherit src;
+      paths = subsystemAttrs.relPathReplacements;
+    };
     writeGitVendorEntries = vendoring.writeGitVendorEntries "vendored-sources";
 
     cargoBuildFlags = "--package ${pname}";

--- a/src/builders/rust/crane/default.nix
+++ b/src/builders/rust/crane/default.nix
@@ -36,6 +36,7 @@
     preConfigure = ''
       ${writeGitVendorEntries}
       ${replacePaths}
+      ${utils.writeCargoLock}
     '';
     # The deps-only derivation will use this as a prefix to the `pname`
     depsNameSuffix = "-deps";

--- a/src/builders/rust/crane/default.nix
+++ b/src/builders/rust/crane/default.nix
@@ -26,7 +26,6 @@
     src = utils.getRootSource pname version;
     cargoVendorDir = vendoring.vendoredDependencies;
     replacePaths = utils.replaceRelativePathsWithAbsolute {
-      inherit src;
       paths = subsystemAttrs.relPathReplacements;
     };
     writeGitVendorEntries = vendoring.writeGitVendorEntries "nix-sources";

--- a/src/builders/rust/crane/default.nix
+++ b/src/builders/rust/crane/default.nix
@@ -25,8 +25,10 @@
   buildPackage = pname: version: let
     src = utils.getRootSource pname version;
     cargoVendorDir = vendoring.vendoredDependencies;
-    replacePaths =
-      utils.replaceRelativePathsWithAbsolute subsystemAttrs.relPathReplacements;
+    replacePaths = utils.replaceRelativePathsWithAbsolute {
+      inherit src;
+      paths = subsystemAttrs.relPathReplacements;
+    };
     writeGitVendorEntries = vendoring.writeGitVendorEntries "nix-sources";
 
     postUnpack = ''

--- a/src/builders/rust/utils.nix
+++ b/src/builders/rust/utils.nix
@@ -16,17 +16,14 @@ in rec {
 
   # Generates a script that replaces relative path dependency paths with absolute
   # ones, if the path dependency isn't in the source dream2nix provides
-  replaceRelativePathsWithAbsolute = {
-    paths,
-    src,
-  }: let
+  replaceRelativePathsWithAbsolute = {paths}: let
     replacements =
       l.concatStringsSep
       " \\\n"
       (
         l.mapAttrsToList
         (
-          from: rel: "--replace '\"${from}\"' '\"${dlib.sanitizePath "${src}/${rel}"}\"'"
+          from: rel: ''--replace "\"${from}\"" "\"$TEMPDIR/$sourceRoot/${rel}\""''
         )
         paths
       );

--- a/src/builders/rust/utils.nix
+++ b/src/builders/rust/utils.nix
@@ -37,7 +37,7 @@ in rec {
   # Script to write the Cargo.lock if it doesn't already exist.
   writeCargoLock = ''
     if [ ! -f "$PWD/Cargo.lock" ]; then
-      ln -s ${cargoLock} "$PWD/Cargo.lock"
+      cp -v ${cargoLock} "$PWD/Cargo.lock"
     fi
   '';
 

--- a/src/builders/rust/utils.nix
+++ b/src/builders/rust/utils.nix
@@ -3,6 +3,7 @@
   getSource,
   getRoot,
   lib,
+  dlib,
   ...
 }: let
   l = lib // builtins;
@@ -15,13 +16,18 @@ in rec {
 
   # Generates a script that replaces relative path dependency paths with absolute
   # ones, if the path dependency isn't in the source dream2nix provides
-  replaceRelativePathsWithAbsolute = paths: let
+  replaceRelativePathsWithAbsolute = {
+    paths,
+    src,
+  }: let
     replacements =
       l.concatStringsSep
       " \\\n"
       (
         l.mapAttrsToList
-        (rel: abs: "--replace '\"${rel}\"' '\"${abs}\"'")
+        (
+          from: rel: "--replace '\"${from}\"' '\"${dlib.sanitizePath "${src}/${rel}"}\"'"
+        )
         paths
       );
   in ''

--- a/src/builders/rust/utils.nix
+++ b/src/builders/rust/utils.nix
@@ -2,8 +2,10 @@
   getSourceSpec,
   getSource,
   getRoot,
+  dreamLock,
   lib,
   dlib,
+  utils,
   ...
 }: let
   l = lib // builtins;
@@ -31,4 +33,68 @@ in rec {
     substituteInPlace ./Cargo.toml \
       ${replacements}
   '';
+
+  # Script to write the Cargo.lock if it doesn't already exist.
+  writeCargoLock = ''
+    if [ ! -f "$PWD/Cargo.lock" ]; then
+      ln -s ${cargoLock} "$PWD/Cargo.lock"
+    fi
+  '';
+
+  # The Cargo.lock for this dreamLock.
+  cargoLock = let
+    mkPkgEntry = {
+      name,
+      version,
+      dependencies,
+    }: let
+      sourceSpec = getSourceSpec name version;
+      source =
+        if sourceSpec.type == "crates-io"
+        then "registry+https://github.com/rust-lang/crates.io-index"
+        else if sourceSpec.type == "git"
+        then let
+          ref = sourceSpec.ref or null;
+          refPart =
+            if l.hasPrefix "refs/heads/" ref
+            then "branch=${l.removePrefix "refs/heads/" ref}"
+            else if l.hasPrefix "refs/tags/" ref
+            then "tag=${l.removePrefix "refs/tags/" ref}"
+            else "rev=${sourceSpec.rev}";
+        in "git+${sourceSpec.url}?${refPart}#${sourceSpec.rev}"
+        else throw "source type '${sourceSpec.type}' not supported";
+    in
+      {
+        inherit name version;
+        dependencies =
+          l.map
+          (dep: "${dep.name} ${dep.version}")
+          dependencies;
+      }
+      // (
+        l.optionalAttrs
+        (sourceSpec.type != "path")
+        {inherit source;}
+      )
+      // (
+        l.optionalAttrs
+        (sourceSpec.type == "crates-io")
+        {checksum = sourceSpec.hash;}
+      );
+    package = l.flatten (
+      l.mapAttrsToList
+      (
+        name: versions:
+          l.mapAttrsToList
+          (
+            version: dependencies:
+              mkPkgEntry {inherit name version dependencies;}
+          )
+          versions
+      )
+      dreamLock.dependencies
+    );
+    lock = {inherit package;};
+  in
+    l.toFile "Cargo.lock" (utils.toTOML lock);
 }

--- a/src/discoverers/rust/default.nix
+++ b/src/discoverers/rust/default.nix
@@ -81,7 +81,11 @@
       l.filter
       (
         project:
-          !(l.any (memberPath: project.relPath == memberPath) workspaceMembers)
+          !(
+            l.any
+            (memberPath: l.hasSuffix memberPath project.relPath)
+            workspaceMembers
+          )
       )
       subdirProjects';
   in

--- a/src/discoverers/rust/default.nix
+++ b/src/discoverers/rust/default.nix
@@ -31,7 +31,40 @@
   }: let
     cargoToml = tree.files."Cargo.toml".tomlContent;
 
-    subdirProjects =
+    hasCargoToml = tree ? files."Cargo.toml";
+    hasCargoLock = tree ? files."Cargo.lock";
+
+    # "cargo-toml" translator is always added (a Cargo.toml should always be there).
+    # "cargo-lock" translator is only available if the tree has a Cargo.lock.
+    translators =
+      (l.optional hasCargoLock "cargo-lock")
+      ++ (l.optional hasCargoToml "cargo-toml");
+
+    # get all workspace members
+    workspaceMembers =
+      l.flatten
+      (
+        l.map
+        (
+          memberName: let
+            components = l.splitString "/" memberName;
+          in
+            # Resolve globs if there are any
+            if l.last components == "*"
+            then let
+              parentDirRel = l.concatStringsSep "/" (l.init components);
+              dirs = (tree.getNodeFromPath parentDirRel).directories;
+            in
+              l.mapAttrsToList
+              (name: _: "${parentDirRel}/${name}")
+              dirs
+            else memberName
+        )
+        (l.optionals hasCargoToml (cargoToml.workspace.members or []))
+      );
+
+    # get projects in the subdirectories
+    subdirProjects' =
       l.flatten
       (l.mapAttrsToList
         (dirName: dir:
@@ -40,21 +73,27 @@
             tree = dir;
           })
         (tree.directories or {}));
+    # filter the subdir projects so we don't add a Cargo project duplicate.
+    # a duplicate can occur if a virtual Cargo manifest (a workspace)
+    # declares a member crate, but this member crate is also detected
+    # by dream2nix's discoverer as a separate project.
+    subdirProjects =
+      l.filter
+      (
+        project:
+          !(l.any (memberPath: project.relPath == memberPath) workspaceMembers)
+      )
+      subdirProjects';
   in
-    # A directory is identified as a project only if it contains a Cargo.toml
-    # and a Cargo.lock.
-    if
-      tree
-      ? files."Cargo.toml"
-      && tree ? files."Cargo.lock"
+    # a directory is identified as a project if it contains a Cargo.toml.
+    if hasCargoToml
     then
       [
         (dlib.construct.discoveredProject {
-          inherit subsystem;
+          inherit subsystem translators;
           relPath = tree.relPath;
           name = cargoToml.package.name or tree.relPath;
-          translators = ["cargo-lock"];
-          subsystemInfo = {inherit crates;};
+          subsystemInfo = {inherit crates workspaceMembers;};
         })
       ]
       ++ subdirProjects

--- a/src/translators/default.nix
+++ b/src/translators/default.nix
@@ -82,11 +82,13 @@
               (builtins.fromJSON
                   (builtins.unsafeDiscardStringContext (builtins.readFile '''$1''')));
 
-            dreamLock =
+            dreamLock' =
               dream2nix.translators.translators.${
           lib.concatStringsSep "." translatorAttrPath
         }.translate
                 translatorArgs;
+            # simpleTranslate2 puts dream-lock in result
+            dreamLock = dreamLock'.result or dreamLock';
           in
             dream2nix.utils.dreamLock.toJSON
               # don't use nix to detect cycles, this will be more efficient in python

--- a/src/translators/rust/impure/cargo-toml/default.nix
+++ b/src/translators/rust/impure/cargo-toml/default.nix
@@ -1,0 +1,64 @@
+{
+  dlib,
+  lib,
+}: {
+  # the input format is specified in /specifications/translator-call-example.json
+  # this script receives a json file including the input paths and specialArgs
+  translateBin = {
+    # dream2nix utils
+    translators,
+    utils,
+    # nixpkgs dependenies
+    coreutils,
+    jq,
+    rustPlatform,
+    ...
+  }:
+    utils.writePureShellScript
+    [
+      coreutils
+      jq
+      rustPlatform.rust.cargo
+    ]
+    ''
+      # according to the spec, the translator reads the input from a json file
+      jsonInput=$1
+
+      # read the json input
+      outputFile=$(jq '.outputFile' -c -r $jsonInput)
+      source=$(jq '.source' -c -r $jsonInput)
+      relPath=$(jq '.project.relPath' -c -r $jsonInput)
+      cargoArgs=$(jq '.project.subsystemInfo.cargoArgs' -c -r $jsonInput)
+
+      cp -r $source/* ./
+      chmod -R +w ./
+      newSource=$(pwd)
+
+      cd ./$relPath
+
+      cargo generate-lockfile $cargoArgs
+      cargoResult=$?
+
+      jq ".source = \"$newSource\"" -c -r $jsonInput > $TMPDIR/newJsonInput
+      cd $WORKDIR
+
+      if [ $cargoResult -eq 0 ]; then
+        ${translators.translators.rust.pure.cargo-lock.translateBin} $TMPDIR/newJsonInput
+      else
+        echo "cargo failed to generate the lockfile"
+        exit 1
+      fi
+    '';
+
+  # inherit options from package-lock translator
+  extraArgs = {
+    cargoArgs = {
+      description = "Additional arguments for Cargo";
+      type = "argument";
+      default = "";
+      examples = [
+        "--verbose"
+      ];
+    };
+  };
+}

--- a/src/translators/rust/impure/cargo-toml/default.nix
+++ b/src/translators/rust/impure/cargo-toml/default.nix
@@ -28,7 +28,7 @@
       outputFile=$(jq '.outputFile' -c -r $jsonInput)
       source=$(jq '.source' -c -r $jsonInput)
       relPath=$(jq '.project.relPath' -c -r $jsonInput)
-      cargoArgs=$(jq '.project.subsystemInfo.cargoArgs' -c -r $jsonInput)
+      cargoArgs=$(jq '.project.subsystemInfo.cargoArgs | select (.!=null)' -c -r $jsonInput)
 
       cp -r $source/* ./
       chmod -R +w ./

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -41,7 +41,11 @@ in {
         value = (projectTree.getNodeFromPath "${relPath}/Cargo.toml").tomlContent;
       })
       # Filter root referencing member, we already parsed this (rootToml)
-      (l.filter (relPath: relPath != ".") subsystemInfo.workspaceMembers);
+      (
+        l.filter
+        (relPath: relPath != ".")
+        (subsystemInfo.workspaceMembers or [])
+      );
 
     # All cargo packages that we will output
     cargoPackages =

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -312,7 +312,7 @@ in {
                 && (package.version == dependencyObject.version)
               then
                 dlib.construct.pathSource {
-                  path = projectSource;
+                  path = project.relPath;
                   rootName = null;
                   rootVersion = null;
                 }
@@ -326,7 +326,7 @@ in {
               else if nonWorkspaceCrate != null
               then
                 dlib.construct.pathSource {
-                  path = dlib.sanitizePath "${rootSource}/${nonWorkspaceCrate.relPath}";
+                  path = nonWorkspaceCrate.relPath;
                   rootName = null;
                   rootVersion = null;
                 }

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -23,7 +23,7 @@ in {
   } @ args: let
     # get the root source and project source
     rootSource = tree.fullPath;
-    projectSource = "${tree.fullPath}/${project.relPath}";
+    projectSource = dlib.sanitizePath "${tree.fullPath}/${project.relPath}";
     projectTree = tree.getNodeFromPath project.relPath;
     subsystemInfo = project.subsystemInfo;
 
@@ -170,7 +170,11 @@ in {
             (
               dep: {
                 name = dep.path;
-                value = dlib.sanitizePath "${projectSource}/${dep.path}";
+                value = let
+                  absPath = dlib.sanitizePath "${projectSource}/${dep.path}";
+                  relPath = l.removePrefix rootSource absPath;
+                in
+                  relPath;
               }
             )
             pathDeps

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -190,6 +190,19 @@ in {
             );
           # We only need to patch path dependencies
           pathDeps = l.filter (dep: dep ? path) tomlDeps;
+          # filter out path dependencies whose path are same as in
+          # workspace members.
+          # this is because otherwise workspace.members paths will also
+          # get replaced in the build.
+          # and there is no reason to replace these anyways
+          # since they are in the source.
+          outsideDeps =
+            l.filter
+            (
+              dep:
+                !(l.any (memberPath: dep.path == memberPath) workspaceMembers)
+            )
+            pathDeps;
         in
           l.listToAttrs (
             l.map
@@ -203,7 +216,7 @@ in {
                   relPath;
               }
             )
-            pathDeps
+            outsideDeps
           );
         gitSources = let
           gitDeps = l.filter (dep: (getSourceTypeFrom dep) == "git") parsedDeps;

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -242,7 +242,7 @@ in {
         gitSources = let
           gitDeps = l.filter (dep: (getSourceTypeFrom dep) == "git") parsedDeps;
         in
-          l.unique (l.map (dep: parseGitSource dep.source) gitDeps);
+          l.unique (l.map (dep: parseGitSource dep) gitDeps);
       };
 
       defaultPackage = package.name;
@@ -333,7 +333,7 @@ in {
               else throw "could not find crate '${dependencyObject.name}-${dependencyObject.version}'";
 
             git = dependencyObject: let
-              parsed = parseGitSource dependencyObject.source;
+              parsed = parseGitSource dependencyObject;
               maybeRef =
                 if parsed.type or null == "branch"
                 then {ref = "refs/heads/${parsed.value}";}

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -144,11 +144,11 @@ in {
     parsedGitSources = let
       makePair = dep:
         l.nameValuePair
-        dep.source
+        "${dep.name}-${dep.version}"
         (parseGitSourceImpl (dep.source or ""));
     in
       l.listToAttrs (l.map makePair parsedDeps);
-    parseGitSource = src: parsedGitSources.${src};
+    parseGitSource = dep: parsedGitSources."${dep.name}-${dep.version}";
 
     # Extracts a source type from a dependency.
     getSourceTypeFromImpl = dependencyObject: let

--- a/src/translators/rust/pure/cargo-lock/default.nix
+++ b/src/translators/rust/pure/cargo-lock/default.nix
@@ -33,27 +33,6 @@ in {
       value = projectTree.files."Cargo.toml".tomlContent;
     };
 
-    # Get all workspace members
-    workspaceMembers =
-      l.flatten
-      (l.map
-        (
-          memberName: let
-            components = l.splitString "/" memberName;
-          in
-            # Resolve globs if there are any
-            if l.last components == "*"
-            then let
-              parentDirRel = l.concatStringsSep "/" (l.init components);
-              parentDir = "${projectSource}/${parentDirRel}";
-              dirs = (projectTree.getNodeFromPath parentDirRel).directories;
-            in
-              l.mapAttrsToList
-              (name: _: "${parentDirRel}/${name}")
-              dirs
-            else memberName
-        )
-        (rootToml.value.workspace.members or []));
     # Get cargo packages (for workspace members)
     workspaceCargoPackages =
       l.map
@@ -62,7 +41,7 @@ in {
         value = (projectTree.getNodeFromPath "${relPath}/Cargo.toml").tomlContent;
       })
       # Filter root referencing member, we already parsed this (rootToml)
-      (l.filter (relPath: relPath != ".") workspaceMembers);
+      (l.filter (relPath: relPath != ".") subsystemInfo.workspaceMembers);
 
     # All cargo packages that we will output
     cargoPackages =


### PR DESCRIPTION
This implements a new impure `cargo-toml` translator that can translate Cargo projects that don't have a `Cargo.lock` file. In addition, it makes the `cargo-lock` translator not put absolute paths for fixing up path dependency paths in a `Cargo.toml`, instead relative paths are used now, because absolute paths break the generated dream-lock. Rust discoverer is also updated to support the new translator.

~~This is a draft because it doesn't seem to be able to build stuff properly (`ripgrep` doesn't build).~~ `ripgrep` builds fine now.