### PR TITLE
puppeteer: initial override

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -617,6 +617,12 @@ in
       };
     };
 
+    puppeteer = {
+      skip-binary = {
+        PUPPETEER_SKIP_DOWNLOAD = 1;
+      };
+    };
+
     pngquant-bin = {
       add-binary = {
         buildScript = ''


### PR DESCRIPTION
This override fixes the build for ratel (the package I added to dreampkgs).

This is most probably not the override that makes puppeteer work, however it does complete the build.
I would say we merge this now and when we encounter a dependency that fails with a puppeteer related failure we update the override.
