### PR TITLE
fix(rust/crane): improve vendoring

### DIFF
--- a/src/subsystems/rust/builders/vendor.nix
+++ b/src/subsystems/rust/builders/vendor.nix
@@ -98,5 +98,5 @@ in rec {
   # All dependencies in the Cargo.lock file, vendored
   vendoredDependencies = vendorDependencies allDependencies;
 
-  copyVendorDir = path: ''cp -r --no-preserve=mode,ownership ${vendoredDependencies} ${path}'';
+  copyVendorDir = path: ''cp -rs --no-preserve=mode,ownership ${vendoredDependencies} ${path}'';
 }


### PR DESCRIPTION
- vendoring only gets copied to dependencies derivation and from there it is propagated to the main derivation
- vendoring directory is copied recursively as symlinks to reduce the amount of data copied