### PR TITLE
feat: implement makeOutputs that outputs `system`less structure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ Extensive Example `flake.nix`:
 }
 ```
 
+Initializing a dream2nix from a nixpkgs set:
+```nix
+let
+  system = "x86_64-linux";
+  # in this case, 'nixpkgs' is a nixpkgs flake
+  pkgs = nixpkgs.legacyPackages.${system};
+  # 'dream2nix' is a dream2nix flake
+  d2n = dream2nix.lib.init {inherit pkgs;};
+in
+  d2n.realizeProjects {
+    source = ./.;
+    # all other arguments used in above examples
+    # can also be used here (overrides, inject, settings)
+  }
+```
+
 ### Watch the presentation
 (The code examples of the presentation are outdated)
 [![dream2nix - A generic framework for 2nix tools](https://gist.githubusercontent.com/DavHau/755fed3774e89c0b9b8953a0a25309fa/raw/3c8b2c56f5fca3bf5c343ffc179136eef39d4d6a/dream2nix-youtube-talk.png)](https://www.youtube.com/watch?v=jqCfHMvCsfQ)

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The intention is to integrate many existing 2nix converters into this framework,
 (Currently only nodejs and rust packaging is supported)
 
 1. Make sure you use a nix version >= 2.4 and have `experimental-features = "nix-command flakes"` set.
-2. Navigate to to the project intended to be packaged and initialize a dream2nix flake:
+1. Navigate to to the project intended to be packaged and initialize a dream2nix flake:
     ```command
       cd ./my-project
       nix flake init -t github:nix-community/dream2nix#simple
     ```
-3. List the packages that can be built
+1. List the packages that can be built
     ```command
       nix flake show
     ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Extensive Example `flake.nix`:
         (system: nixpkgs.legacyPackages.${system})
         ["x86_64-linux"];
 
