### PR TITLE
Simpler discover

### DIFF
--- a/src/lib/default.nix
+++ b/src/lib/default.nix
@@ -228,7 +228,17 @@
 
   # call a function using arguments defined by the env var FUNC_ARGS
   callViaEnv = func: let
-    funcArgs = l.fromJSON (l.readFile (l.getEnv "FUNC_ARGS"));
+    funcArgs' = l.fromJSON (l.readFile (l.getEnv "FUNC_ARGS"));
+    # re-create string contexts for store paths
+    funcArgs =
+      l.mapAttrsRecursive
+      (path: val:
+        if
+          l.isString val
+          && l.hasPrefix "/nix/store/" val
+        then l.path {path = val;}
+        else val)
+      funcArgs';
   in
     callWithAttrArgs func funcArgs;
 

--- a/src/templates/builders/default.nix
+++ b/src/templates/builders/default.nix
@@ -1,75 +1,81 @@
-{
-  lib,
-  pkgs,
-  stdenv,
-  # dream2nix inputs
-  externals,
-  utils,
-  ...
-}: {
-  ### FUNCTIONS
-  # AttrSet -> Bool) -> AttrSet -> [x]
-  getCyclicDependencies, # name: version: -> [ {name=; version=; } ]
-  getDependencies, # name: version: -> [ {name=; version=; } ]
-  getSource, # name: version: -> store-path
-  # to get information about the original source spec
-  getSourceSpec, # name: version: -> {type="git"; url=""; hash="";}
-  ### ATTRIBUTES
-  subsystemAttrs, # attrset
-  defaultPackageName, # string
-  defaultPackageVersion, # string
-  # all exported (top-level) package names and versions
-  # attrset of pname -> version,
-  packages,
-  # all existing package names and versions
-  # attrset of pname -> versions,
-  # where versions is a list of version strings
-  packageVersions,
-  # function which applies overrides to a package
-  # It must be applied by the builder to each individual derivation
-  # Example:
-  #   produceDerivation name (mkDerivation {...})
-  produceDerivation,
-  ...
-} @ args: let
-  b = builtins;
+{...}: {
+  type = "pure";
 
-  # the main package
-  defaultPackage = allPackages."${defaultPackageName}"."${defaultPackageVersion}";
+  build = {
+    lib,
+    pkgs,
+    stdenv,
+    # dream2nix inputs
+    externals,
+    utils,
+    ...
+  }: {
+    ### FUNCTIONS
+    # AttrSet -> Bool) -> AttrSet -> [x]
+    getCyclicDependencies, # name: version: -> [ {name=; version=; } ]
+    getDependencies, # name: version: -> [ {name=; version=; } ]
+    getSource, # name: version: -> store-path
+    # to get information about the original source spec
+    getSourceSpec, # name: version: -> {type="git"; url=""; hash="";}
+    ### ATTRIBUTES
+    subsystemAttrs, # attrset
+    defaultPackageName, # string
+    defaultPackageVersion, # string
+    # all exported (top-level) package names and versions
+    # attrset of pname -> version,
+    packages,
+    # all existing package names and versions
+    # attrset of pname -> versions,
+    # where versions is a list of version strings
+    packageVersions,
+    # function which applies overrides to a package
+    # It must be applied by the builder to each individual derivation
+    # Example:
+    #   produceDerivation name (mkDerivation {...})
+    produceDerivation,
+    ...
+  } @ args: let
+    b = builtins;
 
-  # packages to export
-  packages =
-    lib.mapAttrs
-    (name: version: allPackages.${name}.${version})
-    packages;
+    # the main package
+    defaultPackage = allPackages."${defaultPackageName}"."${defaultPackageVersion}";
 
-  # manage packages in attrset to prevent duplicated evaluation
-  allPackages =
-    lib.mapAttrs
-    (name: versions:
-      lib.genAttrs
-      versions
-      (version: makeOnePackage name version))
-    packageVersions;
+    # packages to export
+    packages =
+      lib.mapAttrs
+      (name: version: {
+        "${version}" = allPackages.${name}.${version};
+      })
+      args.packages;
 
-  # Generates a derivation for a specific package name + version
-  makeOnePackage = name: version: let
-    pkg = stdenv.mkDerivation rec {
-      pname = utils.sanitizeDerivationName name;
-      inherit version;
+    # manage packages in attrset to prevent duplicated evaluation
+    allPackages =
+      lib.mapAttrs
+      (name: versions:
+        lib.genAttrs
+        versions
+        (version: makeOnePackage name version))
+      packageVersions;
 
-      src = getSource name version;
+    # Generates a derivation for a specific package name + version
+    makeOnePackage = name: version: let
+      pkg = stdenv.mkDerivation rec {
+        pname = utils.sanitizeDerivationName name;
+        inherit version;
 
-      buildInputs =
-        map
-        (dep: allPackages."${dep.name}"."${dep.version}")
-        (getDependencies name version);
+        src = getSource name version;
 
-      # TODO: Implement build phases
-    };
-  in
-    # apply packageOverrides to current derivation
-    produceDerivation name pkg;
-in {
-  inherit defaultPackage packages;
+        buildInputs =
+          map
+          (dep: allPackages."${dep.name}"."${dep.version}")
+          (getDependencies name version);
+
+        # TODO: Implement build phases
+      };
+    in
+      # apply packageOverrides to current derivation
+      produceDerivation name pkg;
+  in {
+    inherit defaultPackage packages;
+  };
 }

--- a/src/templates/translators/impure.nix
+++ b/src/templates/translators/impure.nix
@@ -6,6 +6,27 @@
 
   type = "impure";
 
+  /*
+    Allow dream2nix to detect if a given directory contains a project
+    which can be translated with this translator.
+    Usually this can be done by checking for the existence of specific
+    file names or file endings.
+
+    Alternatively a fully featured discoverer can be implemented under
+    `src/subsystems/{subsystem}/discoverers`.
+    This is recommended if more complex project structures need to be
+    discovered like, for example, workspace projects spanning over multiple
+    sub-directories
+
+    If a fully featured discoverer exists, do not define `discoverProject`.
+  */
+  discoverProject = tree:
+    # Example
+    # Returns true if given directory contains a file ending with .cabal
+    l.any
+    (filename: l.hasSuffix ".cabal" filename)
+    (l.attrNames tree.files);
+
   # A derivation which outputs a single executable at `$out`.
   # The executable will be called by dream2nix for translation
   # The input format is specified in /specifications/translator-call-example.json.

--- a/src/templates/translators/pure.nix
+++ b/src/templates/translators/pure.nix
@@ -25,6 +25,27 @@ in
     })
   ];
 
