### PR TITLE
fix: nodejs devShell creates broken links

### DIFF
--- a/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
+++ b/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
@@ -53,13 +53,15 @@ mkShell {
     nodeModulesDir = "${nodeModulesDrv}/lib/node_modules/${packageName}/node_modules";
     binDir = "${nodeModulesDrv}/lib/node_modules/.bin";
   in ''
-    # create the ./node_modules directory
+    # re-create the ./node_modules directory
     rm -rf ./node_modules
     mkdir -p ./node_modules/.bin
     cp -r ${nodeModulesDir}/* ./node_modules/
-    for link in $(ls ${binDir}); do
-      target=$(readlink ${binDir}/$link | cut -d'/' -f4-)
-      ln -s ../$target ./node_modules/.bin/$link
+    for executablePath in ${binDir}/*; do
+      binaryName=$(basename $executablePath)
+      target=$(readlink $executable)
+      echo linking binary $binaryName to nix store: $target
+      ln -s $target ./node_modules/.bin/$binaryName
     done
     chmod -R +w ./node_modules
     export PATH="$PATH:$(realpath ./node_modules)/.bin"

--- a/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
+++ b/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
@@ -59,7 +59,7 @@ mkShell {
     cp -r ${nodeModulesDir}/* ./node_modules/
     for executablePath in ${binDir}/*; do
       binaryName=$(basename $executablePath)
-      target=$(readlink $executable)
+      target=$(readlink $executablePath)
       echo linking binary $binaryName to nix store: $target
       ln -s $target ./node_modules/.bin/$binaryName
     done


### PR DESCRIPTION
The devShell in nodeJs subsystem creates broken symlinks (unrelated to my other current PRs)

fixes the following two problems:

- `../$target` is creating a relative link, but $target already hold an nix store path, which is absolute
- line `for link in $(ls ${binDir}); do` the `ls` command should not be used in shell `for...in` as here an additional `magic` file `->` appears because it tries to split the string that is also holding an -> from the ls command. e.g. `ls $binDir` returns `tsc -> nix/store/..../.bin/tsc` but that string gets splitted and it creates an file for ->