+      # shorthand function to create a dream2nix instance from
+      # some pkgs set.
+      #
+      # the 'init' function takes a 'pkgs' and a 'config' and
+      # outputs a dream2nix instance.
       initD2N = pkgs: dream2nix.lib.init {
         inherit pkgs;
         config.projectRoot = ./.;

--- a/examples/d2n-extended-new-subsystem/flake.nix
+++ b/examples/d2n-extended-new-subsystem/flake.nix
@@ -6,14 +6,11 @@
   outputs = {
     self,
     dream2nix,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       config.extra = ./extra.nix;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = ./.;
       settings = [
         {

--- a/examples/d2n-extended/flake.nix
+++ b/examples/d2n-extended/flake.nix
@@ -9,8 +9,8 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       config.extra = {
@@ -21,9 +21,6 @@
         };
         fetchers.crates-io = "${inp.dream2nix}/src/fetchers/crates-io";
       };
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
       settings = [
         {

--- a/examples/d2n-init-pkgs/flake.lock
+++ b/examples/d2n-init-pkgs/flake.lock
@@ -1,0 +1,229 @@
+{
+  "nodes": {
+    "alejandra": {
+      "inputs": {
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1652972885,
+        "narHash": "sha256-OKTV5Mi0WyDGsF6GcTwWkgJPNRkskD5yqCZZmghZYHI=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "69d2075e432c562099965829d8bc4da701b10d20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644785799,
+        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "crane": "crane",
+        "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "gomod2nix": "gomod2nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "node2nix": "node2nix",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-cMxGUD65rheZKUfWX0DDgFUqkKXvSS1syweUtmn3peM=",
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      }
+    },
+    "flake-utils-pre-commit": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627572165,
+        "narHash": "sha256-MFpwnkvQpauj799b4QTBJQFEddbD02+Ln5k92QyHOSk=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634711045,
+        "narHash": "sha256-m5A2Ty88NChLyFhXucECj6+AuiMZPHXNbw+9Kcs7F6Y=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "4433f74a97b94b596fa6cd9b9c0402104aceef5d",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "node2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634916276,
+        "narHash": "sha256-lov2b/8ydYjq+MhKQugmWV2lFnq35AU5RTRBTfLq7B4=",
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "rev": "644e90c0304038a446ed53efc97e9eb1e2831e71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632969109,
+        "narHash": "sha256-jPDclkkiAy5m2gGLBlKgH+lQtbF7tL4XxBrbSzw+Ioc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.21.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "dream2nix",
+          "flake-utils-pre-commit"
+        ],
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "nixpkgs": "nixpkgs",
+        "src": "src"
+      }
+    },
+    "src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1623499944,
+        "narHash": "sha256-udEh+Re2PeO3DnX4fQThsaT1Y3MBHFfrX5Q5EN2XrF0=",
+        "owner": "BurntSushi",
+        "repo": "ripgrep",
+        "rev": "af6b6c543b224d348a8876f0c06245d9ea7929c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BurntSushi",
+        "ref": "13.0.0",
+        "repo": "ripgrep",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/d2n-init-pkgs/flake.nix
+++ b/examples/d2n-init-pkgs/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    dream2nix.url = "path:../..";
+    dream2nix.inputs.nixpkgs.follows = "nixpkgs";
+    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.flake = false;
+  };
+
+  outputs = inp: let
+    l = inp.nixpkgs.lib // builtins;
+
+    systems = ["x86_64-linux" "aarch64-linux"];
+
+    makeOutputsForSystem = system: let
+      pkgs = inp.nixpkgs.legacyPackages.${system};
+      d2n = inp.dream2nix.lib.init {
+        inherit pkgs;
+        config.projectRoot = ./.;
+      };
+      projectOutputs = d2n.makeOutputs {
+        source = inp.src;
+        settings = [
+          {
+            builder = "build-rust-package";
+            translator = "cargo-lock";
+          }
+        ];
+      };
+    in rec {
+      packages.${system} = projectOutputs.packages;
+      checks.${system} = {
+        inherit (projectOutputs.packages) ripgrep;
+      };
+    };
+    outputsForSystems = l.map makeOutputsForSystem systems;
+    outputs = l.foldl' l.recursiveUpdate {} outputsForSystems;
+  in
+    outputs;
+}

--- a/examples/eslint-aggreagted/flake.nix
+++ b/examples/eslint-aggreagted/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
       settings = [
         {

--- a/examples/eslint/flake.nix
+++ b/examples/eslint/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
       settings = [
         {

--- a/examples/mattermost-webapp/flake.nix
+++ b/examples/mattermost-webapp/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
     })
     // {

--- a/examples/no-cargo-lock-example/flake.nix
+++ b/examples/no-cargo-lock-example/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
       settings = [
         {

--- a/examples/path-example/flake.nix
+++ b/examples/path-example/flake.nix
@@ -6,13 +6,10 @@
   outputs = {
     self,
     dream2nix,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = ./.;
       settings = [
       ];

--- a/examples/prettier/flake.nix
+++ b/examples/prettier/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
     })
     // {

--- a/examples/ripgrep/flake.nix
+++ b/examples/ripgrep/flake.nix
@@ -9,13 +9,10 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    dream2nix = inp.dream2nix.lib2.init {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
-    };
-  in
-    (dream2nix.makeFlakeOutputs {
       source = src;
       settings = [
         {

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -81,7 +81,7 @@
   } @ args: let
     allPkgs = makeNixpkgs pkgs systems;
 
-    config = loadConfig config' (args.config or {});
+    config = loadConfig (args.config or {});
     dlib = import ./lib {inherit lib config;};
 
     initD2N = initDream2nix config;

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -81,13 +81,7 @@
   } @ args: let
     allPkgs = makeNixpkgs pkgs systems;
 
-    config' = args.config or {};
-    config = loadConfig (
-      config'
-      // l.optionalAttrs
-      (! config' ? projectRoot)
-      {projectRoot = source;}
-    );
+    config = loadConfig config' (args.config or {});
     dlib = import ./lib {inherit lib config;};
 
     initD2N = initDream2nix config;

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -69,26 +69,29 @@
     forAllSystems = f: lib.mapAttrs f allPkgs;
 
     dream2nixFor = forAllSystems (dream2nixForSystem config);
-  in {
-    riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
+  in
+    if pkgs != null
+    then dream2nixFor."${makePkgsKey pkgs}"
+    else {
+      riseAndShine = throw "Use makeFlakeOutputs instead of riseAndShine.";
 
-    makeFlakeOutputs = mArgs:
-      makeFlakeOutputsFunc
-      (
-        {inherit config pkgs systems;}
-        // mArgs
-      );
+      makeFlakeOutputs = mArgs:
+        makeFlakeOutputsFunc
+        (
+          {inherit config pkgs systems;}
+          // mArgs
+        );
 
-    apps =
-      forAllSystems
-      (system: pkgs:
-        dream2nixFor."${system}".apps.flakeApps);
+      apps =
+        forAllSystems
+        (system: pkgs:
+          dream2nixFor."${system}".apps.flakeApps);
 
-    defaultApp =
-      forAllSystems
-      (system: pkgs:
-        dream2nixFor."${system}".apps.flakeApps.dream2nix);
-  };
+      defaultApp =
+        forAllSystems
+        (system: pkgs:
+          dream2nixFor."${system}".apps.flakeApps.dream2nix);
+    };
 
   makeFlakeOutputsFunc = {
     config ? {},

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -57,7 +57,7 @@
 
   flakifyBuilderOutputs = system: outputs:
     l.mapAttrs
-    (ouputType: outputValue: {"${system}" = outputValue;})
+    (_: outputValue: {"${system}" = outputValue;})
     outputs;
 
   init = {
@@ -81,7 +81,13 @@
   } @ args: let
     allPkgs = makeNixpkgs pkgs systems;
 
-    config = loadConfig (args.config or {});
+    config' = args.config or {};
+    config = loadConfig (
+      config'
+      // l.optionalAttrs
+      (! config' ? projectRoot)
+      {projectRoot = source;}
+    );
     dlib = import ./lib {inherit lib config;};
 
     initD2N = initDream2nix config;

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -168,9 +168,15 @@ in
     satisfiesSemver = poetry2nixSemver.satisfiesSemver;
 
     makeTranslateScript = {
-      invalidationHash,
       source,
       project,
+      invalidationHash ?
+        dlib.calcInvalidationHash {
+          inherit project source;
+          # TODO: translatorArgs
+          translatorArgs = {};
+          translator = project.translator;
+        },
     } @ args: let
       aggregate = project.aggregate or false;
 

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -1,16 +1,9 @@
 {
   inputs.dream2nix.url = "github:nix-community/dream2nix";
-  outputs = {
-    self,
-    dream2nix,
-  } @ inputs: let
-    dream2nix = inputs.dream2nix.lib.init {
+  outputs = inp:
+    inp.dream2nix.lib.makeFlakeOutputs {
       # modify according to your supported systems
       systems = ["x86_64-linux"];
-      config.projectRoot = ./.;
-    };
-  in
-    dream2nix.makeFlakeOutputs {
       source = ./.;
     };
 }

--- a/tests/examples/default.nix
+++ b/tests/examples/default.nix
@@ -29,7 +29,7 @@
       cp -r ${examples}/$dir/* .
       chmod -R +w .
       nix flake lock --override-input dream2nix ${../../.}
-      nix run .#resolveImpure
+      nix run .#resolveImpure || echo "no resolveImpure probably?"
       nix flake check "$@"
     '';
 in


### PR DESCRIPTION
This implements a `makeDream2nix` function for creating a dream2nix instance with `externalSources` and `externalPaths` already provided. This is useful because otherwise you have to create these yourself, and since this is a flake lib function it's more convenient than `import`ing the `src/default.nix` (`dream2nix.lib.makeDream2nix {inherit pkgs;}` as opposed to `import "${dream2nix}/src" {inherit pkgs;}`). It is also useful for users of dream2nix that don't want dream2nix to "take over" the flake outputs, but still want to take advantage of the flake.