+  /*
+    Allow dream2nix to detect if a given directory contains a project
+    which can be translated with this translator.
+    Usually this can be done by checking for the existence of specific
+    file names or file endings.
+
+    Alternatively a fully featured discoverer can be implemented under
+    `src/subsystems/{subsystem}/discoverers`.
+    This is recommended if more complex project structures need to be
+    discovered like, for example, workspace projects spanning over multiple
+    sub-directories
+
+    If a fully featured discoverer exists, do not define `discoverProject`.
+  */
+  discoverProject = tree:
+    # Example
+    # Returns true if given directory contains a file ending with .cabal
+    l.any
+    (filename: l.hasSuffix ".cabal" filename)
+    (l.attrNames tree.files);
+
   # translate from a given source and a project specification to a dream-lock.
   translate =
     {


### PR DESCRIPTION
This aims to reduce the complexity of adding support for new ecosystems to dream2nix.

Now`discoverProject` can be defined in a translator, which allows to detect projects for that translator with a simple 3-liner.
This should be the default, and only later if complexity is required a fully featured discoverer needs to be implemented.

This is achieved by generating a `defaultDiscoverer` in `./src/lib/discoverers.nix` which iterates over all the existing `discoverProject` definitions of all translators and traverses the source tree calling these functions on each directory.

Other fixes:
`dlib.callViaEnv` now re-creates contexts for store path passed via the JSON. This is important for the python-ffi. Before this, IFD based translators could not be unit tested because the string context got lost when called by python.