### PR TITLE
Add schema validation for specific subsystems

### DIFF
--- a/src/specifications/subsystems/nodejs/dream-lock-schema.json
+++ b/src/specifications/subsystems/nodejs/dream-lock-schema.json
@@ -5,6 +5,7 @@
   "properties": {
     "_subsystem": {
       "type": "object",
+      "required": ["nodejsVersion"],
       "properties": {
         "nodejsVersion": {
           "type": "string"

--- a/src/specifications/subsystems/nodejs/dream-lock-schema.json
+++ b/src/specifications/subsystems/nodejs/dream-lock-schema.json
@@ -7,7 +7,7 @@
       "type": "object",
       "properties": {
         "nodejsVersion": {
-          "type": "integer"
+          "type": "string"
         }
       }
     }

--- a/src/specifications/subsystems/nodejs/dream-lock-schema.json
+++ b/src/specifications/subsystems/nodejs/dream-lock-schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "manifest",
+  "type": "object",
+  "properties": {
+    "_subsystem": {
+      "type": "object",
+      "properties": {
+        "nodejsVersion": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/specifications/subsystems/nodejs/dream.lock.example.json
+++ b/src/specifications/subsystems/nodejs/dream.lock.example.json
@@ -1,5 +1,5 @@
 {
   "_subsystem": {
-    "nodejsVersion": 14
+    "nodejsVersion": "14"
   }
 }

--- a/src/specifications/subsystems/rust/dream-lock-schema.json
+++ b/src/specifications/subsystems/rust/dream-lock-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "manifest",
+  "type": "object",
+  "properties": {
+    "_subsystem": {
+      "type": "object",
+      "properties": {
+        "gitSources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["url", "sha", "type", "value"],
+            "additionalProperties": false
+          }
+        },
+        "relPathReplacements": {
+          "type": "object",
+          "properties": {
+            "^.*$": {
+              "type": "object",
+              "properties": {
+                "^.*$": {
+                  "type": "object",
+                  "properties": {
+                    "^.*$": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/specifications/subsystems/rust/dream-lock-schema.json
+++ b/src/specifications/subsystems/rust/dream-lock-schema.json
@@ -5,6 +5,7 @@
   "properties": {
     "_subsystem": {
       "type": "object",
+      "required": ["gitSources"],
       "properties": {
         "gitSources": {
           "type": "array",

--- a/src/subsystems/nodejs/builders/granular/default.nix
+++ b/src/subsystems/nodejs/builders/granular/default.nix
@@ -44,9 +44,9 @@
 
     nodejs =
       if args ? nodejs
-      then args.nodejs
+      then b.toString args.nodejs
       else
-        pkgs."nodejs-${builtins.toString nodejsVersion}_x"
+        pkgs."nodejs-${nodejsVersion}_x"
         or (throw "Could not find nodejs version '${nodejsVersion}' in pkgs");
 
     nodeSources = runCommandLocal "node-sources" {} ''

--- a/src/subsystems/nodejs/translators/package-lock/default.nix
+++ b/src/subsystems/nodejs/translators/package-lock/default.nix
@@ -170,7 +170,7 @@
 
       subsystemName = "nodejs";
 
-      subsystemAttrs = {nodejsVersion = args.nodejs;};
+      subsystemAttrs = {nodejsVersion = b.toString args.nodejs;};
 
       # functions
       serializePackages = inputData: let

--- a/src/subsystems/nodejs/translators/yarn-lock/default.nix
+++ b/src/subsystems/nodejs/translators/yarn-lock/default.nix
@@ -140,7 +140,7 @@
 
       subsystemName = "nodejs";
 
-      subsystemAttrs = {nodejsVersion = args.nodejs;};
+      subsystemAttrs = {nodejsVersion = b.toString args.nodejs;};
 
       keys = {
         yarnName = rawObj: finalObj:

--- a/src/utils/default.nix
+++ b/src/utils/default.nix
@@ -233,6 +233,18 @@ in
             --output pretty \
             ${../specifications/dream-lock-schema.json}
 
+          # if applicable, validate subsystem portion against jsonschema
+          subsystem=$(jq '._generic.subsystem' $dreamLockPath)
+          subsystem=''${subsystem%\"}
+          subsystem=''${subsystem#\"}
+          schema=${../specifications/subsystems}/$subsystem/dream-lock-schema.json
+          if [[ -f "$schema" ]]; then
+            ${python3.pkgs.jsonschema}/bin/jsonschema \
+                --instance $dreamLockPath \
+                --output pretty \
+                $schema
+          fi
+
           # add dream-lock.json to git
           if git rev-parse --show-toplevel &>/dev/null; then
             echo "adding file to git: $dreamLockPath"


### PR DESCRIPTION
- Create validation for existing schemas
- Validate only for subsystems with existing schemas
- Also add schemas for nodejs and rust

Co-authored-by: a-kenji <aks.kenji@protonmail.com>