### PR TITLE
feat: allow passing project without source

### DIFF
--- a/src/lib.nix
+++ b/src/lib.nix
@@ -75,6 +75,7 @@
     inject ? {},
     pname ? throw "Please pass `pname` to makeFlakeOutputs",
     packageOverrides ? {},
+    projects ? {},
     settings ? [],
     sourceOverrides ? oldSources: {},
   } @ args: let
@@ -92,7 +93,7 @@
     dream2nixFor = l.mapAttrs (_: pkgs: initD2N pkgs) allPkgs;
 
     discoveredProjects = dlib.discoverers.discoverProjects {
-      inherit settings;
+      inherit projects settings;
       tree = dlib.prepareSourceTree {inherit source;};
     };
 

--- a/src/lib/discoverers.nix
+++ b/src/lib/discoverers.nix
@@ -65,6 +65,7 @@
   );
 
   discoverProjects = {
+    projects,
     source ? throw "Pass either `source` or `tree` to discoverProjects",
     tree ? dlib.prepareSourceTree {inherit source;},
     settings ? [],
@@ -78,19 +79,22 @@
     discoveredProjectsSorted = let
       sorted =
         l.sort
-        (p1: p2: l.hasPrefix p1.relPath p2.relPath)
+        (p1: p2: l.hasPrefix p1.relPath or "" p2.relPath or "")
         discoveredProjects;
     in
       sorted;
 
-    rootProject = l.head discoveredProjectsSorted;
+    allProjects = discoveredProjectsSorted ++ (l.attrValues projects);
+
+    rootProject = l.head allProjects;
 
     projectsExtended =
-      l.forEach discoveredProjectsSorted
+      l.forEach allProjects
       (proj:
         proj
         // {
-          translator = l.head proj.translators;
+          relPath = proj.relPath or "";
+          translator = proj.translator or (l.head proj.translators);
           dreamLockPath = getDreamLockPath proj rootProject;
         });
   in
@@ -98,7 +102,7 @@
 
   getDreamLockPath = project: rootProject:
     dlib.sanitizeRelativePath
-    "${config.packagesDir}/${rootProject.name}/${project.relPath}/dream-lock.json";
+    "${config.packagesDir}/${rootProject.name}/${project.relPath or ""}/dream-lock.json";
 
   applyProjectSettings = projects: settingsList: let
     settingsListForProject = project:

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -188,7 +188,7 @@ in
       aggregate = project.aggregate or false;
 
       translator =
-        subsystems."${project.subsystem}".translators."${project.translator}";
+        framework.translatorInstances."${project.translator}";
 
       argsJsonFile =
         pkgs.writeText "translator-args.json"


### PR DESCRIPTION
Aside from the automatically discovered project, this allows adding extra `projects` like in this example flake.nix.
```nix
{
  inputs = {
    dream2nix.url = "github:nix-community/dream2nix";
  };

  outputs = {
    self,
    dream2nix,
  } @ inp: (dream2nix.lib.makeFlakeOutputs {
    systems = ["x86_64-linux"];
    config.projectRoot = ./.;
    source = ./.;
    projects = {
      htop = {
        name = "htop";
        translator = "debian-binary";
        # ... more args for the translator
      };
    };
  });
}
```
Right now the source is still required. In the future we should make the `source` field optional.

@a-kenji Probably relevant for your debian translator