### PR TITLE
Leverage module system to type check and document `makeOutputs` arguments

### DIFF
--- a/examples/python_poetry/flake.nix
+++ b/examples/python_poetry/flake.nix
@@ -30,7 +30,6 @@
             name = "my-project";
             subsystem = "python";
             translator = "poetry";
-            pythonVersion = "3.10";
             subsystemInfo.system = system;
             subsystemInfo.pythonVersion = "3.10";
           };

--- a/src/modules/flake-parts/implementation.nix
+++ b/src/modules/flake-parts/implementation.nix
@@ -28,12 +28,7 @@ in {
       outputs =
         l.mapAttrs
         (_: args: instance.dream2nix-interface.makeOutputs args)
-        (
-          # Remove empty discoveredProjects so that default argument in makeOutputs is called
-          # TODO(antotocar34) maybe this should be done for all default arguments?
-          lib.filterAttrs (n: v: {n = v;} != {discoveredProjects = [];})
-          config.dream2nix.inputs
-        );
+        config.dream2nix.inputs;
 
       getAttrFromOutputs = attrName:
         l.mkMerge (

--- a/src/modules/flake-parts/implementation.nix
+++ b/src/modules/flake-parts/implementation.nix
@@ -28,7 +28,12 @@ in {
       outputs =
         l.mapAttrs
         (_: args: instance.dream2nix-interface.makeOutputs args)
-        config.dream2nix.inputs;
+        (
+          # Remove empty discoveredProjects so that default argument in makeOutputs is called
+          # TODO(antotocar34) maybe this should be done for all default arguments?
+          lib.filterAttrs (n: v: {n = v;} != {discoveredProjects = [];})
+          config.dream2nix.inputs
+        );
 
       getAttrFromOutputs = attrName:
         l.mkMerge (

--- a/src/modules/flake-parts/interface.nix
+++ b/src/modules/flake-parts/interface.nix
@@ -42,7 +42,7 @@ in {
               '';
             };
             inputs = l.mkOption {
-              type = t.attrsOf t.attrs;
+              type = t.attrsOf (t.submodule (import ./makeOutputsArgs.nix {inherit lib;}));
               default = {};
               description = ''
                 A list of inputs to generate outputs from.

--- a/src/modules/flake-parts/interface.nix
+++ b/src/modules/flake-parts/interface.nix
@@ -42,7 +42,7 @@ in {
               '';
             };
             inputs = l.mkOption {
-              type = t.attrsOf (t.submodule (import ./makeOutputsArgs.nix {inherit lib;}));
+              type = t.attrsOf (t.submodule ./makeOutputsArgs.nix);
               default = {};
               description = ''
                 A list of inputs to generate outputs from.

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -1,0 +1,123 @@
+{lib, ...}: let
+  l = lib // builtins;
+  t = l.types;
+  mkOption = l.options.mkOption;
+
+  project.options = {
+    name = mkOption {
+      description = "name of the project";
+      type = t.str;
+    };
+
+    # TODO(antotocar34) Is the type correct here?
+    relPath = mkOption {
+      default = "";
+      description = "relative path to project tree from source";
+      type = t.str;
+    };
+
+    # TODO(antotocar34) make a smart enum of all available translators conditional on the given the subsystem? Is this possible?
+    translator = mkOption {
+      description = "translators to use";
+      example = ["yarn-lock" "package-json"];
+      type = t.str;
+    };
+
+    # TODO(antotocar34) make an enum of all available subsystems?
+    subsystem = mkOption {
+      description = ''name of subsystem to use. Examples: rust, python, nodejs'';
+      example = "nodejs";
+      type = t.str;
+    };
+
+    subsystemInfo = mkOption {
+      default = {}; # TODO(antotocar34) Does there need to be a default?
+      description = ""; # TODO(antotocar34) what exactly is this?
+      # example = "";
+      type = t.lazyAttrsOf (t.anything);
+    };
+  };
+in {
+  options = {
+    source = mkOption {
+      type = t.either t.path t.package;
+      description = "source of the package to build with dream2nix";
+    };
+
+    projects = mkOption {
+      default = {};
+      type = t.attrsOf (t.submodule project);
+      description = "projects that dream2nix will build";
+    };
+
+    discoveredProjects = mkOption {
+      # Let default be null so we can pass a default argument to makeOutputs
+      default = [];
+      internal = true; # TODO should this option be exposed to the user?
+      # TODO should it be readonly?
+      type = t.nullOr (t.listOf (t.submodule project));
+      description = "the projects found by the discoverer";
+    };
+
+    pname = mkOption {
+      default = null;
+      type = t.nullOr t.str;
+      description = "package name";
+    };
+
+    settings = mkOption {
+      default = [];
+      # TODO(antotocar34) Refine type
+      type = t.listOf t.attrs;
+      example = [
+        {
+          aggregate = true;
+        }
+        {
+          filter = project: project.translator == "package-json";
+          subsystemInfo.npmArgs = "--legacy-peer-deps";
+          subsystemInfo.nodejs = 18;
+        }
+      ];
+      description = "settings to customize dream2nix's behaviour";
+    };
+
+    packageOverrides = mkOption {
+      default = {};
+      type = t.lazyAttrsOf t.attrs;
+      # TODO(antotocar34) is this the right description
+      description = "Overrides to customize build logic for certain dependencies";
+    };
+
+    sourceOverrides = mkOption {
+      default = old: {};
+      type = t.functionTo (t.lazyAttrsOf (t.listOf t.package));
+      description = ""; # TODO(antotocar34) find a suitable description
+      example = oldSources: {
+        bar."13.2.0" = builtins.fetchTarball {
+          url = "https://example.com/example.tar.gz";
+          sha256 = "";
+        };
+        baz."1.0.0" = builtins.fetchTarball {
+          url = "https://example2.com/example2.tar.gz";
+          sha256 = "";
+        };
+      };
+    };
+
+    inject = mkOption {
+      default = {};
+      type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
+      description = ""; # TODO(antotocar34) find a suitable description
+      example = {
+        foo."6.4.1" = [
+          ["bar" "13.2.0"]
+          ["baz" "1.0.0"]
+        ];
+        "@tiptap/extension-code"."2.0.0-beta.26" = [
+          ["@tiptap/core" "2.0.0-beta.174"]
+        ];
+      };
+    };
+  };
+}

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -50,15 +50,6 @@ in {
       description = "projects that dream2nix will build";
     };
 
-    discoveredProjects = mkOption {
-      # Let default be null so we can pass a default argument to makeOutputs
-      default = [];
-      internal = true; # TODO should this option be exposed to the user?
-      # TODO should it be readonly?
-      type = t.nullOr (t.listOf (t.submodule project));
-      description = "the projects found by the discoverer";
-    };
-
     pname = mkOption {
       default = null;
       type = t.nullOr t.str;

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -5,35 +5,33 @@
 
   project.options = {
     name = mkOption {
-      description = "name of the project";
+      description = "Name of the project";
       type = t.str;
     };
 
-    # TODO(antotocar34) Is the type correct here?
     relPath = mkOption {
       default = "";
-      description = "relative path to project tree from source";
+      description = "Relative path to project tree from source";
       type = t.str;
     };
 
     # TODO(antotocar34) make a smart enum of all available translators conditional on the given the subsystem? Is this possible?
     translator = mkOption {
-      description = "translators to use";
+      description = "Translators to use";
       example = ["yarn-lock" "package-json"];
       type = t.str;
     };
 
     # TODO(antotocar34) make an enum of all available subsystems?
     subsystem = mkOption {
-      description = ''name of subsystem to use. Examples: rust, python, nodejs'';
+      description = ''Name of subsystem to use. Examples: rust, python, nodejs'';
       example = "nodejs";
       type = t.str;
     };
 
     subsystemInfo = mkOption {
-      default = {}; # TODO(antotocar34) Does there need to be a default?
-      description = ""; # TODO(antotocar34) what exactly is this?
-      # example = "";
+      default = {};
+      description = "Translator specific arguments";
       type = t.lazyAttrsOf (t.anything);
     };
   };
@@ -41,24 +39,23 @@ in {
   options = {
     source = mkOption {
       type = t.either t.path t.package;
-      description = "source of the package to build with dream2nix";
+      description = "Source of the package to build with dream2nix";
     };
 
     projects = mkOption {
       default = {};
       type = t.attrsOf (t.submodule project);
-      description = "projects that dream2nix will build";
+      description = "Projects that dream2nix will build";
     };
 
     pname = mkOption {
       default = null;
       type = t.nullOr t.str;
-      description = "package name";
+      description = "The name of the package to be built with dream2nix";
     };
 
     settings = mkOption {
       default = [];
-      # TODO(antotocar34) Refine type
       type = t.listOf t.attrs;
       example = [
         {
@@ -70,45 +67,61 @@ in {
           subsystemInfo.nodejs = 18;
         }
       ];
-      description = "settings to customize dream2nix's behaviour";
+      description = ''        Settings to customize dream2nix's behaviour.
+
+                This is likely to be removed in the future:
+                Quote from DavHau @ https://github.com/nix-community/dream2nix/pull/399/files#r1036801060:
+                Eventually this option should be removed.
+                This custom settings merging logic I once implemented is an ugly quick hack,
+                and not needed anymore since we now have the module system for merging options.
+      '';
     };
 
     packageOverrides = mkOption {
       default = {};
       type = t.lazyAttrsOf t.attrs;
-      # TODO(antotocar34) is this the right description
-      description = "Overrides to customize build logic for certain dependencies";
+      description = "Overrides to customize build logic for dependencies or top-level packages";
     };
 
     sourceOverrides = mkOption {
       default = old: {};
       type = t.functionTo (t.lazyAttrsOf (t.listOf t.package));
-      description = ""; # TODO(antotocar34) find a suitable description
-      example = oldSources: {
+      description = ''
+        Override the sources of dependencies or top-level packages.
+        For more details, refer to
+        https://nix-community.github.io/dream2nix/intro/override-system.html
+      '';
+      example = l.literalExpression ''
+        oldSources: {
         bar."13.2.0" = builtins.fetchTarball {
           url = "https://example.com/example.tar.gz";
-          sha256 = "";
+          sha256 = "sha256-0000000000000000000000000000000000000000000=";
         };
         baz."1.0.0" = builtins.fetchTarball {
           url = "https://example2.com/example2.tar.gz";
-          sha256 = "";
+          sha256 = "sha256-0000000000000000000000000000000000000000000=";
         };
-      };
+      '';
     };
+  };
 
-    inject = mkOption {
-      default = {};
-      type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
-      description = ""; # TODO(antotocar34) find a suitable description
-      example = {
-        foo."6.4.1" = [
-          ["bar" "13.2.0"]
-          ["baz" "1.0.0"]
-        ];
-        "@tiptap/extension-code"."2.0.0-beta.26" = [
-          ["@tiptap/core" "2.0.0-beta.174"]
-        ];
-      };
-    };
+  inject = mkOption {
+    default = {};
+    type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
+    description = "Inject missing dependencies into the dependency tree"; # TODO(antotocar34) find a suitable description
+    example =
+      l.literalExpression
+      # TODO(DavHau) don't require specifying the version here. This will break as soon as the dependencies get updated
+      ''
+        {
+          foo."6.4.1" = [
+            ["bar" "13.2.0"]
+            ["baz" "1.0.0"]
+          ];
+          "@tiptap/extension-code"."2.0.0-beta.26" = [
+            ["@tiptap/core" "2.0.0-beta.174"]
+          ];
+        };
+      '';
   };
 }

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -103,25 +103,25 @@ in {
         };
       '';
     };
-  };
 
-  inject = mkOption {
-    default = {};
-    type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
-    description = "Inject missing dependencies into the dependency tree"; # TODO(antotocar34) find a suitable description
-    example =
-      l.literalExpression
-      # TODO(DavHau) don't require specifying the version here. This will break as soon as the dependencies get updated
-      ''
-        {
-          foo."6.4.1" = [
-            ["bar" "13.2.0"]
-            ["baz" "1.0.0"]
-          ];
-          "@tiptap/extension-code"."2.0.0-beta.26" = [
-            ["@tiptap/core" "2.0.0-beta.174"]
-          ];
-        };
-      '';
+    inject = mkOption {
+      default = {};
+      type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
+      description = "Inject missing dependencies into the dependency tree"; # TODO(antotocar34) find a suitable description
+      example =
+        l.literalExpression
+        # TODO(DavHau) don't require specifying the version here. This will break as soon as the dependencies get updated
+        ''
+          {
+            foo."6.4.1" = [
+              ["bar" "13.2.0"]
+              ["baz" "1.0.0"]
+            ];
+            "@tiptap/extension-code"."2.0.0-beta.26" = [
+              ["@tiptap/core" "2.0.0-beta.174"]
+            ];
+          };
+        '';
+    };
   };
 }


### PR DESCRIPTION
Defines a module in `./src/modules/flake-parts/makeOutputsArgs.nix` , which defines an option for each argument that the `makeOutputs` function expects.

I've left TODO comments around the place where I'm not certain about things. 

Goes some way towards fixing #320

