### PR TITLE
Path improvements

### DIFF
--- a/examples/path-example/flake.lock
+++ b/examples/path-example/flake.lock
@@ -1,0 +1,210 @@
+{
+  "nodes": {
+    "alejandra": {
+      "inputs": {
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1648332543,
+        "narHash": "sha256-9FWmFNLCOp4y0I8Yb4GvgGXxtDq3nBDSTI9qyCi2LJ4=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "5cbb3486c7959646f452830c0a223edc5db5b951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644785799,
+        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "crane": "crane",
+        "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "gomod2nix": "gomod2nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "node2nix": "node2nix",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1651844867,
+        "narHash": "sha256-a+bAmmeIudRVY23ZkEB5W5xJumBY3ydsiDIGN/56NmQ=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "e5d0e9cdb00695b0b63d1f52ff3b39c0e3035fe3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-utils-pre-commit": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627572165,
+        "narHash": "sha256-MFpwnkvQpauj799b4QTBJQFEddbD02+Ln5k92QyHOSk=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634711045,
+        "narHash": "sha256-m5A2Ty88NChLyFhXucECj6+AuiMZPHXNbw+9Kcs7F6Y=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "4433f74a97b94b596fa6cd9b9c0402104aceef5d",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645433236,
+        "narHash": "sha256-4va4MvJ076XyPp5h8sm5eMQvCrJ6yZAbBmyw95dGyw4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "node2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634916276,
+        "narHash": "sha256-lov2b/8ydYjq+MhKQugmWV2lFnq35AU5RTRBTfLq7B4=",
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "rev": "644e90c0304038a446ed53efc97e9eb1e2831e71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632969109,
+        "narHash": "sha256-jPDclkkiAy5m2gGLBlKgH+lQtbF7tL4XxBrbSzw+Ioc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.21.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "dream2nix",
+          "flake-utils-pre-commit"
+        ],
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/path-example/flake.nix
+++ b/examples/path-example/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+  } @ inp: let
+    dream2nix = inp.dream2nix.lib2.init {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+    };
+  in
+    (dream2nix.makeFlakeOutputs {
+      source = ./.;
+      settings = [
+      ];
+    })
+    // {
+      checks = self.packages;
+    };
+}

--- a/examples/path-example/package.json
+++ b/examples/path-example/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "path-test",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/examples/path-example/packages/cli/bin/cli.js
+++ b/examples/path-example/packages/cli/bin/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const { getHello } = require("lib");
+
+console.log(getHello());

--- a/examples/path-example/packages/cli/package.json
+++ b/examples/path-example/packages/cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cli",
+  "version": "1.0.0",
+  "bin": {
+    "cli": "bin/cli.js"
+  },
+  "dependencies": {
+    "lib": "^1.0.0"
+  }
+}

--- a/examples/path-example/packages/lib/package.json
+++ b/examples/path-example/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lib",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+
+  }
+}

--- a/examples/path-example/packages/lib/src/main.js
+++ b/examples/path-example/packages/lib/src/main.js
@@ -1,0 +1,3 @@
+const getHello = () => "Salve, mundus!";
+
+module.exports = { getHello };

--- a/src/discoverers/nodejs/default.nix
+++ b/src/discoverers/nodejs/default.nix
@@ -41,9 +41,9 @@
       # if the package has no dependencies we use the
       # package-lock translator with `packageLock = null`
       if
-        ! packageJson ? dependencies
-        && ! packageJson ? devDependencies
-        && ! packageJson ? workspaces
+        (packageJson.dependencies or {} == {})
+        && (packageJson.devDependencies or {} == {})
+        && (packageJson.workspaces or [] == [])
       then ["package-lock"]
       else
         l.optionals (nodes ? "package-lock.json") ["package-lock"]

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -36,6 +36,8 @@
     packageJson =
       (tree.getNodeFromPath "package.json").jsonContent;
 
+    packageVersion = packageJson.version or "unknown";
+
     packageLockDeps =
       if packageLock == null
       then {}
