### PR TITLE
chore: CI performance improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         name: nix-community
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
-    - run: nix run .#tests-examples
+    - run: JOBS=10 nix run .#tests-examples
 
   tests-pure:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
         name: nix-community
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
-    - run: nix run .#tests-integration
+    - run: JOBS=10 nix run .#tests-integration
 
   tests-unit-nix:
     runs-on: ubuntu-latest
@@ -66,6 +66,10 @@ jobs:
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - uses: cachix/cachix-action@v10
+      with:
+        name: nix-community
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
     - run: nix run .#tests-unit
 

--- a/tests/examples/default.nix
+++ b/tests/examples/default.nix
@@ -53,7 +53,8 @@ in
   ''
     export STATS_FILE=$(mktemp)
     if [ -z ''${1+x} ]; then
-      parallel --halt now,fail=1 -j$(nproc) -a <(ls ${examples}) ${testScript}
+      JOBS=''${JOBS:-$(nproc)}
+      parallel --halt now,fail=1 -j$JOBS -a <(ls ${examples}) ${testScript}
     else
       arg1=$1
       shift

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -48,7 +48,8 @@ in
   ''
     export STATS_FILE=$(mktemp)
     if [ -z ''${1+x} ]; then
-      parallel --halt now,fail=1 -j$(nproc) -a <(ls ${tests}) ${testScript}
+      JOBS=''${JOBS:-$(nproc)}
+      parallel --halt now,fail=1 -j$JOBS -a <(ls ${tests}) ${testScript}
     else
       arg1=$1
       shift


### PR DESCRIPTION
- run more jobs in parallel for `example` and `integration` tests
- use cachitx for unit tests