### PR TITLE
Poetry: support build requirements

### DIFF
--- a/src/specifications/subsystems/python/dream-lock-schema.json
+++ b/src/specifications/subsystems/python/dream-lock-schema.json
@@ -11,7 +11,11 @@
           "type": "object"
         },
         "application": { "type": "boolean" },
-        "pythonAttr": { "type": "string" }
+        "pythonAttr": { "type": "string" },
+        "buildRequirements": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
       }
     }
   }

--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -39,10 +39,10 @@
 
     buildRequirements =
       l.map
-        # We strip the version constraint, because we currently use the version in nixpkgs.
-        (requirement:
-          python.pkgs.${l.head (builtins.match "([^<>=]+).*" requirement)})
-        (subsystemAttrs.buildRequirements or []);
+      # We strip the version constraint, because we currently use the version in nixpkgs.
+      (requirement:
+        python.pkgs.${l.head (builtins.match "([^<>=]+).*" requirement)})
+      (subsystemAttrs.buildRequirements or []);
 
     package = produceDerivation defaultPackageName (buildFunc {
       name = defaultPackageName;
@@ -78,7 +78,8 @@
         # Some packages have another package as a dependency *and* as a buildRequirement.
         # In this case, pip tries to uninstall the buildRequirement before installing the dependency and fails
         # as it can't delete something in the nix store. So we patch PYTHONPATH to remove the buildRequirement in installPhase.
-        removeBuildRequirements = l.concatMapStringsSep "\n"
+        removeBuildRequirements =
+          l.concatMapStringsSep "\n"
           (requirement: "export PYTHONPATH=\${PYTHONPATH//\"${requirement}/lib/${python.libPrefix}/site-packages\"}")
           buildRequirements;
       in ''

--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -37,6 +37,8 @@
       (src: src.original or src)
       allDependencySources';
 
+    buildRequirements = lib.concatStringsSep " " (subsystemAttrs.buildRequirements or []);
+
     package = produceDerivation defaultPackageName (buildFunc {
       name = defaultPackageName;
       src = getSource defaultPackageName defaultPackageVersion;
@@ -72,7 +74,7 @@
           --no-cache \
           --ignore-installed \
           $pipInstallFlags"
-        ${python}/bin/python -m pip install $pipInstallFlags ${lib.concatStringsSep " " subsystemAttrs.buildRequirements}
+        ${lib.optionalString (buildRequirements != "") "${python}/bin/python -m pip install $pipInstallFlags ${buildRequirements}"}
         ${python}/bin/python -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .
         ${python}/bin/python -m pip install $pipInstallFlags .\
       '';

--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -48,13 +48,14 @@
       name = defaultPackageName;
       src = getSource defaultPackageName defaultPackageVersion;
       format = "other";
-      buildInputs = [pkgs.pythonManylinuxPackages.manylinux1] ++ buildRequirements;
+      buildInputs = pkgs.pythonManylinuxPackages.manylinux1;
       nativeBuildInputs =
         [pkgs.autoPatchelfHook]
         ++ (with python.pkgs; [
           pip
           wheel
-        ]);
+        ])
+        ++ buildRequirements;
       propagatedBuildInputs = [python.pkgs.setuptools];
       doCheck = false;
       dontStrip = true;

--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -72,13 +72,14 @@
           --no-warn-script-location \
           --prefix="$out" \
           --no-cache \
-          --ignore-installed \
           $pipInstallFlags"
         ${lib.optionalString (buildRequirements != "") "${python}/bin/python -m pip install $pipInstallFlags ${buildRequirements}"}
         ${python}/bin/python -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .
-        ${python}/bin/python -m pip install $pipInstallFlags .\
       '';
-      installPhase = "true";
+
+      installPhase = ''
+        ${python}/bin/python -m pip install $pipInstallFlags dist/*
+      '';
     });
 
     devShell = pkgs.mkShell {

--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -71,7 +71,7 @@
 
         mkdir -p "$out/${python.sitePackages}"
         export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
-        ${python}/bin/python -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .
+        ${python.interpreter} -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .
       '';
 
       installPhase = let
@@ -92,7 +92,7 @@
           --prefix="$out" \
           --no-cache \
           $pipInstallFlags"
-        ${python}/bin/python -m pip install $pipInstallFlags dist/*
+        ${python.interpreter} -m pip install $pipInstallFlags dist/*
       '';
     });
 

--- a/src/subsystems/python/translators/poetry/default.nix
+++ b/src/subsystems/python/translators/poetry/default.nix
@@ -115,6 +115,7 @@ in {
         application = false;
         pythonAttr = "python3";
         sourceFormats = {};
+        buildRequirements = pyproject.build-system.requires or [];
       };
 
       cyclicDependencies = {};


### PR DESCRIPTION
This is a continuation of my work in #397. It adds rather naive support for a subsystem attr `buildRequirements` in the translator.

This means we can install those `buildRequirements` during `buildPhase` instead of hard-coding packages like `poetry-core` in `buildInputs`. That approach didn't work for packages that explicitly require another version of `poetry-core` than what's in nixpkgs, as `buildPhase` would try and fail to uninstall the nixpkgs version before installing the required version.

It's naive in the sense that it leaves version constraints and platform compatibility tags ("markers") to pip. Which might or might not be a good idea for `buildRequirements`. 

[X] actually install the built wheel
[X] make sure buildRequirements don't leak into the final derivation or use buildRequirements from nixpkgs

Needs to be integrated with  #401