### PR TITLE
WIP: indexers: make use of source-less translators

### DIFF
--- a/src/apps/translate/default.nix
+++ b/src/apps/translate/default.nix
@@ -1,5 +1,6 @@
 {
   # dream2nix deps
+  framework,
   utils,
   callNixWithD2N,
   translateSourceShortcut,
@@ -21,7 +22,7 @@ utils.writePureShellScriptBin
 ]
 ''
   usage="usage:
-    $0 SOURCE_SHORTCUT TARGET_DIR"
+    $0 PROJECT_JSON TARGET_DIR"
 
   if [ "$#" -ne 2 ]; then
     echo "error: wrong number of arguments"
@@ -29,91 +30,43 @@ utils.writePureShellScriptBin
     exit 1
   fi
 
-  source=''${1:?"error: pass a source shortcut"}
+  projectJson=''${1:?"error: pass projects spec as json string"}
   targetDir=''${2:?"error: please pass a target directory"}
   targetDir="$(realpath "$targetDir")"
-
-  sourceInfoPath=''${translateSourceInfoPath:-"$TMPDIR/sourceInfo.json"}
-  translateSkipResolved=''${translateSkipResolved:-"0"}
+  translator=$(jq '.translator' -c -r <(echo $projectJson))
+  name=$(jq '.name' -c -r <(echo $projectJson))
+  id=$(jq '.id' -c -r <(echo $projectJson))
+  if [ "$id" == "null" ]; then
+    echo "error: 'id' field not specified for project $name"
+    exit 1
+  fi
+  dreamLockPath="$targetDir/$id/dream-lock.json"
 
   mkdir -p $targetDir && cd $targetDir
 
-  export dream2nixConfig="{packagesDir=\"./.\"; projectRoot=\"$targetDir\";}"
+  echo -e "\nTranslating:: $name (translator: $translator) (lock path: $dreamLockPath)"
 
