### PR TITLE
Fix: make sourceRoot emulate normal nodejs build

### DIFF
--- a/src/subsystems/nodejs/builders/granular-nodejs/default.nix
+++ b/src/subsystems/nodejs/builders/granular-nodejs/default.nix
@@ -447,6 +447,11 @@
           buildPhase = ''
             runHook preBuild
 
+            cd $out
+            mv $sourceRoot $out/src
+            ln -s $out/src $sourceRoot
+            cd $out/src
+
             # execute electron-rebuild
             if [ -n "$electronHeaders" ]; then
               echo "executing electron-rebuild"
@@ -474,6 +479,9 @@
                 npm --production --offline --nodedir=$nodeSources run postinstall
               fi
             fi
+
+            rm $sourceRoot
+            mv $out/src $sourceRoot
 
             runHook postBuild
           '';


### PR DESCRIPTION
This is currently just a small hack provided by @max-privatevoid on matrix that's worked as expected in several places.

A lot of problems come up when building using the granular builder in nodejs because the directory structure in dream2nix's outputs `$out/lib/node_modules/` is a bit different than what node module resolvers expect, causing the inability to find eachother.

Fixes:
https://github.com/nix-community/dream2nix/issues/237
https://github.com/nix-community/dream2nix/issues/303
Potentially fixes:
https://github.com/nix-community/dream2nix/issues/120
https://github.com/nix-community/dream2nix/issues/158
https://github.com/nix-community/dream2nix/issues/324