### PR TITLE
Add example of overriding devShells to prettier flake

### DIFF
--- a/examples/nodejs_prettier/flake.nix
+++ b/examples/nodejs_prettier/flake.nix
@@ -9,13 +9,36 @@
     self,
     dream2nix,
     src,
-  } @ inp:
-    (dream2nix.lib.makeFlakeOutputs {
+  } @ inp: let
+    d2n-flake = dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-    })
-    // {
+    };
+
+    overrideDevShells = {
+      devShells =
+        d2n-flake.devShells
+        // {
+          x86_64-linux =
+            d2n-flake.devShells.x86_64-linux
+            // {
+              default =
+                d2n-flake.devShells.x86_64-linux.default.overrideAttrs
+                (old: {
+                  buildInputs =
+                    old.buildInputs
+                    ++ [
+                      self.packages.x86_64-linux.hello
+                    ];
+                });
+            };
+        };
+    };
+
+    addChecks = {
       checks.x86_64-linux.prettier = self.packages.x86_64-linux.prettier;
     };
+  in
+    d2n-flake // overrideDevShells // addChecks;
 }


### PR DESCRIPTION
Pulled out `makeFlakeOutputs` and checks into a `let`.
Then override the devShells to add to `buildInputs`.

Thanks to @DavHau for helping me figuring this out.