### PR TITLE
php: impure translator `composer-json` + fix `composer-lock`

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Python](./subsystems/python.md)
 - [Node.js](./subsystems/node.md)
 - [Haskell](./subsystems/haskell.md)
+- [PHP](./subsystems/php.md)
 
 # Concepts
 - [Architectural Considerations](./intro/architectural-considerations.md)

--- a/docs/src/subsystems/php.md
+++ b/docs/src/subsystems/php.md
@@ -1,0 +1,23 @@
+# PHP subsystem
+
+> !!! PHP support is a work in progress, and it is not yet usable (a
+> builder is missing). You can track the progress in
+> [nix-community/dream2nix#240](https://github.com/nix-community/dream2nix/issues/240).
+
+This section documents the PHP subsystem.
+
+## Translators
+
+### composer-lock (pure)
+
+Translates `composer.lock` into a dream2nix lockfile.
+
+### composer-json (impure)
+
+Resolves dependencies in `composer.json` using `composer` to generate a
+`composer.lock` lockfile, then invokes the `composer-lock` translator to
+generate a dream2nix lockfile.
+
+## Builders
+
+None so far.

--- a/src/subsystems/php/translators/composer-json/default.nix
+++ b/src/subsystems/php/translators/composer-json/default.nix
@@ -1,0 +1,103 @@
+{
+  dlib,
+  lib,
+  ...
+}: let
+  l = lib // builtins;
+in {
+  type = "impure";
+
+  /*
+  Allow dream2nix to detect if a given directory contains a project
+  which can be translated with this translator.
+  Usually this can be done by checking for the existence of specific
+  file names or file endings.
+
+  Alternatively a fully featured discoverer can be implemented under
+  `src/subsystems/{subsystem}/discoverers`.
+  This is recommended if more complex project structures need to be
+  discovered like, for example, workspace projects spanning over multiple
+  sub-directories
+
+  If a fully featured discoverer exists, do not define `discoverProject`.
+  */
+  discoverProject = tree: (l.pathExists "${tree.fullPath}/composer.json");
+
+  # A derivation which outputs a single executable at `$out`.
+  # The executable will be called by dream2nix for translation
+  # The input format is specified in /specifications/translator-call-example.json.
+  # The first arg `$1` will be a json file containing the input parameters
+  # like defined in /src/specifications/translator-call-example.json and the
+  # additional arguments required according to extraArgs
+  #
+  # The program is expected to create a file at the location specified
+  # by the input parameter `outFile`.
+  # The output file must contain the dream lock data encoded as json.
+  # See /src/specifications/dream-lock-example.json
+  translateBin = {
+    # dream2nix utils
+    subsystems,
+    utils,
+    # nixpkgs dependenies
+    bash,
+    coreutils,
+    jq,
+    phpPackages,
+    writeScriptBin,
+    ...
+  }:
+    utils.writePureShellScript
+    [
+      bash
+      coreutils
+      jq
+      phpPackages.composer
+    ]
+    ''
+      # accroding to the spec, the translator reads the input from a json file
+      jsonInput=$1
+
+      # read the json input
+      outputFile=$(realpath -m $(jq '.outputFile' -c -r $jsonInput))
+      source=$(jq '.source' -c -r $jsonInput)
+      relPath=$(jq '.project.relPath' -c -r $jsonInput)
+
+      pushd $TMPDIR
+      cp -r $source/* ./
+      chmod -R +w ./
+      newSource=$(pwd)
+
+      cd ./$relPath
+      rm -f composer.lock
+
+      echo "translating in temp dir: $(pwd)"
+
+      # create lockfile
+      if [ "$(jq '.project.subsystemInfo.noDev' -c -r $jsonInput)" == "true" ]; then
+        echo "excluding dev dependencies"
+        jq '.require-dev = {}' ./composer.json > composer.json.mod
+        mv composer.json.mod composer.json
+        composer update --no-install --no-dev
+      else
+        composer update --no-install
+      fi
+
+      jq ".source = \"$newSource\"" -c -r $jsonInput > $TMPDIR/newJsonInput
+
+      popd
+      ${subsystems.php.translators.composer-lock.translateBin} $TMPDIR/newJsonInput
+    '';
+
+  # If the translator requires additional arguments, specify them here.
+  # When users run the CLI, they will be asked to specify these arguments.
+  # There are only two types of arguments:
+  #   - string argument (type = "argument")
+  #   - boolean flag (type = "flag")
+  # String arguments contain a default value and examples. Flags do not.
+  extraArgs = {
+    noDev = {
+      description = "Exclude development dependencies";
+      type = "flag";
+    };
+  };
+}

--- a/src/subsystems/php/translators/composer-json/default.nix
+++ b/src/subsystems/php/translators/composer-json/default.nix
@@ -88,16 +88,6 @@ in {
       ${subsystems.php.translators.composer-lock.translateBin} $TMPDIR/newJsonInput
     '';
 
-  # If the translator requires additional arguments, specify them here.
-  # When users run the CLI, they will be asked to specify these arguments.
-  # There are only two types of arguments:
-  #   - string argument (type = "argument")
-  #   - boolean flag (type = "flag")
-  # String arguments contain a default value and examples. Flags do not.
-  extraArgs = {
-    noDev = {
-      description = "Exclude development dependencies";
-      type = "flag";
-    };
-  };
+  # inherit options from composer-lock translator
+  extraArgs = dlib.translators.translators.php.composer-lock.extraArgs;
 }

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -17,8 +17,8 @@ in {
   */
   generateUnitTestsForProjects = [
     (builtins.fetchTarball {
-      url = "https://github.com/tinybeachthor/dream2nix-php-composer-lock/archive/refs/tags/simple.tar.gz";
-      sha256 = "sha256:0yg3f943l5sgikw0pg6jggik5z2gwcwf9brndysszzfhiv3dl289";
+      url = "https://github.com/tinybeachthor/dream2nix-php-composer-lock/archive/refs/tags/complex.tar.gz";
+      sha256 = "sha256:1xa5paafhwv4bcn2jsmbp1v2afh729r2h153g871zxdmsxsgwrn1";
     })
   ];
 

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -154,7 +154,9 @@ in {
     pinPackages = pkgs: let
       clean = requires:
         l.filterAttrs
-        (name: _: (name != "php") && !(l.strings.hasPrefix "ext-" name))
+        (name: _:
+          (l.all (x: name != x) ["php" "composer/composer" "composer-runtime-api"])
+          && !(l.strings.hasPrefix "ext-" name))
         requires;
       doPin = name: semver:
         (l.head

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -203,14 +203,8 @@ in {
     in
       map (l.strings.removePrefix "ext-") (l.lists.unique extensions);
 
-    # get require (and require-dev)
-    getDependencies = pkg:
-      (
-        if noDev
-        then []
-        else (pkg.require-dev or {})
-      )
-      // (pkg.require or {});
+    # get dependencies
+    getDependencies = pkg: (pkg.require or {});
 
     # resolve semvers into exact versions
     pinPackages = pkgs: let
@@ -230,7 +224,6 @@ in {
         pkg
         // {
           require = l.mapAttrs doPin (clean pkg.require);
-          require-dev = l.mapAttrs doPin (clean pkg.require-dev);
         };
     in
       map doPins pkgs;
@@ -279,7 +272,13 @@ in {
               type = "path";
               path = projectSource;
             };
-            inherit (composerJson) require require-dev;
+            require =
+              (
+                if noDev
+                then {}
+                else composerJson.require-dev
+              )
+              // composerJson.require;
           }
         ]
         ++ resolvedPackages

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -138,8 +138,7 @@ in {
       all = map (pkg: l.attrsets.attrNames (getRequire pkg)) packages;
       flat = l.lists.flatten all;
       extensions = l.filter (l.strings.hasPrefix "ext-") flat;
-    in
-      l.lists.unique extensions;
+    in (map (l.strings.removePrefix "ext-") (l.lists.unique extensions));
 
     # get require (and require-dev)
     getRequire = pkg:

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -132,7 +132,7 @@ in {
       );
 
     # toplevel php semver
-    phpSemver = composerJson.require."php";
+    phpSemver = composerJson.require."php" or "*";
     # all the php extensions
     phpExtensions = let
       all = map (pkg: l.attrsets.attrNames (getRequire pkg)) packages;
@@ -200,7 +200,7 @@ in {
       Users will not be interested in all individual dependencies.
       */
       exportedPackages = {
-        "${defaultPackage}" = composerJson.version;
+        "${defaultPackage}" = composerJson.version or "0.0.0";
       };
 
       /*

--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -17,8 +17,8 @@ in {
   */
   generateUnitTestsForProjects = [
     (builtins.fetchTarball {
-      url = "https://code.castopod.org/adaures/castopod/-/archive/v1.0.0-alpha.80/castopod-v1.0.0-alpha.80.tar.gz";
-      sha256 = "sha256:0lv75pxzhs6q9w22czbgbnc48n6zhaajw9bag2sscaqnvfvfhcsf";
+      url = "https://github.com/tinybeachthor/dream2nix-php-composer-lock/archive/refs/tags/simple.tar.gz";
+      sha256 = "sha256:0yg3f943l5sgikw0pg6jggik5z2gwcwf9brndysszzfhiv3dl289";
     })
   ];
 

--- a/src/subsystems/php/utils.nix
+++ b/src/subsystems/php/utils.nix
@@ -1,14 +1,60 @@
-{utils, ...}: {
+{
+  utils,
+  lib,
+  ...
+}: let
+  l = lib // builtins;
+
   # composer.lock uses a less strict semver interpretation
   # ~1.2 -> >=1.2 <2.0.0 (instead of >=1.2.0 <1.3.0)
+  # ~1   -> >=1.0 <2.0.0
   # this is identical with ^1.2 in the semver standard
-  satisfiesSemver = version: constraint: let
-    minorTilde = l.match "^[~]([[:d:]]+[.][[:d:]]+)$" constraint;
-    cleanConstraint =
-      if minorTilde != null && l.length minorTilde >= 0
-      then "^${l.head minorTilde}"
-      else constraint;
-    cleanVersion = l.removePrefix "v" version;
+  #
+  # remove v from version strings: ^v1.2.3 -> ^1.2.3
+  #
+  # remove branch suffix: ^1.2.x-dev -> ^1.2
+  #
+  satisfiesSemverSingle = version: constraint: let
+    removeSuffix = c: let
+      m = l.match "^(.*)[-][[:alpha:]]+$" c;
+    in
+      if m != null && l.length m >= 0
+      then l.head m
+      else c;
+    removeX = l.strings.removeSuffix ".x";
+    tilde = c: let
+      m = l.match "^[~]([[:d:]]+.*)$" c;
+    in
+      if m != null && l.length m >= 0
+      then "^${l.head m}"
+      else c;
+    wildcard = c: let
+      m = l.match "^([[:d:]]+.*)[.][*x]$" c;
+    in
+      if m != null && l.length m >= 0
+      then "^${l.head m}"
+      else c;
+    removeV = c: let
+      m = l.match "^(.)v([[:d:]]+[.].*)$" c;
+    in
+      if m != null && l.length m > 0
+      then l.concatStrings m
+      else c;
+    cleanConstraint = removeV (wildcard (tilde (removeSuffix constraint)));
+    cleanVersion = removeX (l.removePrefix "v" (removeSuffix version));
   in
-    utils.satisfiesSemver cleanVersion cleanConstraint;
+    (version == constraint)
+    || (
+      utils.satisfiesSemver
+      cleanVersion
+      cleanConstraint
+    );
+in {
+  satisfiesSemver = version: constraint: let
+    # handle version alternatives: ^1.2 || ^2.0
+    trim = s: l.head (l.match "^[[:space:]]*([^[:space:]]*)[[:space:]]*$" s);
+    clean = l.replaceStrings ["||"] ["|"] constraint;
+    alternatives = map trim (l.splitString "|" clean);
+  in
+    l.any (satisfiesSemverSingle version) alternatives;
 }


### PR DESCRIPTION
Towards #240  

Found out a couple of issues with `composer-lock` translator (mostly semver resolution).

- [x] fix php semver resolution
- [x] handle composer dependency `replace`
- [x] handle composer dependency `provide`
- [x] impure translator `composer-json`
- [x] fix dev dependencies resolution
- [x] add php subsystems docs section