### PR TITLE
Remove projects when discovered translators do not match user specified translators

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -461,7 +461,7 @@ in let
     # Remove projects whose translator's do not match with the translator
     # specified by the user
     discoveredProjectsStrict =
-      if b.hasAttr "translator" (b.elemAt settings 0)
+      if l.length settings != 0 && b.hasAttr "translator" (b.elemAt settings 0)
       then
         l.filter
         (project: b.elem (b.elemAt settings 0).translator project.translators)

--- a/src/default.nix
+++ b/src/default.nix
@@ -458,6 +458,16 @@ in let
 
     getProjectKey = project: "${project.name}_|_${project.subsystem}_|_${project.relPath}";
 
+    # Remove projects whose translator's do not match with the translator
+    # specified by the user
+    discoveredProjectsStrict =
+      if b.hasAttr "translator" (b.elemAt settings 0)
+      then
+        l.filter
+        (project: b.elem (b.elemAt settings 0).translator project.translators)
+        discoveredProjects
+      else discoveredProjects;
+
     # list of projects extended with some information requried for processing
     projectsList =
       l.map
@@ -478,7 +488,7 @@ in let
           };
       in
         self))
-      discoveredProjects;
+      discoveredProjectsStrict;
 
     # projects without existing valid dream-lock.json
     projectsPureUnresolved =
@@ -498,7 +508,7 @@ in let
       (proj: let
         translator = getTranslator proj.translator;
         dreamLock'' = translator.translate {
-          inherit source tree discoveredProjects;
+          inherit source tree discoveredProjectsStrict;
           project = proj;
         };
 


### PR DESCRIPTION
This fixes https://github.com/nix-community/dream2nix/issues/265 by requiring projects that are discovered to have compatible translators before being sent for translation.

I'm still relatively unfamiliar with the internals of dream2nix so this might be a sketchy way of doing things.