### PR TITLE
fix: nodejs: link direct bins

### DIFF
--- a/src/subsystems/nodejs/builders/granular/default.nix
+++ b/src/subsystems/nodejs/builders/granular/default.nix
@@ -168,35 +168,6 @@
         deps
         (dep: allPackages."${dep.name}"."${dep.version}");
 
-      # Derivation building the ./node_modules directory in isolation.
-      # This is used for the devShell of the current package.
-      # We do not want to build the full package for the devShell.
-      nodeModulesDir = pkgs.runCommandLocal "node_modules-${pname}" {} ''
-        # symlink direct dependencies to ./node_modules
-        mkdir $out
-        ${l.concatStringsSep "\n" (
-          l.forEach nodeDeps
-          (pkg: ''
-            for dir in $(ls ${pkg}/lib/node_modules/); do
-              if [[ $dir == @* ]]; then
-                mkdir -p $out/$dir
-                ln -s ${pkg}/lib/node_modules/$dir/* $out/$dir/
-              else
-                ln -s ${pkg}/lib/node_modules/$dir $out/
-              fi
-            done
-          '')
-        )}
-
-        # symlink transitive executables to ./node_modules/.bin
-        mkdir $out/.bin
-        for dep in ${l.toString nodeDeps}; do
-          for binDir in $(ls -d $dep/lib/node_modules/.bin 2>/dev/null ||:); do
-            ln -sf $binDir/* $out/.bin/
-          done
-        done
-      '';
-
       passthruDeps =
         l.listToAttrs
         (l.forEach deps

--- a/src/subsystems/nodejs/builders/granular/devShell.nix
+++ b/src/subsystems/nodejs/builders/granular/devShell.nix
@@ -39,8 +39,6 @@ mkShell {
     nodeModulesDrv = pkg.overrideAttrs (old: {
       buildPhase = ":";
       installMethod = "copy";
-      src = "";
-      dontUnpack = true;
       dontPatch = true;
       dontBuild = true;
       dontInstall = true;

--- a/src/subsystems/nodejs/builders/granular/install-deps.py
+++ b/src/subsystems/nodejs/builders/granular/install-deps.py
@@ -46,7 +46,8 @@ def install_direct_dependencies():
             print(f"installing: {module}/{submodule}")
             origin =\
               os.path.realpath(f"{dep}/lib/node_modules/{module}/{submodule}")
-            os.symlink(origin, f"{root}/{module}/{submodule}")
+            if not os.path.exists(f"{root}/{module}/{submodule}"):
+              os.symlink(origin, f"{root}/{module}/{submodule}")
         else:
           print(f"installing: {module}")
           origin = os.path.realpath(f"{dep}/lib/node_modules/{module}")

--- a/src/subsystems/nodejs/builders/granular/install-deps.py
+++ b/src/subsystems/nodejs/builders/granular/install-deps.py
@@ -6,7 +6,6 @@ import subprocess as sp
 import sys
 
 
-out = os.environ.get('out')
 pname = os.environ.get('packageName')
 version = os.environ.get('version')
 bin_dir = f"{os.path.abspath('..')}/.bin"
@@ -26,15 +25,11 @@ def get_package_json(path):
   return package_json_cache[path]
 
 def install_direct_dependencies():
-  add_to_bin_path = []
   if not os.path.isdir(root):
     os.mkdir(root)
   with open(os.environ.get('nodeDepsPath')) as f:
     deps = f.read().split()
   for dep in deps:
-    # check for bin directory
-    if os.path.isdir(f"{dep}/bin"):
-      add_to_bin_path.append(f"{dep}/bin")
     if os.path.isdir(f"{dep}/lib/node_modules"):
       for module in os.listdir(f"{dep}/lib/node_modules"):
         # ignore hidden directories
@@ -55,8 +50,6 @@ def install_direct_dependencies():
             os.symlink(origin, f"{root}/{module}")
           else:
             print(f"already exists: {root}/{module}")
-
-  return add_to_bin_path
 
 
 def collect_dependencies(root, depth):
@@ -206,11 +199,7 @@ def symlink_direct_bins():
 
 
 # install direct deps
-add_to_bin_path = install_direct_dependencies()
-
-# dump bin paths
-with open(f"{os.environ.get('TMP')}/ADD_BIN_PATH", 'w') as f:
-  f.write(':'.join(add_to_bin_path))
+install_direct_dependencies()
 
 # symlink non-colliding deps
 symlink_sub_dependencies()
@@ -219,4 +208,5 @@ symlink_sub_dependencies()
 if os.environ.get('installMethod') == 'copy':
   symlinks_to_copies(root)
 
+# symlink direct deps bins
 symlink_direct_bins()


### PR DESCRIPTION
Fixes #221 

At the end of the `src/subsystems/nodejs/builders/granular/install-deps.py`, 
read `package.json`,
and link bins of direct dependencies to `node_modules/.bin`.

Needs to pass the `src` (+ run unpack phase) to `devShell` so `package.json` is available. 