### PR TITLE
feat(rust): add devshells to rust builder outputs

### DIFF
--- a/src/subsystems/rust/builders/utils.nix
+++ b/src/subsystems/rust/builders/utils.nix
@@ -42,7 +42,12 @@ in rec {
       # so we can apply it to the actual derivation later
       overrideDrvFunc = args.overrideDrvFunc or (_: {});
       cleanedArgs = l.removeAttrs args ["overrideDrvFunc"];
-      drv = ((mkBuildFunc toolchain) cleanedArgs).overrideAttrs overrideDrvFunc;
+      _drv = ((mkBuildFunc toolchain) cleanedArgs).overrideAttrs overrideDrvFunc;
+      drv =
+        _drv
+        // {
+          passthru = (_drv.passthru or {}) // {rustToolchain = toolchain;};
+        };
     in
       drv
       // {


### PR DESCRIPTION
Adds devshells for the Rust builders outputs. This is pretty simple, as it is basically just the packages themselves but with the Rust toolchain added so `cargo` and `rustc` is available in the shell.