### PR TITLE
fix dream-lock example & schema

### DIFF
--- a/src/specifications/dream-lock-example.json
+++ b/src/specifications/dream-lock-example.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "requests": {
       "1.2.3": [
-        {"name": "certifi", "name": "2.3.4"}
+        {"name": "certifi", "version": "2.3.4"}
       ]
     }
   },

--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -209,8 +209,17 @@
       "type": "object",
       "properties": {
         "^.*$": {
-          "type": "array",
-          "items": { "type": "string" }
+          "type": "object",
+          "properties": {
+            "^.*$": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string"},
+                "version": { "type": "string"}
+               },
+              "additionalProperties": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes a typo introduced in 2a3582741947e6f6d3bff8344562327d43df7114 and adapts the schema to reflect changes.

@DavHau 