### PR TITLE
nodejs: support npm-shrinkwrap.json for package-lock translator

### DIFF
--- a/src/subsystems/nodejs/discoverers/discoverer-nodejs/default.nix
+++ b/src/subsystems/nodejs/discoverers/discoverer-nodejs/default.nix
@@ -45,7 +45,7 @@
         && (packageJson.workspaces or [] == [])
       then ["package-lock"]
       else
-        l.optionals (tree.files ? "package-lock.json") ["package-lock"]
+        l.optionals (tree.files ? "npm-shrinkwrap.json" || tree.files ? "package-lock.json") ["package-lock"]
         ++ l.optionals (tree.files ? "yarn.lock") ["yarn-lock"]
         ++ ["package-json"];
   in

--- a/src/subsystems/nodejs/translators/package-lock/default.nix
+++ b/src/subsystems/nodejs/translators/package-lock/default.nix
@@ -8,8 +8,16 @@
   l = lib // builtins;
   nodejsUtils = import ../utils.nix {inherit dlib lib;};
 
+  getPackageLockPath = tree: project: let
+    parent = nodejsUtils.getWorkspaceParent project;
+    node = tree.getNodeFromPath parent;
+  in
+    if node.files ? "npm-shrinkwrap.json"
+    then "npm-shrinkwrap.json"
+    else "package-lock.json";
+
   getPackageLock = tree: project:
-    nodejsUtils.getWorkspaceLockFile tree project "package-lock.json";
+    nodejsUtils.getWorkspaceLockFile tree project (getPackageLockPath tree project);
 
   translate = {
     project,
@@ -109,7 +117,7 @@
               else
                 l.trace
                 ''
-                  WARNING: could not find dependency ${name} in package-lock.json
+                  WARNING: could not find dependency ${name} in ${getPackageLockPath args.tree project}
                   This might be expected for bundled dependencies of sub-dependencies.
                 ''
                 false)

--- a/src/subsystems/nodejs/translators/utils.nix
+++ b/src/subsystems/nodejs/translators/utils.nix
@@ -16,12 +16,14 @@ in rec {
     (packageJson.dependencies or {})
     // (lib.optionalAttrs (! noDev) (packageJson.devDependencies or {}));
 
+  getWorkspaceParent = project:
+    if project ? subsystemInfo.workspaceParent
+    then "${project.subsystemInfo.workspaceParent}"
+    else "${project.relPath}";
+
   getWorkspaceLockFile = tree: project: fname: let
     # returns the parsed package-lock.json for a given project
-    dirRelPath =
-      if project ? subsystemInfo.workspaceParent
-      then "${project.subsystemInfo.workspaceParent}"
-      else "${project.relPath}";
+    dirRelPath = getWorkspaceParent project;
 
     packageJson =
       (tree.getNodeFromPath "${dirRelPath}/package.json").jsonContent;


### PR DESCRIPTION
[npm-shrinkwrap.json](https://docs.npmjs.com/cli/v8/configuring-npm/npm-shrinkwrap-json) is an alternative to package-lock.json that follows the same format. It is typically used with applications (rather than libraries) distributed via npm's registry. This change detects its presence and feeds it through the package-lock translator if it exists.

Per the npm documentation, npm-shrinkwrap.json takes precedence over package-lock.json.