### PR TITLE
No discovery

### DIFF
--- a/examples/_d2n-define-projects-manually/flake.nix
+++ b/examples/_d2n-define-projects-manually/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    nixpkgs.follows = "dream2nix/nixpkgs";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    src.url = "github:prettier/prettier/2.4.1";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    flake-parts,
+    src,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit self;} {
+      systems = ["x86_64-linux"];
+      imports = [dream2nix.flakeModuleBeta];
+
+      perSystem = {config, ...}: {
+        # define an input for dream2nix to generate outputs for
+        dream2nix.inputs."prettier" = {
+          source = src;
+          projects = {
+            prettier = {
+              name = "prettier";
+              subsystem = "nodejs";
+              translator = "yarn-lock";
+            };
+          };
+        };
+      };
+    };
+}

--- a/src/default.nix
+++ b/src/default.nix
@@ -644,7 +644,7 @@ in let
     source ? throw "pass a 'source' to 'makeOutputs'",
     discoveredProjects ?
       framework.functions.discoverers.discoverProjects {
-        inherit projects settings source;
+        inherit settings source;
       },
     pname ? null,
     projects ? {},

--- a/src/default.nix
+++ b/src/default.nix
@@ -609,7 +609,7 @@ in let
 
   generateImpureResolveScript = {
     source,
-    impureDiscoveredProjects,
+    impureProjects,
   }: let
     impureResolveScriptsList =
       l.listToAttrs
@@ -621,7 +621,7 @@ in let
             "Name: ${project.name}; Subsystem: ${project.subsystem or "?"}; relPath: ${project.relPath}"
             (utils.makeTranslateScript {inherit project source;})
         )
-        impureDiscoveredProjects
+        impureProjects
       );
 
     resolveImpureScript =
@@ -653,20 +653,40 @@ in let
     sourceOverrides ? old: {},
     inject ? {},
   }: let
-    impureDiscoveredProjects =
+    # if projects are defined manually, ignore discoveredProjects
+    finalProjects =
+      if projects != {}
+      then let
+        projectsList = l.attrValues projects;
+      in
+        # skip discovery and just add required attributes to project list
+        l.forEach projectsList
+        (proj:
+          proj
+          // {
+            relPath = proj.relPath or "";
+            translator = proj.translator or (l.head proj.translators);
+            dreamLockPath =
+              framework.functions.discoverers.getDreamLockPath
+              proj
+              (l.head projectsList);
+          })
+      else discoveredProjects;
+
+    impureProjects =
       l.filter
       (proj:
         framework.translators."${proj.translator}".type
         == "impure")
-      discoveredProjects;
+      finalProjects;
 
     resolveImpureScript = generateImpureResolveScript {
-      inherit impureDiscoveredProjects source;
+      inherit impureProjects source;
     };
 
     translatedProjects = translateProjects {
+      discoveredProjects = finalProjects;
       inherit
-        discoveredProjects
         pname
         settings
         source
@@ -702,7 +722,7 @@ in let
               or by resolving all impure projects by running the `resolveImpure` package
             '';
           })
-        impureDiscoveredProjects);
+        impureProjects);
   in
     realizedProjects
     // {

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -110,19 +110,38 @@
     dream2nixFor = l.mapAttrs (_: pkgs: initD2N pkgs) allPkgs;
 
     discoveredProjects = framework.functions.discoverers.discoverProjects {
-      inherit projects settings;
+      inherit settings;
       tree = dlib.prepareSourceTree {inherit source;};
     };
+
+    finalProjects =
+      if projects != {}
+      then let
+        projectsList = l.attrValues projects;
+      in
+        # skip discovery and just add required attributes to project list
+        l.forEach projectsList
+        (proj:
+          proj
+          // {
+            relPath = proj.relPath or "";
+            translator = proj.translator or (l.head proj.translators);
+            dreamLockPath =
+              framework.functions.discoverers.getDreamLockPath
+              proj
+              (l.head projectsList);
+          })
+      else discoveredProjects;
 
     allBuilderOutputs =
       l.mapAttrs
       (system: pkgs: let
         dream2nix = dream2nixFor."${system}";
         allOutputs = dream2nix.makeOutputs {
+          discoveredProjects = finalProjects;
           inherit
             source
             pname
-            discoveredProjects
             settings
             sourceOverrides
             packageOverrides
@@ -145,7 +164,7 @@
       flakifiedOutputsList;
 
     flakeOutputs =
-      {projectsJson = l.toJSON discoveredProjects;}
+      {projectsJson = l.toJSON finalProjects;}
       // flakeOutputsBuilders;
   in
     flakeOutputs;

--- a/src/modules/flake-parts/implementation.nix
+++ b/src/modules/flake-parts/implementation.nix
@@ -33,7 +33,7 @@ in {
       getAttrFromOutputs = attrName:
         l.mkMerge (
           l.mapAttrsToList
-          (_: output: mkDefaultRecursive output.${attrName})
+          (_: output: mkDefaultRecursive output.${attrName} or {})
           outputs
         );
     in {

--- a/src/modules/functions.discoverers/implementation.nix
+++ b/src/modules/functions.discoverers/implementation.nix
@@ -3,7 +3,6 @@
   dlib = config.dlib;
 
   discoverProjects = {
-    projects,
     source ? throw "Pass either `source` or `tree` to discoverProjects",
     tree ? dlib.prepareSourceTree {inherit source;},
     settings ? [],
@@ -24,7 +23,7 @@
     in
       sorted;
 
-    allProjects = discoveredProjectsSorted ++ (l.attrValues projects);
+    allProjects = discoveredProjectsSorted;
 
     rootProject = l.head allProjects;
 


### PR DESCRIPTION
This change allows to take control over the project definition completely and not use discovery at all.

Here an example flake that builds prettier using the current PR:
```nix
{
  inputs = {
    dream2nix.url = "github:nix-community/dream2nix/ba44952315ea9aa11f45d80b563ffeea996e06bf";
    nixpkgs.follows = "dream2nix/nixpkgs";
    flake-parts.url = "github:hercules-ci/flake-parts";
    src.url = "github:prettier/prettier/2.4.1";
    src.flake = false;
  };

  outputs = {
    self,
    dream2nix,
    flake-parts,
    src,
    ...
  }:
    flake-parts.lib.mkFlake {inherit self;} {
      systems = ["x86_64-linux"];
      imports = [dream2nix.flakeModuleBeta];

      perSystem = {config, ...}: {
        # define an input for dream2nix to generate outputs for
        dream2nix.inputs."prettier" = {
          source = src;
          projects = {
            prettier = {
              name = "prettier";
              subsystem = "nodejs";
              translator = "yarn-lock";
            };
          };
        };
      };
    };
}
```