### PR TITLE
feat: implement overrideRustToolchain for crane and build-rust-package

### DIFF
--- a/docs/src/subsystems/rust.md
+++ b/docs/src/subsystems/rust.md
@@ -106,3 +106,23 @@ takes `cargo` packages like so:
 
 where `cargoHostTarget` has the same meaning as coming from a `pkgsHostTarget`
 and `cargoBuildBuild` has the same meaning as coming from a `pkgsBuildBuild`.
+
+Also keep in mind that if you want to override the toolchain for a package
+and you are using the `crane` builder, you would need to set an override
+for both the dependencies and the main package derivation:
+
+```nix
+let
+  toolchainOverride = old: { /* ... */ };
+in
+{
+  # ...
+  packageOverrides = {
+    # ...
+    crate-name.set-toolchain.overrideRustToolchain = toolchainOverride;
+    crate-name-deps.set-toolchain.overrideRustToolchain = toolchainOverride;
+    # ...
+  };
+  # ...
+}
+```

--- a/docs/src/subsystems/rust.md
+++ b/docs/src/subsystems/rust.md
@@ -16,7 +16,7 @@ generated lockfile.
 
 ## Builders
 
-### build-rust-package (pure)
+### build-rust-package (pure) (default)
 
 Builds a package using `buildRustPackage` from `nixpkgs`.
 
