### PR TITLE
replace readlink by realpath

### DIFF
--- a/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
+++ b/src/subsystems/nodejs/builders/granular-nodejs/devShell.nix
@@ -59,7 +59,7 @@ mkShell {
     cp -r ${nodeModulesDir}/* ./node_modules/
     for executablePath in ${binDir}/*; do
       binaryName=$(basename $executablePath)
-      target=$(readlink $executablePath)
+      target=$(realpath $executablePath)
       echo linking binary $binaryName to nix store: $target
       ln -s $target ./node_modules/.bin/$binaryName
     done


### PR DESCRIPTION
realpath resolves all links recursively where the executable for sure exists. 

Otherwise creating the devShell will fail.

readlink does only resolve one layer of links, which in some cases is not enough as if one link gets cleaned up after build it will break.

@Kazimazi this should resolve your recent problems.