@@ -137,18 +139,10 @@
       # values
       inputData = pinnedRootDeps;
 
-      defaultPackage =
-        if name != "{automatic}"
-        then name
-        else
-          packageJson.name
-          or (throw (
-            "Could not identify package name. "
-            + "Please specify extra argument 'name'"
-          ));
+      defaultPackage = project.name;
 
       packages =
-        {"${defaultPackage}" = packageJson.version or "unknown";}
+        {"${defaultPackage}" = packageVersion;}
         // (nodejsUtils.getWorkspacePackages tree workspaces);
 
       mainPackageDependencies =
@@ -229,9 +223,12 @@
             hash = dependencyObject.integrity;
           };
 
-        path = dependencyObject: rec {
-          path = getPath dependencyObject;
-        };
+        path = dependencyObject:
+          dlib.construct.pathSource {
+            path = getPath dependencyObject;
+            rootName = project.name;
+            rootVersion = packageVersion;
+          };
       };
 
       getDependencies = dependencyObject:

--- a/src/translators/nodejs/pure/yarn-lock/default.nix
+++ b/src/translators/nodejs/pure/yarn-lock/default.nix
@@ -39,6 +39,8 @@
     packageJson =
       (tree.getNodeFromPath "package.json").jsonContent;
 
+    packageVersion = packageJson.version or "unknown";
+
     packageJsonDeps = nodejsUtils.getPackageJsonDeps packageJson noDev;
 
     workspacesPackageJson = nodejsUtils.getWorkspacePackageJson tree workspaces;
@@ -73,7 +75,7 @@
           type = "path";
           path = workspace;
           rootName = defaultPackage;
-          rootVersion = packageJson.version or "unknown";
+          rootVersion = packageVersion;
         };
       };
 
@@ -124,7 +126,7 @@
       location = relPath;
 
       exportedPackages =
-        {"${defaultPackage}" = packageJson.version or "unknown";}
+        {"${defaultPackage}" = packageVersion;}
         // exportedWorkspacePackages;
 
       subsystemName = "nodejs";
@@ -243,15 +245,21 @@
             else if type == "path"
             then
               if lib.hasInfix "@link:" rawObj.yarnName
-              then {
-                path =
-                  lib.last (lib.splitString "@link:" rawObj.yarnName);
-              }
+              then
+                dlib.contruct.pathSource {
+                  path =
+                    lib.last (lib.splitString "@link:" rawObj.yarnName);
+                  rootName = project.name;
+                  rootVersion = packageVersion;
+                }
               else if lib.hasInfix "@file:" rawObj.yarnName
-              then {
-                path =
-                  lib.last (lib.splitString "@file:" rawObj.yarnName);
-              }
+              then
+                dlib.contruct.pathSource {
+                  path =
+                    lib.last (lib.splitString "@file:" rawObj.yarnName);
+                  rootName = project.name;
+                  rootVersion = packageVersion;
+                }
               else throw "unknown path format ${b.toJSON rawObj}"
             else # type == "http"
               {
@@ -296,7 +304,7 @@
       in [
         {
           name = defaultPackage;
-          version = packageJson.version or "unknown";
+          version = packageVersion;
           dependencies = defaultPackageDependencies ++ workspaceDependencies;
         }
       ];

--- a/tests/examples/default.nix
+++ b/tests/examples/default.nix
@@ -38,7 +38,7 @@ in
         tmp=\$(mktemp -d)
         echo \"tempdir: \$tmp\"
         mkdir \$tmp
-        cp ${examples}/$dir/* \$tmp/
+        cp -r ${examples}/$dir/* \$tmp/
         chmod -R +w \$tmp
         cd \$tmp
         nix flake lock --override-input dream2nix ${../../.}


### PR DESCRIPTION
Alternative fix to https://github.com/nix-community/dream2nix/pull/143

The problem here was that we changed the path source some time ago to expect a `rootName` and `rootVersion`. The package-lock and yarn-lock translators simply didn't set these values, which is fixed by this PR

@jaen @yusdacra 