### PR TITLE
nodejs: improve builder (executable linking)

### DIFF
--- a/src/subsystems/nodejs/builders/granular/fix-package.py
+++ b/src/subsystems/nodejs/builders/granular/fix-package.py
@@ -71,25 +71,33 @@ if 'dependencies' in package_json:
       )
 
 # create symlinks for executables (bin entries from package.json)
-if 'bin' in package_json and package_json['bin']:
-  bin = package_json['bin']
+def symlink_bin(bin_dir, package_json):
+  if 'bin' in package_json and package_json['bin']:
+    bin = package_json['bin']
 
-  def link(name, relpath):  
-    source = f'{out}/lib/node_modules/.bin/{name}'
-    sourceDir = os.path.dirname(source)
-    # create parent dir
-    pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
-    dest = os.path.relpath(relpath, sourceDir)
-    print(f"dest: {dest}; source: {source}")
-    os.symlink(dest, source)
+    def link(name, relpath):
+      source = f'{bin_dir}/{name}'
+      sourceDir = os.path.dirname(source)
+      # make target executable
+      os.chmod(relpath, 0o777)
+      # create parent dir
+      pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
+      dest = os.path.relpath(relpath, sourceDir)
+      print(f"symlinking executable. dest: {dest}; source: {source}")
+      os.symlink(dest, source)
 
-  if isinstance(bin, str):
-    name = package_json['name'].split('/')[-1]
-    link(name, bin)
+    if isinstance(bin, str):
+      name = package_json['name'].split('/')[-1]
+      link(name, bin)
 
-  else:
-    for name, relpath in bin.items():
-      link(name, relpath)
+    else:
+      for name, relpath in bin.items():
+        link(name, relpath)
+
+# symlink current packages executables to $nodeModules/.bin
+symlink_bin(f'{out}/lib/node_modules/.bin/', package_json)
+# symlink current packages executables to $out/bin
+symlink_bin(f'{out}/bin/', package_json)
 
 # write changes to package.json
 if changed:


### PR DESCRIPTION
- unsure that all executables of transitive dependencies are linked to /lib/node_modules/.bin
- stop adding many store paths to PATH, instead add .bin directory to PATH
- if installMethod=copy, .bin symlinks will now point to the local copy of the dependency instead of the original store path. This improves issues with runtime dependency errors in some situations