### PR TITLE
Remove makeOutputs from examples

### DIFF
--- a/examples/_d2n-init-pkgs/flake.nix
+++ b/examples/_d2n-init-pkgs/flake.nix
@@ -10,34 +10,19 @@
 
     allPkgs =
       l.map
+      # nixpkgs could be imported manually here with overrides etc.
       (system: inp.dream2nix.inputs.nixpkgs.legacyPackages.${system})
       ["x86_64-linux" "aarch64-linux"];
-
-    initD2N = pkgs:
-      inp.dream2nix.lib.init {
-        inherit pkgs;
-        config.projectRoot = ./.;
-      };
-
-    makeOutputs = pkgs: let
-      outputs = (initD2N pkgs).dream2nix-interface.makeOutputs {
-        source = inp.src;
-        settings = [
-          {
-            builder = "build-rust-package";
-            translator = "cargo-lock";
-          }
-        ];
-      };
-    in rec {
-      packages.${pkgs.system} = outputs.packages;
-      # checks.${pkgs.system} = {
-      #   inherit (outputs.packages) linemd;
-      # };
-    };
-
-    allOutputs = l.map makeOutputs allPkgs;
-    outputs = l.foldl' l.recursiveUpdate {} allOutputs;
   in
-    outputs;
+    inp.dream2nix.lib.makeFlakeOutputs {
+      pkgs = allPkgs;
+      config.projectRoot = ./.;
+      source = inp.src;
+      settings = [
+        {
+          builder = "build-rust-package";
+          translator = "cargo-lock";
+        }
+      ];
+    };
 }

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -53,8 +53,7 @@
       if l.isList pkgsList
       then
         l.listToAttrs
-        (pkgs: l.nameValuePair (makePkgsKey pkgs) pkgs)
-        pkgsList
+        (map (pkgs: l.nameValuePair (makePkgsKey pkgs) pkgs) pkgsList)
       else {"${makePkgsKey pkgsList}" = pkgsList;}
     # only systems is specified
     else


### PR DESCRIPTION
I'd like to reduce the API surface, so the overhead in maintaining backwards compatibility is lower.
Therefore I'd like to remove makeOutputs from the examples and not promote its use anymore.

The only example where it is used is the one for `importing nixpkgs manually`.
But there is no reason to use makeOutputs for this anyways. This can be done with makeFlakeOutputs as well and is even easier. There was just a [bug that I needed to fix](https://github.com/nix-community/dream2nix/commit/e4a682ba0e81b617b428fcb81983978a57010a53).

@yusdacra I saw that you are using `makeOutputs` in nix-cargo-integration. Would you be OK, with changing to makeFlakeOutputs? Then there would only one function for which we need to ensure backwards compatibility. Everything else becomes playground and future refactoring should become easier.