### PR TITLE
chore: use numtide devshell instead of nixpkgs mkShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,6 +37,22 @@
         "type": "github"
       }
     },
+    "devshell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653917170,
+        "narHash": "sha256-FyxOnEE/V4PNEcMU62ikY4FfYPo349MOhMM97HS0XEo=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "fc7a3e3adde9bbcab68af6d1e3c6eb738e296a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-utils-pre-commit": {
       "locked": {
         "lastModified": 1644229661,
@@ -174,6 +190,7 @@
       "inputs": {
         "alejandra": "alejandra",
         "crane": "crane",
+        "devshell": "devshell",
         "flake-utils-pre-commit": "flake-utils-pre-commit",
         "gomod2nix": "gomod2nix",
         "mach-nix": "mach-nix",


### PR DESCRIPTION
Changes the devshell dream2nix uses from nixpkgs' mkShell to numtide's devshell. Reduces the amount of env vars exported by a lot and we can add commands and make them visible more easily, so it may be helpful in the future potentially.

Also changes from using `devShell` output to `devShells`, according to the new flake outputs since 2.7+.