### PR TITLE
feat: make crane builder more easily configurable

### DIFF
--- a/docs/src/subsystems/rust.md
+++ b/docs/src/subsystems/rust.md
@@ -24,6 +24,13 @@ Builds a package using [`crane`](https://github.com/ipetkov/crane).
 This builder builds two separate derivations, one for dependencies and the other for your crate.
 The dependencies derivation will be named `<crate>-deps` where `<crate>` is the name of the crate you are building.
 
+#### Setting profile and Cargo flags
+
+This can be done via setting environment variables:
+
+- `cargoTestFlags` and `cargoBuildFlags` are passed to `cargo` invocations for `checkPhase` and `buildPhase` respectively.
+- `cargoTestProfile` and `cargoBuildProfile` are used as profiles while compiling for `checkPhase` and `buildPhase` respectively.
+
 #### Override gotchas
 
 This builder builds two separate derivations, one for your crate's dependencies and another for your crate.

--- a/examples/_d2n-extended/flake.nix
+++ b/examples/_d2n-extended/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     dream2nix.url = "path:../..";
-    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.url = "github:yusdacra/linemd/v0.4.0";
     src.flake = false;
   };
 

--- a/examples/_d2n-extended/flake.nix
+++ b/examples/_d2n-extended/flake.nix
@@ -58,6 +58,6 @@
       ];
     })
     // {
-      checks.x86_64-linux.ripgrep = self.packages.x86_64-linux.ripgrep;
+      checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
     };
 }

--- a/examples/_d2n-flake-parts/flake.nix
+++ b/examples/_d2n-flake-parts/flake.nix
@@ -20,7 +20,7 @@
 
       perSystem = {config, ...}: {
         # define an input for dream2nix to generate outputs for
-        dream2nix.inputs."ripgrep" = {
+        dream2nix.inputs."linemd" = {
           source = src;
           settings = [{builder = "crane";}];
         };

--- a/examples/_d2n-flake-parts/flake.nix
+++ b/examples/_d2n-flake-parts/flake.nix
@@ -3,7 +3,7 @@
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.url = "github:yusdacra/linemd/v0.4.0";
     src.flake = false;
   };
 

--- a/examples/_d2n-init-pkgs/flake.nix
+++ b/examples/_d2n-init-pkgs/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     dream2nix.url = "path:../..";
-    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.url = "github:yusdacra/linemd/v0.4.0";
     src.flake = false;
   };
 

--- a/examples/_d2n-init-pkgs/flake.nix
+++ b/examples/_d2n-init-pkgs/flake.nix
@@ -32,7 +32,7 @@
     in rec {
       packages.${pkgs.system} = outputs.packages;
       checks.${pkgs.system} = {
-        inherit (outputs.packages) ripgrep;
+        inherit (outputs.packages) linemd;
       };
     };
 

--- a/examples/rust_no-cargo-lock/flake.nix
+++ b/examples/rust_no-cargo-lock/flake.nix
@@ -22,6 +22,6 @@
       ];
     })
     // {
-      checks.x86_64-linux.rand = self.packages.x86_64-linux.rand;
+      checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
     };
 }

--- a/examples/rust_no-cargo-lock/flake.nix
+++ b/examples/rust_no-cargo-lock/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
-    src.url = "github:rust-random/rand";
+    src.url = "github:yusdacra/linemd/v0.4.0";
     src.flake = false;
   };
 

--- a/examples/rust_set-rust-toolchain/flake.nix
+++ b/examples/rust_set-rust-toolchain/flake.nix
@@ -48,6 +48,6 @@
       };
     })
     // {
-      checks.x86_64-linux.ripgrep = self.packages.x86_64-linux.ripgrep;
+      checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
     };
 }

--- a/examples/rust_set-rust-toolchain/flake.nix
+++ b/examples/rust_set-rust-toolchain/flake.nix
@@ -5,7 +5,7 @@
     fenix.inputs.nixpkgs.follows = "nixpkgs";
     dream2nix.url = "github:nix-community/dream2nix";
     dream2nix.inputs.nixpkgs.follows = "nixpkgs";
-    src.url = "github:BurntSushi/ripgrep/13.0.0";
+    src.url = "github:yusdacra/linemd/v0.4.0";
     src.flake = false;
   };
 

--- a/overrides/rust/default.nix
+++ b/overrides/rust/default.nix
@@ -27,4 +27,7 @@ in rec {
     # the tests seem to be undeterministic if ran in parallel
     disable-parallel-tests.RUST_TEST_THREADS = 1;
   };
+  linemd = {
+    fix-tests.cargoTestFlags = "--features svg";
+  };
 }

--- a/src/subsystems/rust/builders/crane/default.nix
+++ b/src/subsystems/rust/builders/crane/default.nix
@@ -68,9 +68,12 @@
           ${replacePaths}
         '';
 
+        cargoTestProfile = "release";
+        cargoBuildProfile = "release";
+
         # Make sure cargo only builds & tests the package we want
-        cargoBuildCommand = "cargo build \${cargoBuildFlags:-} --release --package ${pname}";
-        cargoTestCommand = "cargo test \${cargoTestFlags:-} --release --package ${pname}";
+        cargoBuildCommand = "cargo build \${cargoBuildFlags:-} --profile \${cargoBuildProfile} --package ${pname}";
+        cargoTestCommand = "cargo test \${cargoTestFlags:-} --profile \${cargoTestProfile} --package ${pname}";
       };
 
       # The deps-only derivation will use this as a prefix to the `pname`

--- a/src/subsystems/rust/builders/crane/default.nix
+++ b/src/subsystems/rust/builders/crane/default.nix
@@ -69,8 +69,8 @@
         '';
 
         # Make sure cargo only builds & tests the package we want
-        cargoBuildCommand = "cargo build --release --package ${pname}";
-        cargoTestCommand = "cargo test --release --package ${pname}";
+        cargoBuildCommand = "cargo build \${cargoBuildFlags:-} --release --package ${pname}";
+        cargoTestCommand = "cargo test \${cargoTestFlags:-} --release --package ${pname}";
       };
 
       # The deps-only derivation will use this as a prefix to the `pname`


### PR DESCRIPTION
Introduces new env vars for crane builder:

- `cargoTestProfile` and `cargoBuildProfile` for setting the profile to be used when compiling
- `cargoTestFlags` and `cargoBuildFlags` for setting arbitrary flags

This is so that users can easily set flags and profile, like you can do already with `buildRustPackage` builder since that also uses env vars for these.

Also changes some of the projects used in Rust examples to reduce load on CI (we may also want to change other examples like the php composer example which seems to take a long time to build)