### PR TITLE
fix: nodejs: link package bins after buildPhase

### DIFF
--- a/src/subsystems/nodejs/builders/granular/default.nix
+++ b/src/subsystems/nodejs/builders/granular/default.nix
@@ -293,6 +293,9 @@
         # script to install (symlink or copy) dependencies.
         installDeps = "${./install-deps.py}";
 
+        # python script to link bin entries from package.json
+        linkBins = "${./link-bins.py}";
+
         # costs performance and doesn't seem beneficial in most scenarios
         dontStrip = true;
 
@@ -493,6 +496,9 @@
         # Symlinks executables and manual pages to correct directories
         installPhase = ''
           runHook preInstall
+
+          echo "Symlinking bin entries from package.json"
+          python $linkBins
 
           echo "Symlinking manual pages"
           if [ -d "$nodeModules/$packageName/man" ]

--- a/src/subsystems/nodejs/builders/granular/fix-package.py
+++ b/src/subsystems/nodejs/builders/granular/fix-package.py
@@ -70,35 +70,6 @@ if 'dependencies' in package_json:
         file=sys.stderr
       )
 
-# create symlinks for executables (bin entries from package.json)
-def symlink_bin(bin_dir, package_json):
-  if 'bin' in package_json and package_json['bin']:
-    bin = package_json['bin']
-
-    def link(name, relpath):
-      source = f'{bin_dir}/{name}'
-      sourceDir = os.path.dirname(source)
-      # make target executable
-      os.chmod(relpath, 0o777)
-      # create parent dir
-      pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
-      dest = os.path.relpath(relpath, sourceDir)
-      print(f"symlinking executable. dest: {dest}; source: {source}")
-      os.symlink(dest, source)
-
-    if isinstance(bin, str):
-      name = package_json['name'].split('/')[-1]
-      link(name, bin)
-
-    else:
-      for name, relpath in bin.items():
-        link(name, relpath)
-
-# symlink current packages executables to $nodeModules/.bin
-symlink_bin(f'{out}/lib/node_modules/.bin/', package_json)
-# symlink current packages executables to $out/bin
-symlink_bin(f'{out}/bin/', package_json)
-
 # write changes to package.json
 if changed:
   with open('package.json', 'w') as f:

--- a/src/subsystems/nodejs/builders/granular/link-bins.py
+++ b/src/subsystems/nodejs/builders/granular/link-bins.py
@@ -22,6 +22,9 @@ def symlink_bin(bin_dir, package_json):
       pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
       dest = os.path.relpath(relpath, sourceDir)
       print(f"symlinking executable. dest: {dest}; source: {source}")
+      # if a bin with this name exists, overwrite
+      if os.path.exists(source):
+        os.remove(source)
       os.symlink(dest, source)
 
     if isinstance(bin, str):

--- a/src/subsystems/nodejs/builders/granular/link-bins.py
+++ b/src/subsystems/nodejs/builders/granular/link-bins.py
@@ -1,0 +1,38 @@
+import json
+import os
+import pathlib
+
+
+with open('package.json') as f:
+  package_json = json.load(f)
+
+out = os.environ.get('out')
+
+# create symlinks for executables (bin entries from package.json)
+def symlink_bin(bin_dir, package_json):
+  if 'bin' in package_json and package_json['bin']:
+    bin = package_json['bin']
+
+    def link(name, relpath):
+      source = f'{bin_dir}/{name}'
+      sourceDir = os.path.dirname(source)
+      # make target executable
+      os.chmod(relpath, 0o777)
+      # create parent dir
+      pathlib.Path(sourceDir).mkdir(parents=True, exist_ok=True)
+      dest = os.path.relpath(relpath, sourceDir)
+      print(f"symlinking executable. dest: {dest}; source: {source}")
+      os.symlink(dest, source)
+
+    if isinstance(bin, str):
+      name = package_json['name'].split('/')[-1]
+      link(name, bin)
+
+    else:
+      for name, relpath in bin.items():
+        link(name, relpath)
+
+# symlink current packages executables to $nodeModules/.bin
+symlink_bin(f'{out}/lib/node_modules/.bin/', package_json)
+# symlink current packages executables to $out/bin
+symlink_bin(f'{out}/bin/', package_json)


### PR DESCRIPTION
Fixes #235 

Do not link bins from the `package.json` in the `d2nPatchPhase`, instead link in the `installPhase`.
Some of the binaries may have to be built (e.g. typescript compile).

Tested on [`serve`](https://github.com/vercel/serve):
```nix
{
  inputs = {
    dream2nix.url = "github:tinybeachthor/dream2nix/fix-nodejs-link-built-binary";
    serveSrc = {
      url = "github:vercel/serve/main";
      flake = false;
    };
  };
  outputs = { self, dream2nix, serveSrc }:
    dream2nix.lib.makeFlakeOutputs {
      systemsFromFile = ./nix_systems;
      config.projectRoot = ./.;
      source = serveSrc;
      packageOverrides = {
        serve = {
          "compile" = {
            buildScript = ''
              npm run compile
            '';
          };
        };
      };
    };
}
```
