### PR TITLE
docs: add nodejs quickstart guide

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,13 +10,12 @@
 - [Python](./subsystems/python.md)
 - [Haskell](./subsystems/haskell.md)
 
-# Concept
+# Concepts
 - [Architectural Considerations](./intro/architectural-considerations.md)
 - [Nixpkgs improvements](./intro/nixpkgs-improvements.md)
 - [Override system](./intro/override-system.md)
 - [Translators](./intro/translators.md)
 - [Indexers](./intro/indexers.md)
-
 
 # Contributing
 - [Extending dream2nix](./extending-dream2nix.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,8 @@
 
 # Guides
 - [Python: getting started in 10 minutes](./guides/getting-started-python.md)
+- [Node.js: quickstart](./guides/getting-started-nodejs.md)
+
 # Subsystems
 - [Rust](./subsystems/rust.md)
 - [Python](./subsystems/python.md)

--- a/docs/src/guides/getting-started-nodejs.md
+++ b/docs/src/guides/getting-started-nodejs.md
@@ -1,0 +1,275 @@
+# Build your nodejs project with nix in 10 minutes or less
+
+{{#include ../warning.md}}
+
+This guide takes you step-by-step through setting up a nodejs
+reproducible build and development environment using nix (the build
+system) and dream2nix (bridge between external package managers and nix).
+
+This setup will allow for the same environment to be reproduced on
+different machines and CI systems with high accuracy - thus avoiding
+many pitfalls of distributed software development.
+
+## Outline
+0. Install nix with flakes enabled
+1. Navigate to your nodejs project
+2. Initialize the dream2nix flake
+3. Define target platform(s)
+4. Explore the outputs
+5. Build the project
+6. Development shell
+7. FAQ
+
+{{#include ../install-nix.md}}
+
+## Navigate to your nodejs project
+For this guide we will use the fun
+[`cowsay`](https://github.com/piuccio/cowsay) nodejs project.
+It is simply a talking cow for your console. This project is a nodejs
+port from the original perl version.
+Feel free to use any other project, if you do and hit a roadblock,
+please consult the [FAQ](#FAQ) at the end of this article for solutions
+to some common issues.
+
+We start by cloning the project:
+```command
+> git clone https://github.com/piuccio/cowsay /tmp/my_project
+> cd ./my_project
+```
+
+## Initialize the dream2nix flake
+We have our repository cloned and ready. Now we will create the flake.
+
+The flake is a standalone description of the project, it will define the
+inputs and outputs of our project, the build steps - in this case
+handled by dream2nix, and the development environment.
+The flake is a fully standalone and complete configuration for nix to
+build a software package.
+
+We use a dream2nix flake template:
+```command
+> nix flake init -t github:nix-community/dream2nix#simple
+wrote: /tmp/my_project/flake.nix
+```
+to create a `flake.nix`:
+```nix
+{
+  inputs.dream2nix.url = "github:nix-community/dream2nix";
+  outputs = inp:
+    inp.dream2nix.lib.makeFlakeOutputs {
+      systemsFromFile = ./nix_systems;
+      config.projectRoot = ./.;
+      source = ./.;
+    };
+}
+```
+This file configures our build and development environment using the
+dream2nix framework to bridge the nodejs ecosystem into nix. This let's
+nix read and understand `package.json` and how to install and link
+nodejs packages - to avoid duplication of dependency definitions and
+build steps.
+
+## Define the target platform(s)
+We have the flake setup, now we need to define the supported systems,
+this is necessary because nix can do multi platform and cross-platform
+builds so we need to tell it what can be built and where.
+
+```command
+> nix eval --impure --raw --expr 'builtins.currentSystem' > ./nix_systems
+> git add ./nix_systems
+```
+
+Remember to add the file `./nix_systems` to git, or it will be ignored.
+If you want to support more platforms later,
+just add more lines to that file.
+
+## Explore the outputs
+We have setup the flake, defined our target system(s), now we are ready
+to use it. Let's start by listing out what is available to us (actual
+output may be different, this is a shortened version):
+```command
+> nix flake show
+warning: Git tree '/tmp/my_project' is dirty
+warning: creating lock file '/tmp/my_project/flake.lock'
+warning: Git tree '/tmp/my_project' is dirty
+git+file:///tmp/my_project
+├───devShell
+│   └───x86_64-linux: development environment 'nix-shell'
+├───devShells
+│   └───x86_64-linux
+│       ├───cowsay: development environment 'nix-shell'
+│       └───default: development environment 'nix-shell'
+├───packages
+│   └───x86_64-linux
+│       ├───cowsay: package 'cowsay-1.5.0'
+│       ├───default: package 'cowsay-1.5.0'
+│       └───resolveImpure: package 'resolve'
+└───projectsJson: unknown
+```
+
+We can see that:
+1. `warning: Git tree '/tmp/my_project' is dirty`
+Our repository has uncommitted changes.
+Nix uses git commit hashes to version build artifacts,
+so this can result in some extra rebuilds.
+Since we are just setting up the project now, this is alright.
+1. `warning: creating lock file '/tmp/my_project/flake.lock'`
+Our flake itself has an input (external dependency), the `dream2nix`
+framework. When we first use the flake, like we just did, nix created a
+lock file with the exact version of the input (and its inputs). Commit
+this file to version control to ensure reproducible builds.
+1. Finally, we see the outputs of our flake.
+We see it outputs `packages` for the `x86_64-linux` systems:
+the `cowsay` package (our nodejs project) and a `resolveImpure` package
+(more about that in the next section). It also sets out `cowsay` package
+as the `default` package of this flake.
+
+## Build the project
+We have setup our flake for the nodejs project and identified the
+output we want to build.
+
+To build the output, we run:
+```command
+> nix build .#cowsay
+```
+(The `.` means the flake in the current directory, `#` is a special
+character separating the flake name and the package name, and `cowsay` is
+the name of the package we want to build. Since we want to `build`, nix
+will look under `packages` first, and it knows our current platform
+(`x86_64-linux` in this case), so it will actually build the output
+`.#packages.x86_64-linux.cowsay`.)
+
+Since, `cowsay` is the `default` package, we could also simply run:
+```command
+> nix build
+```
+To build the `.#packages.x86_64-linux.default` output. (In our case
+these are the same.)
+
+This creates our `./result` directory with all our final build
+artifacts.
+```command
+> ./result/bin/cowsay 'hello dream2nix'
+ _________________
+< hello dream2nix >
+ -----------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+Nix was able to build this project, because it has a `package-lock.json`
+file pinning the exact dependency versions. If we did not have this
+file, the `nix build` would fail with `error: unresolved impurities`.
+```command
+> git rm package-lock.json
+> nix build .#cowsay
+warning: Git tree '/tmp/my_project' is dirty
+error: The nodejs package cowsay contains unresolved impurities.
+       Resolve by running the .resolve attribute of this derivation
+       or by resolving all impure projects by running the `resolveImpure` package
+```
+We can fix this by generating a language specific lockfile
+(`package-lock.json` or `yarn.lock` for nodejs), or let dream2nix
+generate a universal `dream-lock.json`.
+```command
+> nix run .#resolveImpure
+warning: Git tree '/tmp/my_project' is dirty
+Resolving:: Name: cowsay; Subsystem: nodejs; relPath:
+translating in temp dir: /tmp/tmp.SwBFt0WcH4
+
+up to date, audited 172 packages in 9s
+
+57 packages are looking for funding
+  run `npm fund` for details
+
+3 high severity vulnerabilities
+
+To address all issues (including breaking changes), run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+===[SUCCESS]===(dream2nix-packages/cowsay/dream-lock.json)===
+adding file to git: dream2nix-packages/cowsay/dream-lock.json
+```
+This runs `npm` behind the scenes and resolves dependencies for all
+packages inside the flake.
+
+There is no difference between using an external lockfile or
+`dream-lock.json`, all they do is pin dependency version and are
+completely interchangeable.
+
+## Development shell
+We were able to build our nodejs project with nix, however our build
+artifacts under `./result` are read-only and we do not have `node` and
+`npm` in `PATH`. To be able to work in this project we will need those.
+
+Nix provides us with `devShells` for exactly this.
+```command
+> nix flake show
+warning: Git tree '/tmp/my_project' is dirty
+warning: creating lock file '/tmp/my_project/flake.lock'
+warning: Git tree '/tmp/my_project' is dirty
+git+file:///tmp/my_project
+├───devShell
+│   └───x86_64-linux: development environment 'nix-shell'
+├───devShells
+│   └───x86_64-linux
+│       ├───cowsay: development environment 'nix-shell'
+│       └───default: development environment 'nix-shell'
+├───packages
+│   └───x86_64-linux
+│       ├───cowsay: package 'cowsay-1.5.0'
+│       ├───default: package 'cowsay-1.5.0'
+│       └───resolveImpure: package 'resolve'
+└───projectsJson: unknown
+```
+When we enter the `cowsay` development shell, we will get `node` in our
+`PATH`, together with all the binaries from our dependencies packages.
+And nix will copy over `node_modules` for us to save us from having to
+`npm install` everything over again.
+To get in the shell, simply run:
+```command
+> nix develop -c $SHELL
+```
+(The `-c $SHELL` part is only necessary if you use a different shell than bash
+and would like to bring that shell with you into the dev environment.)
+
+From here on it's the same as using a normal installation of nodejs.
+However, if we do imperative changes to `node_modules` and later
+re-enter the nix development shell, nix will overwrite the
+`node_modules` with the pinned versions of the dependencies from our
+lockfile.
+
+## FAQ
+> Refusing to overwrite existing file on `flake init`.
+When initializing a flake it needs to write some files, if these already
+exists, the initialization will fail. Since our repository is under
+version control, we can delete the conflicting files, let `flake init`
+create them and then check the diff and merge the changes manually.
+
+> Getting status of `flake.nix`: no such file or directory.
+The flake build does not happen inside the directory. Nix copies your
+repository to a temporary location and builds there; only files under
+version control are used. To resolve this run `git add flake.nix` and
+all other missing files.
+
+> warning: Git tree is dirty
+This is just a warning, nix is using the git revision for build artifact
+versioning. Having a dirty git tree - meaning uncommitted changes - can
+lead to some extra rebuilds, for simple projects this should not be a
+major concern.
+
+> error: The package contains unresolved impurities. Resolve all impure
+> projects by running the `resolveImpure` package.
+This happens when dream2nix cannot resolve exact package versions. We
+can define a dependency like `something@^2.1`, but it is not obvious if
+we actually want `2.1.1` or `2.1.2` or maybe `2.1.1-alpha`.
+There are 2 ways to resolve this error: either by running
+`nix run .#resolveImpure` and letting dream2nix resolve the most
+up-to-date versions of all dependencies, or using an external package
+manager to generate a lock file, which can be later read by dream2nix.
+(In case of Node.js, both `package-lock.json` and `yarn.lock` are
+supported.)

--- a/docs/src/guides/getting-started-python.md
+++ b/docs/src/guides/getting-started-python.md
@@ -3,20 +3,8 @@
 {{#include ../warning.md}}
 
 This guide walks you through the process of setting up nix for your project using dream2nix. This will allow your project's build and dev-environment to be reproduced by machines of other developers or CI systems with high accuracy.
- 
-## Install nix
-If you don't have nix already, check out [nixos.org/download.html](https://nixos.org/download.html) on how to install it.
 
-## Enable the nix flakes feature
-For internal dependency management dream2nix requires the experimental nix feature `flakes` being enabled.
-```
-export NIX_CONFIG="extras-experimental-features = flakes nix-command"
-```
-
-If you find yourself using dream2nix regularly, you can permanently save these settings by adding the following line to your `/etc/nix/nix.conf`:
-```
-experimental-features = flakes nix-command
-```
+{{#include ../install-nix.md}}
 
 ## Navigate to your python project
 In this example I will clone the python project [`httpie`](https://github.com/httpie/httpie) to `/tmp/my_project` as an example.

--- a/docs/src/guides/getting-started-python.md
+++ b/docs/src/guides/getting-started-python.md
@@ -18,16 +18,18 @@ In this example I will clone the python project [`httpie`](https://github.com/ht
 > nix flake init -t github:nix-community/dream2nix#simple
 wrote: /tmp/my_project/flake.nix
 ```
-Great, this created a new file `flake.nix` which is like a recipe that tells nix how to build our python project or how to assemble a development environment for it.  
+Great, this created a new file `flake.nix` which is like a recipe that tells nix how to build our python project or how to assemble a development environment for it.
 By modifying this file, we can tweak settings and change the way our package gets built by nix. But for now we just go with the defaults.
 
 ## Define the target platform
-Before we can start, we need to tell dream2nix which platform we want to build software for. dream2nix will read these platforms from the file `./nix_systems`. To get started we will jsut add our current platform to it with the following command.
+Before we can start, we need to tell dream2nix which platform we want to build software for.
+Dream2nix will read these platforms from the file `./nix_systems`.
+To get started we will just add our current platform to it with the following command.
 ```command
 > nix eval --impure --raw --expr 'builtins.currentSystem' > ./nix_systems
 > git add ./nix_systems
 ```
-Don't forget to add the file `./nix_systems` to git, otherwise it will be ignored.  
+Don't forget to add the file `./nix_systems` to git, otherwise it will be ignored.
 If you want to support more platforms later, just add more lines to that file.
 
 ## List the available packages
@@ -46,9 +48,9 @@ git+file:///tmp/my_project
 ```
 
 What we can observe here:
-1. ```warning: Git tree '/tmp/my_project' is dirty```  
+1. ```warning: Git tree '/tmp/my_project' is dirty```
 Nix warns us that the current git repo has uncommited changes. Thats fine, because we like to experiment for now. This warning will go away as soon as we commit our changes.
-1. `warning: creating lock file '/tmp/my_project/flake.lock'`  
+1. `warning: creating lock file '/tmp/my_project/flake.lock'`
 Our flake.nix imported external libraries. The versions of these libraries have now been locked inside a new file `flake.lock`. We should later commit this file to the repo, in order to allow others to reproduce our build exactly.
 1.
     ```
@@ -59,16 +61,16 @@ Our flake.nix imported external libraries. The versions of these libraries have 
       │       └───resolveImpure: package 'resolve'
       └───projectsJson: unknown
     ```
-    Similar like a .json file defines a structure of data, our flake.nix defines a structure of `nix attributes` which are things that we can build or run with nix.  
+    Similar like a .json file defines a structure of data, our flake.nix defines a structure of `nix attributes` which are things that we can build or run with nix.
     We can see that it contains packages for my current platform `x86_64-linux`.
-    
-    The packages which we can see here is my python package and a package called`resolveImpure`, which is a special package provided by dream2nix which we will learn more about later.
+
+    The packages which we can see here is my python package and a package called `resolveImpure`, which is a special package provided by dream2nix which we will learn more about later.
 
 ## Build the Project
 Let's try building our project.
 If you get an error about `unresolved impurities`, see [Resolve Impurities](#resolve-impurities)
-```
-nix build .#default
+```command
+> nix build .#default
 ```
 Congratulations, your build artifacts will now be accessible via the `./result` directory. If your project contains executables, you can run these via `./result/bin/executable-name`.
 If you want to develop on your python project, see [Create a development shell](#create-a-development-shell)
@@ -77,13 +79,13 @@ If you want to develop on your python project, see [Create a development shell](
 Nix can provide you with a development shell containing all your project's dependencies.
 First, ensure that your project [is resolved](#resolve-impurities), then execute the following command.
 ```command
-nix develop -c $SHELL
+> nix develop -c $SHELL
 ```
 The `-c $SHELL` part is only necessary if you use a different shell than bash and would like to bring that shell with you into the dev environment.
 
 ## Resolve Impurities
 If you try to build, you might run into the following error.
-```
+```command
 > nix build .#default
 error: The python package main contains unresolved impurities.
        Resolve by running the .resolve attribute of this derivation
@@ -91,7 +93,7 @@ error: The python package main contains unresolved impurities.
 ```
 Oops. It seems like our project does not contain enough information for dream2nix to construct a reproducible build. But this is not a problem as we can fix this by using the `resolveImpure` package that dream2nix provides.
 ```command
-nix run .#resolveImpure
+> nix run .#resolveImpure
 ...
 adding file to git: dream2nix-packages/main/dream-lock.json
 ```

--- a/docs/src/install-nix.md
+++ b/docs/src/install-nix.md
@@ -1,0 +1,13 @@
+## Install nix
+If you don't have nix already, check out [nixos.org/download.html](https://nixos.org/download.html) on how to install it.
+
+## Enable the nix flakes feature
+For internal dependency management dream2nix requires the experimental nix feature `flakes` being enabled.
+```
+export NIX_CONFIG="extras-experimental-features = flakes nix-command"
+```
+
+If you find yourself using dream2nix regularly, you can permanently save these settings by adding the following line to your `/etc/nix/nix.conf`:
+```
+experimental-features = flakes nix-command
+```


### PR DESCRIPTION
Currently there is only a python quickstart guide, which is very nice.

This PR will add a similar guide for nodejs.