### PR TITLE
refactor: use new flake output schema for default package and devshells

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -279,6 +279,7 @@
     # Makes the packages tree compatible with flakes schema.
     # For each package the attr `{pname}` will link to the latest release.
     # Other package versions will be inside: `{pname}.versions`
+    # Adds a `default` package by using `defaultPackageName` and `defaultPackageVersion`.
     formattedOutputs =
       outputs
       // {
@@ -297,8 +298,13 @@
                   versions = releases;
                 })))
             allPackages;
+
+          defaultPackage =
+            allPackages
+            ."${dreamLockInterface.defaultPackageName}"
+            ."${dreamLockInterface.defaultPackageVersion}";
         in
-          latestPackages;
+          latestPackages // {default = defaultPackage;};
       };
   in
     formattedOutputs;

--- a/src/subsystems/nodejs/builders/granular/default.nix
+++ b/src/subsystems/nodejs/builders/granular/default.nix
@@ -1,4 +1,6 @@
-let
+{...}: {
+  type = "pure";
+
   build = {
     jq,
     lib,
@@ -54,8 +56,6 @@ let
       mv node-* $out
     '';
 
-    defaultPackage = allPackages."${defaultPackageName}"."${defaultPackageVersion}";
-
     allPackages =
       lib.mapAttrs
       (name: versions:
@@ -66,8 +66,6 @@ let
       packageVersions;
 
     outputs = {
-      inherit defaultPackage;
-
       # select only the packages listed in dreamLock as main packages
       packages =
         b.foldl'
@@ -453,8 +451,4 @@ let
       pkg;
   in
     outputs;
-in
-  {...}: {
-    type = "pure";
-    inherit build;
-  }
+}

--- a/src/subsystems/nodejs/builders/node2nix/default.nix
+++ b/src/subsystems/nodejs/builders/node2nix/default.nix
@@ -1,4 +1,6 @@
-let
+{...}: {
+  type = "pure";
+
   build =
     # builder imported from node2nix
     {
@@ -75,18 +77,21 @@ let
             src = getSource defaultPackageName defaultPackageVersion;
           }
           // args);
-    in rec {
-      packages."${defaultPackageName}"."${defaultPackageVersion}" = defaultPackage;
 
-      defaultPackage = let
-        pkg = callNode2Nix "buildNodePackage" {};
-      in
-        utils.applyOverridesToPackage packageOverrides pkg defaultPackageName;
-
-      devShell = callNode2Nix "buildNodeShell" {};
+      devShells = {
+        "${defaultPackageName}" = callNode2Nix "buildNodeShell" {};
+      };
+    in {
+      packages = {
+        "${defaultPackageName}"."${defaultPackageVersion}" = let
+          pkg = callNode2Nix "buildNodePackage" {};
+        in
+          utils.applyOverridesToPackage packageOverrides pkg defaultPackageName;
+      };
+      devShells =
+        devShells
+        // {
+          default = devShells."${defaultPackageName}";
+        };
     };
-in
-  {...}: {
-    type = "pure";
-    inherit build;
-  }
+}

--- a/src/subsystems/python/builders/simple-builder/default.nix
+++ b/src/subsystems/python/builders/simple-builder/default.nix
@@ -1,5 +1,7 @@
 # A very simple single derivation python builder
-let
+{...}: {
+  type = "pure";
+
   build = {
     lib,
     pkgs,
@@ -75,8 +77,4 @@ let
   in {
     packages.${defaultPackageName}.${defaultPackageVersion} = package;
   };
-in
-  {...}: {
-    type = "pure";
-    inherit build;
-  }
+}

--- a/src/subsystems/rust/builders/build-rust-package/default.nix
+++ b/src/subsystems/rust/builders/build-rust-package/default.nix
@@ -1,4 +1,6 @@
-let
+{...}: {
+  type = "pure";
+
   build = {
     lib,
     pkgs,
@@ -53,16 +55,10 @@ let
           ${utils.writeCargoLock}
         '';
       });
-  in rec {
+  in {
     packages =
       l.mapAttrs
       (name: version: {"${version}" = buildPackage name version;})
       args.packages;
-
-    defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
   };
-in
-  {...}: {
-    type = "pure";
-    inherit build;
-  }
+}

--- a/src/subsystems/rust/builders/crane/default.nix
+++ b/src/subsystems/rust/builders/crane/default.nix
@@ -1,4 +1,5 @@
-let
+{...}: {
+  type = "ifd";
   build = {
     lib,
     pkgs,
@@ -65,16 +66,10 @@ let
         };
     in
       produceDerivation pname (crane.buildPackage buildArgs);
-  in rec {
+  in {
     packages =
       l.mapAttrs
       (name: version: {"${version}" = buildPackage name version;})
       args.packages;
-
-    defaultPackage = packages."${defaultPackageName}"."${defaultPackageVersion}";
   };
-in
-  {...}: {
-    type = "ifd";
-    inherit build;
-  }
+}


### PR DESCRIPTION
Changes builder outputs so that they fit the new flake outputs schema (nix 2.7+). Current nixos stable nix version is 2.8, so this should be an OK change.