@@ -43,3 +43,66 @@ where `<crate-name>` is the name of the crate you are building.
   # ...
 }
 ```
+
+#### On the IFD marking
+
+The `crane` builder utilizes IFD to clean the source your crates reside in.
+This is needed to not rebuild the dependency only derivation everytime the
+source for your crates is changed.
+
+However this does not mean that the IFD will always be triggered. If you
+are passing dream2nix a path source or a flake source, then IFD won't be
+triggered as these sources are already realized. But if you are passing
+the result of a `pkgs.fetchFromGitHub` for example, this will trigger IFD
+since it is not already realized.
+
+### Specifying the Rust toolchain
+
+Specify an override for all packages that override the Rust toolchain used.
+This can be done like so:
+
+```nix
+{
+  # ...
+  packageOverrides = {
+    # ...
+    "^.*".set-toolchain.overrideRustToolchain = old: {
+      inherit (pkgs) cargo rustc;
+    };
+    # ...
+  };
+  # ...
+}
+```
+
+You can also of course override the toolchain for only certain crates:
+
+```nix
+{
+  # ...
+  packageOverrides = {
+    # ...
+    crate-name.set-toolchain.overrideRustToolchain = old: {
+      inherit (pkgs) cargo rustc;
+    };
+    # ...
+  };
+  # ...
+}
+```
+
+#### crane notes
+
+The crane builder does not require a `rustc` package in the toolchain specified,
+only a `cargo` package is needed. If cross-compiling, keep in mind that it also
+takes `cargo` packages like so:
+
+```nix
+{
+  cargoHostTarget = cargo-package;
+  cargoBuildBuild = other-cargo-package;
+}
+```
+
+where `cargoHostTarget` has the same meaning as coming from a `pkgsHostTarget`
+and `cargoBuildBuild` has the same meaning as coming from a `pkgsBuildBuild`.

--- a/examples/set-rust-toolchain/flake.nix
+++ b/examples/set-rust-toolchain/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      source = src;
+      settings = [
+        {
+          builder = "crane";
+          translator = "cargo-lock";
+        }
+      ];
+      packageOverrides = {
+        # override all packages and set a toolchain
+        # here we don't actually change the toolchain as this is just an example
+        "^.*".set-toolchain.overrideRustToolchain = old: {
+          cargo = builtins.trace "using custom toolchain!" old.cargo;
+        };
+      };
+    })
+    // {
+      checks.x86_64-linux.ripgrep = self.packages.x86_64-linux.ripgrep;
+    };
+}

--- a/examples/set-rust-toolchain/flake.nix
+++ b/examples/set-rust-toolchain/flake.nix
@@ -1,9 +1,9 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    fenix.url = "github:nix-community/fenix";
+    fenix.url = "github:nix-community/fenix/720b54260dee864d2a21745bd2bb55223f58e297";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
-    dream2nix.url = "github:nix-community/dream2nix";
+    dream2nix.url = "path:../..";
     dream2nix.inputs.nixpkgs.follows = "nixpkgs";
     src.url = "github:BurntSushi/ripgrep/13.0.0";
     src.flake = false;

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -76,8 +76,6 @@
     packageOverrides ? {},
     settings ? [],
     sourceOverrides ? oldSources: {},
-    translator ? null,
-    translatorArgs ? {},
   } @ args: let
     allPkgs = makeNixpkgs pkgs systems;
 

--- a/src/subsystems/rust/builders/build-rust-package/default.nix
+++ b/src/subsystems/rust/builders/build-rust-package/default.nix
@@ -22,6 +22,13 @@
     utils = import ../utils.nix (args // topArgs);
     vendoring = import ../vendor.nix (args // topArgs);
 
+    buildWithToolchain =
+      utils.mkBuildWithToolchain
+      (toolchain: (pkgs.makeRustPlatform toolchain).buildRustPackage);
+    defaultToolchain = {
+      inherit (pkgs) cargo rustc;
+    };
+
     buildPackage = pname: version: let
       src = utils.getRootSource pname version;
       vendorDir = vendoring.vendoredDependencies;
@@ -32,7 +39,7 @@
 
       cargoBuildFlags = "--package ${pname}";
     in
-      produceDerivation pname (pkgs.rustPlatform.buildRustPackage {
+      produceDerivation pname (buildWithToolchain defaultToolchain {
         inherit pname version src;
 
         cargoBuildFlags = cargoBuildFlags;

--- a/src/subsystems/rust/builders/utils.nix
+++ b/src/subsystems/rust/builders/utils.nix
@@ -37,8 +37,10 @@ in rec {
   '';
 
   mkBuildWithToolchain = mkBuildFunc: let
-    buildWithToolchain = toolchain: args:
-      ((mkBuildFunc toolchain) args)
+    buildWithToolchain = toolchain: args: let
+      drv = (mkBuildFunc toolchain) args;
+    in
+      drv
       // {
         overrideRustToolchain = f: let
           newToolchain = toolchain // (f toolchain);
@@ -49,7 +51,7 @@ in rec {
         in
           buildWithToolchain newToolchain (args // maybePassthru);
         overrideAttrs = f:
-          buildWithToolchain toolchain (args // (f args));
+          buildWithToolchain toolchain (args // (f drv));
       };
   in
     buildWithToolchain;

--- a/src/utils/override.nix
+++ b/src/utils/override.nix
@@ -75,14 +75,12 @@
 
     # filter the overrides by the package name and conditions
     overridesToApply = let
-      # TODO: figure out if regex names will be useful
-      regexOverrides = {};
-      # lib.filterAttrs
-      #   (name: data:
-      #     lib.hasPrefix "^" name
-      #     &&
-      #     b.match name pname != null)
-      #   conditionalOverrides;
+      regexOverrides =
+        lib.filterAttrs
+        (name: data:
+          lib.hasPrefix "^" name
+          && b.match name pname != null)
+        conditionalOverrides;
 
       overridesForPackage =
         b.foldl'
@@ -182,10 +180,10 @@
       (overrideFuncs ++ singleArgOverrideFuncs);
   in
     # apply the overrides to the given pkg
-    (lib.foldl
-      (pkg: condOverride: applyOneOverride pkg condOverride)
-      pkg
-      overridesToApply);
+    lib.foldl
+    (pkg: condOverride: applyOneOverride pkg condOverride)
+    pkg
+    overridesToApply;
 in {
   inherit applyOverridesToPackage loadOverridesDirs;
 }


### PR DESCRIPTION
This implements an override for the Rust builders called `overrideRustToolchain` that can be used to override the Rust toolchain packages used by the builders. This also enables regex overrides for packages so that overriding the toolchain globally is made much more convenient.