### PR TITLE
translators/stack-lock: Use nix-community/all-cabal-json

### DIFF
--- a/src/subsystems/haskell/translators/stack-lock/default.nix
+++ b/src/subsystems/haskell/translators/stack-lock/default.nix
@@ -153,10 +153,10 @@ in {
         (rawObj: dlib.nameVersionPair rawObj.name rawObj.version)
         serializedRawObjects;
 
-      haskellUtils = import ../utils.nix {inherit lib;};
+      haskellUtils = import ../utils.nix {inherit lib pkgs;};
 
       cabalData =
-        stackLockUtils.batchCabalData
+        haskellUtils.batchFindJsonFromCabalCandidates
         allCandidates;
 
       parseStackLockEntry = entry:

--- a/src/subsystems/haskell/translators/utils.nix
+++ b/src/subsystems/haskell/translators/utils.nix
@@ -1,6 +1,54 @@
-{lib}: let
+{
+  lib,
+  pkgs,
+}: let
   l = lib // builtins;
+
+  all-cabal-json = let
+    src = pkgs.fetchurl {
+      url = "https://github.com/nix-community/all-cabal-json/tarball/bdb5c96a57926392fbfd567867fada983f480195";
+      sha256 = "sha256-C6/4T4yJ8uT0qmRezY5YT+dl0v6/FTpMEahuBMnPhiU=";
+    };
+  in
+    pkgs.runCommandLocal "all-cabal-json" {} ''
+      mkdir $out
+      cd $out
+      tar --strip-components 1 -xf ${src}
+    '';
+
+  findJsonFromCabalCandidate = name: version: let
+    jsonCabalFile = "${all-cabal-json}/${name}/${version}/${name}.json";
+  in
+    if (! (l.pathExists jsonCabalFile))
+    then throw ''"all-cabal-json" seems to be outdated''
+    else l.fromJSON (l.readFile jsonCabalFile);
 in {
+  inherit findJsonFromCabalCandidate;
+
+  findSha256FromCabalCandidate = name: version: let
+    hashFile = "${all-cabal-json}/${name}/${version}/${name}.hashes.json";
+  in
+    if (! (l.pathExists hashFile))
+    then throw ''"all-cabal-json" seems to be outdated''
+    else (l.fromJSON (l.readFile hashFile)).package-hashes.SHA256;
+
+  /*
+  Convert all cabal files for a given list of candidates to an attrset.
+  access like: ${name}.${version}.${some_cabal_attr}
+  */
+  batchFindJsonFromCabalCandidates = candidates: (l.pipe candidates
+    [
+      (l.map ({
+        name,
+        version,
+      }: {"${name}" = version;}))
+      l.zipAttrs
+      (l.mapAttrs (
+        name: versions:
+          l.genAttrs versions (findJsonFromCabalCandidate name)
+      ))
+    ]);
+
   getHackageUrl = {
     name,
     version,

--- a/src/subsystems/haskell/translators/utils.nix
+++ b/src/subsystems/haskell/translators/utils.nix
@@ -1,0 +1,9 @@
+{lib}: let
+  l = lib // builtins;
+in {
+  getHackageUrl = {
+    name,
+    version,
+    ...
+  }: "https://hackage.haskell.org/package/${name}-${version}.tar.gz";
+}


### PR DESCRIPTION
Some things I'm not sure of:

1. Do we additionally want to use `all-cabal-json` for the top-level
   file? This would have the drawback of yielding outdated data for a
   developer of a Haskell project who wants to use `dream2nix` to
   manage their project. I'm not sure if `dream2nix` is really
   designed for that use though.
2. Do we want to continue using `all-cabal-hashes` in the `stack-lock`
   translator? We end up copying a Cabal file from `all-cabal-hashes`
   in the builder anyway. Though I'm not sure why we don't simply use
   the Cabal file from the source tree.