### PR TITLE
Dev shell example

### DIFF
--- a/examples/_d2n-extend-devShell/flake.nix
+++ b/examples/_d2n-extend-devShell/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    src.url = "github:prettier/prettier/2.4.1";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp: let
+    nixpkgs = dream2nix.inputs.nixpkgs;
+    l = nixpkgs.lib // builtins;
+
+    systems = ["x86_64-linux"];
+    forAllSystems = f:
+      l.genAttrs systems (
+        system:
+          f system (nixpkgs.legacyPackages.${system})
+      );
+
+    d2n-flake = dream2nix.lib.makeFlakeOutputs {
+      inherit systems;
+      config.projectRoot = ./.;
+      source = src;
+    };
+  in
+    dream2nix.lib.dlib.mergeFlakes [
+      d2n-flake
+      {
+        devShells = forAllSystems (system: pkgs: {
+          prettier = d2n-flake.devShells.${system}.prettier.overrideAttrs (old: {
+            buildInputs =
+              old.buildInputs
+              ++ [
+                pkgs.hello
+              ];
+          });
+        });
+      }
+      {
+        checks.x86_64-linux.prettier = self.packages.x86_64-linux.prettier;
+      }
+    ];
+}

--- a/examples/nodejs_prettier/flake.nix
+++ b/examples/nodejs_prettier/flake.nix
@@ -9,13 +9,36 @@
     self,
     dream2nix,
     src,
-  } @ inp:
-    (dream2nix.lib.makeFlakeOutputs {
+  } @ inp: let
+    d2n-flake = dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-    })
-    // {
+    };
+
+    overrideDevShells = {
+      devShells =
+        d2n-flake.devShells
+        // {
+          x86_64-linux =
+            d2n-flake.devShells.x86_64-linux
+            // {
+              default =
+                d2n-flake.devShells.x86_64-linux.default.overrideAttrs
+                (old: {
+                  buildInputs =
+                    old.buildInputs
+                    ++ [
+                      self.packages.x86_64-linux.hello
+                    ];
+                });
+            };
+        };
+    };
+
+    addChecks = {
       checks.x86_64-linux.prettier = self.packages.x86_64-linux.prettier;
     };
+  in
+    d2n-flake // overrideDevShells // addChecks;
 }

--- a/examples/nodejs_prettier/flake.nix
+++ b/examples/nodejs_prettier/flake.nix
@@ -9,36 +9,13 @@
     self,
     dream2nix,
     src,
-  } @ inp: let
-    d2n-flake = dream2nix.lib.makeFlakeOutputs {
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-    };
-
-    overrideDevShells = {
-      devShells =
-        d2n-flake.devShells
-        // {
-          x86_64-linux =
-            d2n-flake.devShells.x86_64-linux
-            // {
-              default =
-                d2n-flake.devShells.x86_64-linux.default.overrideAttrs
-                (old: {
-                  buildInputs =
-                    old.buildInputs
-                    ++ [
-                      self.packages.x86_64-linux.hello
-                    ];
-                });
-            };
-        };
-    };
-
-    addChecks = {
+    })
+    // {
       checks.x86_64-linux.prettier = self.packages.x86_64-linux.prettier;
     };
-  in
-    d2n-flake // overrideDevShells // addChecks;
 }

--- a/src/default.nix
+++ b/src/default.nix
@@ -609,17 +609,8 @@ in let
       };
 
     projectOutputs = l.map outputsForProject translatedProjects;
-
-    mergedOutputs = let
-      isNotDrvAttrs = val:
-        l.isAttrs val && (val.type or "") != "derivation";
-      recursiveUpdateUntilDrv =
-        l.recursiveUpdateUntil
-        (_: l: r: !(isNotDrvAttrs l && isNotDrvAttrs r));
-    in
-      l.foldl' recursiveUpdateUntilDrv {} projectOutputs;
   in
-    mergedOutputs;
+    dlib.mergeFlakes projectOutputs;
 
   generateImpureResolveScript = {
     source,


### PR DESCRIPTION
This introduces dlib.mergeFlakes, making at a bit easier to extend the dream2nix generated flake outputs with other flake outputs.
An example is added demonstrating how to extend a devShell generated by dream2nix.