-  # translate the source shortcut
-  ${translateSourceShortcut} $source > $sourceInfoPath
+  translateBin=$(${callNixWithD2N} build --print-out-paths --no-link "
+    dream2nix.framework.translatorInstances.$translator.translateBin
+  ")
 
-  # collect data for the packages we will resolve
-  resolveDatas="$TMPDIR/resolveData.json"
-  ${callNixWithD2N} eval --json "
-    let
-      data =
-        l.map
-        (
-          p:
-          let
-            resolve = p.passthru.resolve or p.resolve;
-            mkBashEnv = name: value:
-              \"\''${name}=\" + \"'\" + value + \"'\";
-          in
-            # skip this project if we don't want to resolve ones that can be resolved on the fly
-            if \"$translateSkipResolved\" == \"1\" && resolve.passthru.project ? dreamLock
-            then null
-            else
-              # write a simple bash script for exporting the data we need
-              # this is better since we don't need to call jq multiple times
-              # to access the data we need
-              l.concatStringsSep
-              \";\"
-              (
-                (with resolve.passthru.project; [
-                  (mkBashEnv \"name\" name)
-                  (mkBashEnv \"dreamLockPath\" dreamLockPath)
-                  (mkBashEnv \"subsystem\" subsystem)
-                ]) ++ [
-                  (mkBashEnv \"drvPath\" resolve.drvPath)
-                ]
-              )
-        )
-        (
-          l.attrValues
-          (
-            l.removeAttrs
-            (dream2nix.makeOutputs {
-              source = dream2nix.fetchers.fetchSource {
-                source =
-                  l.fromJSON (l.readFile \"$sourceInfoPath\");
-              };
-            }).packages
-            [\"resolveImpure\"]
-          )
-        );
-    in
-      l.unique (l.filter (i: i != null) data)
-  " > $resolveDatas
+  echo "
+    {
+      \"project\": $projectJson,
+      \"outputFile\": \"$dreamLockPath\"
+    }
+  " > $TMPDIR/args.json
 
-  # resolve the packages
-  for resolveData in $(jq '.[]' -c -r $resolveDatas); do
-    # extract project data so we can determine where the dream-lock.json will be
-    eval "$resolveData"
+  $translateBin $TMPDIR/args.json
 
-    echo "Resolving:: $name (subsystem: $subsystem) (lock path: $dreamLockPath)"
+  cat $dreamLockPath \
+    | python3 ${../cli/format-dream-lock.py} \
+    | sponge $dreamLockPath
 
-    # build the resolve script and run it
-    nix build --out-link $TMPDIR/resolve $drvPath
-    $TMPDIR/resolve/bin/resolve
+  ${python3.pkgs.jsonschema}/bin/jsonschema \
+      --instance $dreamLockPath \
+      --output pretty \
+      ${../../specifications/dream-lock-schema.json}
 
-    # patch the dream-lock with our source info so the dream-lock works standalone
-    ${callNixWithD2N} eval --json "
-      with dream2nix.utils.dreamLock;
-      replaceRootSources {
-        dreamLock = l.fromJSON (l.readFile \"$targetDir/$dreamLockPath\");
-        newSourceRoot = l.fromJSON (l.readFile \"$sourceInfoPath\");
-      }
-    " \
-      | python3 ${../cli/format-dream-lock.py} \
-      | sponge "$dreamLockPath"
-
-    echo "Resolved:: $name (subsystem: $subsystem) (lock path: $dreamLockPath)"
-  done
+  echo -e "\nFinished:: $name (translator: $translator) (lock path: $dreamLockPath)"
 ''

--- a/src/indexers/libraries-io/default.nix
+++ b/src/indexers/libraries-io/default.nix
@@ -21,6 +21,7 @@ libraries.io also supports other interesting popularity metrics:
     curl,
     jq,
     lib,
+    python3,
     ...
   }: let
     l = lib // builtins;
@@ -31,7 +32,7 @@ libraries.io also supports other interesting popularity metrics:
     };
   in
     utils.writePureShellScript
-    [coreutils curl jq]
+    [coreutils curl jq python3]
     ''
       input=''${1:?"please provide an input as a JSON file"}
 
@@ -44,29 +45,24 @@ libraries.io also supports other interesting popularity metrics:
       fi
       apiKey="$API_KEY"
 
-      platform=$(jq '.platform' -c -r $input)
-      number=$(jq '.number' -c -r $input)
+      export platform=$(jq '.platform' -c -r $input)
+      export number=$(jq '.number' -c -r $input)
 
       # calculate number of pages to query
       # page size is always 100
-      # result will be truncated to the given $number
+      # result will be truncated to the given $number later
       numPages=$(($number/100 + ($number % 100 > 0)))
 
       # get platform
       platformQuery=$(jq ".\"$platform\"" -c -r ${l.toFile "platform-map.json" (l.toJSON platformMap)})
-      jqQuery=".[] | [(\"$platform:\" + .name + \"/\" + (.versions | sort_by(.published_at))[-1].number)] | add"
 
       echo "Starting to query $numPages pages..."
 
-      rm -f $outFile
+      echo "[]" > $outFile
       for page in $(seq 1 $numPages); do
         echo "requesting page $page"
         url="https://libraries.io/api/search?page=$page&sort=dependents_count&per_page=100&platforms=$platformQuery&api_key=$apiKey"
-        curl -k "$url" | jq "$jqQuery" -r >> $outFile
+        curl -k "$url" | python3 ${./process-result.py} $outFile
       done
-
-      # truncate entries to $number and convert back to json
-      head -n $number $outFile | jq --raw-input --slurp 'split("\n") | .[0:-1]' > ''${outFile}.final
-      mv ''${outFile}.final $outFile
     '';
 }

--- a/src/indexers/libraries-io/process-result.py
+++ b/src/indexers/libraries-io/process-result.py
@@ -1,0 +1,27 @@
+import json
+import os
+import sys
+
+out_file = sys.argv[1]
+platform = os.environ.get("platform")
+number = int(os.environ.get("number"))
+
+input = json.load(sys.stdin)
+projects = []
+for package in input:
+  versions = package['versions']
+  latest_version =\
+    (sorted(versions, key=lambda v: v['published_at'])[-1])['number']
+  projects.append(dict(
+    id=f"{package['name']}-{latest_version}",
+    name=package['name'],
+    version=latest_version,
+    translator=platform,
+  ))
+
+with open(out_file) as f:
+  existing_projects = json.load(f)
+
+all_projects = (existing_projects + projects)[:number]
+with open(out_file, 'w') as f:
+  json.dump(all_projects, f, indent=2)

--- a/src/indexers/npm/default.nix
+++ b/src/indexers/npm/default.nix
@@ -4,6 +4,7 @@
     coreutils,
     curl,
     jq,
+    python3,
     ...
   }:
     utils.writePureShellScript
@@ -17,8 +18,7 @@
       size=$(jq '.maxPackageCount' -c -r $input)
 
       url="https://registry.npmjs.org/-/v1/search?text=$text&popularity=1.0&quality=0.0&maintenance=0.0&size=$size"
-      jqQuery="[.objects[].package | [(\"npm:\" + .name + \"/\" + .version)]] | add"
 
-      curl -k "$url" | jq "$jqQuery" -r > $(realpath $outFile)
+      curl -k "$url" | ${python3}/bin/python ${./process-result.py} > $(realpath $outFile)
     '';
 }

--- a/src/indexers/npm/process-result.py
+++ b/src/indexers/npm/process-result.py
@@ -1,0 +1,14 @@
+import json
+import sys
+
+input = json.load(sys.stdin)
+projects = []
+for object in input['objects']:
+  package = object['package']
+  projects.append(dict(
+    id=f"{package['name']}-{package['version']}".replace('/', '_'),
+    name=package['name'],
+    version=package['version'],
+    translator='npm',
+  ))
+print(json.dumps(projects, indent=2))

--- a/src/subsystems/nodejs/translators/npm/default.nix
+++ b/src/subsystems/nodejs/translators/npm/default.nix
@@ -1,0 +1,101 @@
+{
+  dlib,
+  lib,
+  ...
+}: {
+  type = "impure";
+
+  # the input format is specified in /specifications/translator-call-example.json
+  # this script receives a json file including the input paths and specialArgs
+  translateBin = {
+    # dream2nix utils
+    apps,
+    subsystems,
+    utils,
+    # nixpkgs dependenies
+    bash,
+    coreutils,
+    git,
+    jq,
+    moreutils,
+    nodePackages,
+    openssh,
+    writeScriptBin,
+    ...
+  }:
+    utils.writePureShellScript
+    [
+      bash
+      coreutils
+      git
+      jq
+      moreutils
+      nodePackages.npm
+      openssh
+    ]
+    ''
+      # accroding to the spec, the translator reads the input from a json file
+      jsonInput=$1
+
+      # read the json input
+      outputFile=$(realpath -m $(jq '.outputFile' -c -r $jsonInput))
+      name=$(jq '.project.name' -c -r $jsonInput)
+      version=$(jq '.project.version' -c -r $jsonInput)
+      npmArgs=$(jq '.project.subsystemInfo.npmArgs' -c -r $jsonInput)
+
+      if [ "$version" = "null" ]; then
+        candidate="$name"
+      else
+        candidate="$name@$version"
+      fi
+
+
+      pushd $TMPDIR
+      newSource=$(pwd)
+
+      npm install $candidate --package-lock-only $npmArgs
+
+      jq ".source = \"$newSource\"" -c -r $jsonInput > $TMPDIR/newJsonInput
+      jq ".project.relPath = \"\"" -c -r $TMPDIR/newJsonInput | sponge $TMPDIR/newJsonInput
+
+      popd
+
+      # call package-lock translator
+      ${subsystems.nodejs.translators.package-lock.translateBin} $TMPDIR/newJsonInput
+
+      # generate source info for main package
+      url=$(npm view $candidate dist.tarball)
+      hash=$(npm view $candidate dist.integrity)
+      echo "
+        {
+          \"type\": \"http\",
+          \"url\": \"$url\",
+          \"hash\": \"$hash\"
+        }
+      " > $TMPDIR/sourceInfo.json
+
+      # add main package source info to dream-lock.json
+      ${apps.callNixWithD2N} eval --json "
+        with dream2nix.utils.dreamLock;
+        replaceRootSources {
+          dreamLock = l.fromJSON (l.readFile \"$outputFile\");
+          newSourceRoot = l.fromJSON (l.readFile \"$TMPDIR/sourceInfo.json\");
+        }
+      " \
+        | sponge "$outputFile"
+    '';
+
+  # inherit options from package-lock translator
+  extraArgs =
+    dlib.translators.translators.nodejs.package-lock.extraArgs
+    // {
+      npmArgs = {
+        description = "Additional arguments for npm";
+        type = "argument";
+        default = "";
+        examples = [
+          "--force"
+        ];
+      };
+    };
+}

--- a/src/subsystems/rust/translators/crates-io/default.nix
+++ b/src/subsystems/rust/translators/crates-io/default.nix
@@ -1,0 +1,101 @@
+{
+  dlib,
+  lib,
+  ...
+}: {
+  type = "impure";
+
+  # the input format is specified in /specifications/translator-call-example.json
+  # this script receives a json file including the input paths and specialArgs
+  translateBin = {
+    # dream2nix utils
+    apps,
+    subsystems,
+    utils,
+    # nixpkgs dependenies
+    coreutils,
+    curl,
+    gnutar,
+    gzip,
+    jq,
+    moreutils,
+    rustPlatform,
+    ...
+  }:
+    utils.writePureShellScript
+    [
+      coreutils
+      curl
+      gnutar
+      gzip
+      jq
+      moreutils
+      rustPlatform.rust.cargo
+    ]
+    ''
+      # according to the spec, the translator reads the input from a json file
+      jsonInput=$1
+
+      # read the json input
+      outputFile=$(realpath -m $(jq '.outputFile' -c -r $jsonInput))
+      cargoArgs=$(jq '.project.subsystemInfo.cargoArgs | select (.!=null)' -c -r $jsonInput)
+      name=$(jq '.project.name' -c -r $jsonInput)
+      version=$(jq '.project.version' -c -r $jsonInput)
+
+      pushd $TMPDIR
+      mkdir source
+
+      # download and unpack package source
+      curl -L https://crates.io/api/v1/crates/$name/$version/download > $TMPDIR/tarball
+      cd source
+      cat $TMPDIR/tarball | tar xz --strip-components 1
+      cd -
+
+      # generate arguments for cargo-toml translator
+      echo "{
+        \"source\": \"$TMPDIR/source\",
+        \"outputFile\": \"$outputFile\",
+        \"project\": {
+          \"relPath\": \"\",
+          \"subsystemInfo\": {
+            \"cargoArgs\": \"$cargoArgs\"
+          }
+        }
+      }" > $TMPDIR/newJsonInput
+
+      popd
+
+      ${subsystems.rust.translators.cargo-toml.translateBin} $TMPDIR/newJsonInput
+
+      # add main package source info to dream-lock.json
+      echo "
+        {
+          \"type\": \"crates-io\",
+          \"hash\": \"$(sha256sum $TMPDIR/tarball | cut -d " " -f 1)\"
+        }
+      " > $TMPDIR/sourceInfo.json
+
+      ${apps.callNixWithD2N} eval --json "
+        with dream2nix.utils.dreamLock;
+        replaceRootSources {
+          dreamLock = l.fromJSON (l.readFile \"$outputFile\");
+          newSourceRoot = l.fromJSON (l.readFile \"$TMPDIR/sourceInfo.json\");
+        }
+      " \
+        | sponge "$outputFile"
+    '';
+
+  # inherit options from cargo-lock translator
+  extraArgs =
+    dlib.translators.translators.rust.cargo-lock.extraArgs
+    // {
+      cargoArgs = {
+        description = "Additional arguments for Cargo";
+        type = "argument";
+        default = "";
+        examples = [
+          "--verbose"
+        ];
+      };
+    };
+}

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -104,10 +104,9 @@ in
 
         TMPDIR=$(${coreutils}/bin/mktemp -d)
 
-        ${script}
+        trap '${coreutils}/bin/rm -rf "$TMPDIR"' EXIT
 
-        cd
-        ${coreutils}/bin/rm -rf $TMPDIR
+        ${script}
       '';
 
     # builder to create a shell script that has it's own PATH
@@ -121,10 +120,9 @@ in
 
         TMPDIR=$(${coreutils}/bin/mktemp -d)
 
-        ${script}
+        trap '${coreutils}/bin/rm -rf "$TMPDIR"' EXIT
 
-        cd
-        ${coreutils}/bin/rm -rf $TMPDIR
+        ${script}
       '';
 
     # TODO is this really needed? Seems to make builds slower, why not unpack + build?


### PR DESCRIPTION
Previously the output of an indexer was a list of sources.
Since #259, dream2nix supports translation without source.
This change updates the indexers to support that feature.
With this change, the output of each indexer will be a list of project specifications instead of sources.

The new model:
  - Covers more use cases
  - Allows to translate from arbitrary data. For example {translator="apt"; name="htop"} could be a valid project specification.
  - Moves the logic for fetching inside the translator instead of using dream2nix fetchers. (less calls to nix)
  - does not use dream2nix makeFlakeOutputs logic in order to execute translation scripts (This is better, as depending on our high level abstractions would make refactoring/deprecating such more difficult)
  
  
TODO:
 - [x] update app .#translate
 - [x] update app .#translate-index
 - [x] fix output for indexer libraries-io
 - [x] fix output for indexer npm (can probably be removed anyways)
 - [ ] fix output of indexer creates-io
 - [ ] fix output of indexer creates-io-simple
 - [ ] fix makeOutputsForIndexes
 
 @yusdacra As we now have the multi purpose libraries-io indexer, do we still need the `creates-io` and `creates-io-simple` indexers, or should we delete them?