### PR TITLE
fix: expose all builder outputs

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -556,20 +556,9 @@
           (outputs.packages or {});
       };
 
-    projectOutputs =
-      l.map
-      (proj: outputsForProject proj)
-      translatedProjects;
+    projectOutputs = l.map outputsForProject translatedProjects;
 
-    mergedOutputs =
-      l.foldl'
-      (all: outputs:
-        all
-        // {
-          packages = all.packages or {} // outputs.packages;
-        })
-      {}
-      projectOutputs;
+    mergedOutputs = l.foldl' l.recursiveUpdate {} projectOutputs;
   in
     mergedOutputs;
 in {

--- a/src/default.nix
+++ b/src/default.nix
@@ -558,7 +558,14 @@
 
     projectOutputs = l.map outputsForProject translatedProjects;
 
-    mergedOutputs = l.foldl' l.recursiveUpdate {} projectOutputs;
+    mergedOutputs = let
+      isNotDrvAttrs = val:
+        l.isAttrs val && (val.type or "") != "derivation";
+      recursiveUpdateUntilDrv =
+        l.recursiveUpdateUntil
+        (_: l: r: !(isNotDrvAttrs l && isNotDrvAttrs r));
+    in
+      l.foldl' recursiveUpdateUntilDrv {} projectOutputs;
   in
     mergedOutputs;
 in {


### PR DESCRIPTION
This makes a change to expose all builder outputs in `realizeProjects`.