### PR TITLE
add devShell outputs for nodejs ad python

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Extensive Example `flake.nix`:
         {
           filter = project: project.translator == "package-json";
           subsystemInfo.npmArgs = "--legacy-peer-deps";
+          subsystemInfo.nodejs = 18;
         }
       ];
 

--- a/examples/eslint/flake.nix
+++ b/examples/eslint/flake.nix
@@ -17,6 +17,7 @@
       settings = [
         {
           subsystemInfo.noDev = true;
+          subsystemInfo.nodejs = 18;
         }
       ];
     })

--- a/src/subsystems/nodejs/builders/granular/default.nix
+++ b/src/subsystems/nodejs/builders/granular/default.nix
@@ -250,8 +250,8 @@
           shellHook = ''
             # create the ./node_modules directory
             if [ -e ./node_modules ] && [ ! -L ./node_modules ]; then
-              echo -e "\nFailed creating the ./node_modules symlink."
-              echo -e "\n./node_modules already exists and is a directory, which means it is managed by anaother program. Please delete ./node_modules first and re-enter the dev shell."
+              echo -e "\nFailed creating the ./node_modules symlink to ${nodeModulesDir}"
+              echo -e "\n./node_modules already exists and is a directory, which means it is managed by another program. Please delete ./node_modules first and re-enter the dev shell."
             else
               rm -f ./node_modules
               ln -s ${nodeModulesDir} ./node_modules

--- a/src/subsystems/python/builders/simple-builder/default.nix
+++ b/src/subsystems/python/builders/simple-builder/default.nix
@@ -66,7 +66,20 @@
           $pipInstallFlags
       '';
     });
+
+    devShell = pkgs.mkShell {
+      buildInputs = [
+        # a drv with all dependencies without the main package
+        (package.overrideAttrs (old: {
+          src = ".";
+          dontUnpack = true;
+          buildPhase = old.preBuild;
+        }))
+      ];
+    };
   in {
     packages.${defaultPackageName}.${defaultPackageVersion} = package;
+    devShells.${defaultPackageName} = devShell;
+    inherit devShell;
   };
 }


### PR DESCRIPTION
This adds `devShell` and `devShells` outputs to the python and nodejs default builders
That means, flake outputs generated by `makeFlakeOutputs` will be suitable for use with `nix develop` or `direnv`.