### PR TITLE
docs: add nodejs subsystems page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 # Subsystems
 - [Rust](./subsystems/rust.md)
 - [Python](./subsystems/python.md)
+- [Node.js](./subsystems/node.md)
 - [Haskell](./subsystems/haskell.md)
 
 # Concepts

--- a/docs/src/subsystems/node.md
+++ b/docs/src/subsystems/node.md
@@ -1,0 +1,34 @@
+# Node.js subsystem
+
+This section documents the Node.js subsystem.
+
+## Example
+
+```nix
+{{#include ../../../examples/nodejs_eslint/flake.nix}}
+```
+
+## Translators
+
+### package-lock (pure)
+
+Translates `package-lock.json` into a dream2nix lockfile.
+
+### package-json (impure)
+
+Resolves dependencies from `package.json` using `npm` to generate a
+`package-lock.json`, then uses `package-lock` translator to generate the
+dream2nix lockfile.
+
+### yarn-lock (pure)
+
+Translates `yarn.lock` into a dream2nix lockfile.
+
+## Builders
+
+### granular (pure) (default)
+
+Builds all the dependencies in isolation, moving upwards to the top
+package.
+At the end copies over all dependencies into `node_modules` and writes
+symlinks for the bins into `node_modules/.bin`.


### PR DESCRIPTION
Add a new section to subsystems describing the node.js translators/builders.