### PR TITLE
Disable automatic project discovery in makeFlakeOutputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Minimal Example `flake.nix`:
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = ./.;
+      projects = ./projects.toml;
     };
 }
 ```
@@ -86,6 +87,7 @@ Extensive Example `flake.nix`:
       config.projectRoot = ./.;
 
       source = ./.;
+      projects = ./projects.toml;
 
       # Configure the behavior of dream2nix when translating projects.
       # A setting applies to all discovered projects if `filter` is unset,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Extensive Example `flake.nix`:
       config.projectRoot = ./.;
 
       source = ./.;
+
+      # `projects` can alternatively be an attrset.
+      # `projects` can be omitted if `autoProjects = true` is defined.
       projects = ./projects.toml;
 
       # Configure the behavior of dream2nix when translating projects.

--- a/docs/src/define-targets.md
+++ b/docs/src/define-targets.md
@@ -32,6 +32,7 @@ Alternatively, we can define the targets in the `flake.nix` like so:
       systems = ["x86_64-linux"];         # <- This line.
       config.projectRoot = ./.;
       source = ./.;
+      projects = ./projects.toml;
     };
 }
 ```

--- a/docs/src/guides/getting-started-nodejs.md
+++ b/docs/src/guides/getting-started-nodejs.md
@@ -60,6 +60,7 @@ to create a `flake.nix`:
       systemsFromFile = ./nix_systems;
       config.projectRoot = ./.;
       source = ./.;
+      projects = ./projects.toml;
     };
 }
 ```
@@ -87,12 +88,11 @@ git+file:///tmp/my_project
 │   └───x86_64-linux
 │       ├───cowsay: development environment 'nix-shell'
 │       └───default: development environment 'nix-shell'
-├───packages
-│   └───x86_64-linux
-│       ├───cowsay: package 'cowsay-1.5.0'
-│       ├───default: package 'cowsay-1.5.0'
-│       └───resolveImpure: package 'resolve'
-└───projectsJson: unknown
+└───packages
+    └───x86_64-linux
+        ├───cowsay: package 'cowsay-1.5.0'
+        ├───default: package 'cowsay-1.5.0'
+        └───resolveImpure: package 'resolve'
 ```
 
 We can see that:
@@ -207,12 +207,11 @@ git+file:///tmp/my_project
 │   └───x86_64-linux
 │       ├───cowsay: development environment 'nix-shell'
 │       └───default: development environment 'nix-shell'
-├───packages
-│   └───x86_64-linux
-│       ├───cowsay: package 'cowsay-1.5.0'
-│       ├───default: package 'cowsay-1.5.0'
-│       └───resolveImpure: package 'resolve'
-└───projectsJson: unknown
+└───packages
+    └───x86_64-linux
+        ├───cowsay: package 'cowsay-1.5.0'
+        ├───default: package 'cowsay-1.5.0'
+        └───resolveImpure: package 'resolve'
 ```
 When we enter the `cowsay` development shell, we will get `node` in our
 `PATH`, together with all the binaries from our dependencies packages.

--- a/docs/src/guides/getting-started-python.md
+++ b/docs/src/guides/getting-started-python.md
@@ -42,11 +42,10 @@ warning: Git tree '/tmp/my_project' is dirty
 warning: creating lock file '/tmp/my_project/flake.lock'
 warning: Git tree '/tmp/my_project' is dirty
 git+file:///tmp/my_project
-├───packages
-│   └───x86_64-linux
-│       ├───main: package 'main'
-│       └───resolveImpure: package 'resolve'
-└───projectsJson: unknown
+└───packages
+    └───x86_64-linux
+        ├───main: package 'main'
+        └───resolveImpure: package 'resolve'
 ```
 
 What we can observe here:
@@ -57,11 +56,10 @@ Our flake.nix imported external libraries. The versions of these libraries have 
 1.
     ```
       git+file:///tmp/my_project
-      ├───packages
-      │   └───x86_64-linux
-      │       ├───main: package 'main'
-      │       └───resolveImpure: package 'resolve'
-      └───projectsJson: unknown
+      └───packages
+          └───x86_64-linux
+              ├───main: package 'main'
+              └───resolveImpure: package 'resolve'
     ```
     Similar like a .json file defines a structure of data, our flake.nix defines a structure of `nix attributes` which are things that we can build or run with nix.
     We can see that it contains packages for my current platform `x86_64-linux`.

--- a/examples/_d2n-auto-project-detection/flake.nix
+++ b/examples/_d2n-auto-project-detection/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    src.url = "github:yusdacra/linemd/v0.4.0";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      source = src;
+      autoProjects = true;
+    })
+    // {
+      # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
+    };
+}

--- a/examples/_d2n-extend-devShell/flake.nix
+++ b/examples/_d2n-extend-devShell/flake.nix
@@ -24,6 +24,7 @@
       inherit systems;
       config.projectRoot = ./.;
       source = src;
+      projects = ./projects.toml;
     };
   in
     dream2nix.lib.dlib.mergeFlakes [

--- a/examples/_d2n-extend-devShell/projects.toml
+++ b/examples/_d2n-extend-devShell/projects.toml
@@ -1,3 +1,9 @@
 # To re-generate this file, run:
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
+
+[prettier]
+name = "prettier"
+relPath = ""
+subsystem = "nodejs"
+translator = "yarn-lock"

--- a/examples/_d2n-extended-new-subsystem/flake.nix
+++ b/examples/_d2n-extended-new-subsystem/flake.nix
@@ -16,12 +16,8 @@
         ./builders.nix
       ];
       source = ./.;
-      settings = [
-        {
-          builder = "dummy";
-          translator = "dummy";
-        }
-      ];
+      # The dummy discoverer will discover a project `hello` automatically.
+      autoProjects = true;
     })
     // {
       checks.x86_64-linux.hello = self.packages.x86_64-linux.hello;

--- a/examples/_d2n-extended/flake.nix
+++ b/examples/_d2n-extended/flake.nix
@@ -50,12 +50,7 @@
         '')
       ];
       source = src;
-      projects.linemd = {
-        name = "linemd";
-        subsystem = "rust";
-        translator = "cargo-toml-new";
-        builder = "brp-new";
-      };
+      projects = ./projects.toml;
     })
     // {
       # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;

--- a/examples/_d2n-extended/flake.nix
+++ b/examples/_d2n-extended/flake.nix
@@ -50,12 +50,12 @@
         '')
       ];
       source = src;
-      settings = [
-        {
-          builder = "brp-new";
-          translator = "cargo-toml-new";
-        }
-      ];
+      projects.linemd = {
+        name = "linemd";
+        subsystem = "rust";
+        translator = "cargo-toml-new";
+        builder = "brp-new";
+      };
     })
     // {
       # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;

--- a/examples/_d2n-extended/projects.toml
+++ b/examples/_d2n-extended/projects.toml
@@ -1,0 +1,16 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[linemd]
+name = "linemd"
+relPath = ""
+subsystem = "rust"
+translator = "cargo-lock"
+translators = [ "cargo-lock", "cargo-toml",]
+
+[[linemd.subsystemInfo.crates]]
+name = "linemd"
+relPath = ""
+version = "0.4.0"
+

--- a/examples/_d2n-init-pkgs/flake.nix
+++ b/examples/_d2n-init-pkgs/flake.nix
@@ -18,11 +18,6 @@
       pkgs = allPkgs;
       config.projectRoot = ./.;
       source = inp.src;
-      settings = [
-        {
-          builder = "build-rust-package";
-          translator = "cargo-lock";
-        }
-      ];
+      projects = ./projects.toml;
     };
 }

--- a/examples/_d2n-init-pkgs/projects.toml
+++ b/examples/_d2n-init-pkgs/projects.toml
@@ -1,0 +1,16 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[linemd]
+name = "linemd"
+relPath = ""
+subsystem = "rust"
+translator = "cargo-lock"
+builder = "build-rust-package"
+
+[[linemd.subsystemInfo.crates]]
+name = "linemd"
+relPath = ""
+version = "0.4.0"
+

--- a/examples/_d2n-projects-as-attrs/flake.nix
+++ b/examples/_d2n-projects-as-attrs/flake.nix
@@ -1,0 +1,28 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    src.url = "github:yusdacra/linemd/v0.4.0";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      source = src;
+      projects = {
+        linemd = {
+          name = "linemd";
+          subsystem = "rust";
+          translator = "cargo-lock";
+        };
+      };
+    })
+    // {
+      # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
+    };
+}

--- a/examples/haskell_cabal-freeze/flake.nix
+++ b/examples/haskell_cabal-freeze/flake.nix
@@ -13,10 +13,6 @@
     systems = ["x86_64-linux"];
     config.projectRoot = ./.;
     source = src;
-    settings = [
-      {
-        translator = "cabal-freeze";
-      }
-    ];
+    projects = ./projects.toml;
   });
 }

--- a/examples/haskell_cabal-freeze/projects.toml
+++ b/examples/haskell_cabal-freeze/projects.toml
@@ -1,3 +1,9 @@
 # To re-generate this file, run:
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
+
+[main]
+name = "main"
+relPath = ""
+subsystem = "haskell"
+translator = "cabal-freeze"

--- a/examples/haskell_cabal-plan/flake.nix
+++ b/examples/haskell_cabal-plan/flake.nix
@@ -14,11 +14,7 @@
       pkgs = dream2nix.inputs.nixpkgs.legacyPackages.x86_64-linux;
       source = src;
       config.projectRoot = ./.;
-      settings = [
-        {
-          translator = "cabal-plan";
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       # checks.x86_64-linux.cabal2json = self.packages.x86_64-linux.cabal2json.overrideAttrs (old: {

--- a/examples/haskell_cabal-plan/projects.toml
+++ b/examples/haskell_cabal-plan/projects.toml
@@ -1,3 +1,9 @@
 # To re-generate this file, run:
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
+
+[main]
+name = "main"
+relPath = ""
+subsystem = "haskell"
+translator = "cabal-plan"

--- a/examples/haskell_stack-lock/flake.nix
+++ b/examples/haskell_stack-lock/flake.nix
@@ -14,15 +14,7 @@
       pkgs = dream2nix.inputs.nixpkgs.legacyPackages.x86_64-linux;
       source = src;
       config.projectRoot = ./.;
-      settings = [
-        {
-          # Optionally, override the compiler version
-          subsystemInfo.compiler = {
-            name = "ghc";
-            version = "8.10.7";
-          };
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       # checks = self.packages;

--- a/examples/haskell_stack-lock/projects.toml
+++ b/examples/haskell_stack-lock/projects.toml
@@ -1,0 +1,14 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[main]
+name = "main"
+relPath = ""
+subsystem = "haskell"
+translator = "stack-lock"
+translators = [ "stack-lock",]
+
+[[main.subsystemInfo.compiler]]
+name = "ghc"
+version = "8.10.7"

--- a/examples/nodejs_eslint-aggreagted/flake.nix
+++ b/examples/nodejs_eslint-aggreagted/flake.nix
@@ -14,12 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          subsystemInfo.noDev = true;
-          aggregate = true;
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       checks = self.packages;

--- a/examples/nodejs_eslint-aggreagted/projects.toml
+++ b/examples/nodejs_eslint-aggreagted/projects.toml
@@ -1,0 +1,15 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[eslint]
+name = "eslint"
+relPath = ""
+subsystem = "nodejs"
+translator = "package-json"
+translators = [ "package-json",]
+
+[eslint.subsystemInfo]
+noDev = true
+noedjs = 18
+aggregated = true

--- a/examples/nodejs_eslint/flake.nix
+++ b/examples/nodejs_eslint/flake.nix
@@ -14,12 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          subsystemInfo.noDev = true;
-          subsystemInfo.nodejs = 18;
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       # checks = self.packages;

--- a/examples/nodejs_eslint/projects.toml
+++ b/examples/nodejs_eslint/projects.toml
@@ -1,0 +1,14 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[eslint]
+name = "eslint"
+relPath = ""
+subsystem = "nodejs"
+translator = "package-json"
+translators = [ "package-json",]
+
+[eslint.subsystemInfo]
+noDev = true
+noedjs = 18

--- a/examples/nodejs_prettier/flake.nix
+++ b/examples/nodejs_prettier/flake.nix
@@ -14,6 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
+      projects = ./projects.toml;
     })
     // {
       checks.x86_64-linux.prettier = self.packages.x86_64-linux.prettier;

--- a/examples/nodejs_prettier/projects.toml
+++ b/examples/nodejs_prettier/projects.toml
@@ -1,3 +1,9 @@
 # To re-generate this file, run:
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
+
+[prettier]
+name = "prettier"
+relPath = ""
+subsystem = "nodejs"
+translator = "yarn-lock"

--- a/examples/nodejs_workspace/flake.nix
+++ b/examples/nodejs_workspace/flake.nix
@@ -11,8 +11,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = ./.;
-      settings = [
-      ];
+      autoProjects = true;
     })
     // {
       checks = self.packages;

--- a/examples/php_composer/flake.nix
+++ b/examples/php_composer/flake.nix
@@ -14,7 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [];
+      projects = ./projects.toml;
     })
     // {
       # checks = self.packages;

--- a/examples/php_composer/projects.toml
+++ b/examples/php_composer/projects.toml
@@ -1,0 +1,12 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+["gipetto/cowsay"]
+name = "gipetto/cowsay"
+relPath = ""
+subsystem = "php"
+translator = "composer-lock"
+translators = [ "composer-lock", "composer-json",]
+
+["gipetto/cowsay".subsystemInfo]

--- a/examples/python_pip/flake.nix
+++ b/examples/python_pip/flake.nix
@@ -14,14 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          # optionally define python version
-          subsystemInfo.pythonVersion = "3.8";
-          # optionally define extra setup requirements;
-          subsystemInfo.extraSetupDeps = ["cython > 0.29"];
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       checks.x86_64-linux.aiohttp = self.packages.x86_64-linux.main;

--- a/examples/python_pip/projects.toml
+++ b/examples/python_pip/projects.toml
@@ -1,0 +1,21 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[llhttp]
+name = "llhttp"
+relPath = "vendor/llhttp"
+subsystem = "nodejs"
+translator = "package-lock"
+
+[main]
+name = "main"
+relPath = ""
+subsystem = "python"
+translator = "pip"
+
+[llhttp.subsystemInfo]
+
+[main.subsystemInfo]
+pythonAttr = "python3"
+pythonVersion = "3.8"

--- a/examples/racket/flake.nix
+++ b/examples/racket/flake.nix
@@ -14,5 +14,6 @@
     systems = ["x86_64-linux"];
     config.projectRoot = ./.;
     source = goblins;
+    projects = ./projects.toml;
   });
 }

--- a/examples/racket/projects.toml
+++ b/examples/racket/projects.toml
@@ -1,3 +1,11 @@
 # To re-generate this file, run:
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
+
+[goblins]
+name = "goblins"
+relPath = "goblins"
+subsystem = "racket"
+translator = "racket-impure"
+
+[goblins.subsystemInfo]

--- a/examples/rust_no-cargo-lock/flake.nix
+++ b/examples/rust_no-cargo-lock/flake.nix
@@ -14,12 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          builder = "crane";
-          translator = "cargo-toml";
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;

--- a/examples/rust_no-cargo-lock/projects.toml
+++ b/examples/rust_no-cargo-lock/projects.toml
@@ -1,0 +1,17 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[linemd]
+name = "linemd"
+relPath = ""
+subsystem = "rust"
+translator = "cargo-toml"
+builder = "crane"
+
+
+[[linemd.subsystemInfo.crates]]
+name = "linemd"
+relPath = ""
+version = "0.4.0"
+

--- a/examples/rust_ripgrep/flake.nix
+++ b/examples/rust_ripgrep/flake.nix
@@ -14,12 +14,7 @@
       systems = ["x86_64-linux"];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          builder = "crane";
-          translator = "cargo-lock";
-        }
-      ];
+      projects = ./projects.toml;
     })
     // {
       # checks.x86_64-linux.ripgrep = self.packages.x86_64-linux.ripgrep;

--- a/examples/rust_ripgrep/projects.toml
+++ b/examples/rust_ripgrep/projects.toml
@@ -1,0 +1,64 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[ripgrep]
+name = "ripgrep"
+relPath = ""
+subsystem = "rust"
+translator = "cargo-lock"
+translators = [ "cargo-lock", "cargo-toml",]
+builder = "crane"
+
+[ripgrep.subsystemInfo]
+workspaceMembers = [ "crates/globset", "crates/grep", "crates/cli", "crates/matcher", "crates/pcre2", "crates/printer", "crates/regex", "crates/searcher", "crates/ignore",]
+[[ripgrep.subsystemInfo.crates]]
+name = "ripgrep"
+relPath = ""
+version = "13.0.0"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-cli"
+relPath = "crates/cli"
+version = "0.1.6"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "globset"
+relPath = "crates/globset"
+version = "0.4.7"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep"
+relPath = "crates/grep"
+version = "0.2.8"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "ignore"
+relPath = "crates/ignore"
+version = "0.4.18"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-matcher"
+relPath = "crates/matcher"
+version = "0.1.5"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-pcre2"
+relPath = "crates/pcre2"
+version = "0.1.5"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-printer"
+relPath = "crates/printer"
+version = "0.1.6"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-regex"
+relPath = "crates/regex"
+version = "0.1.9"
+
+[[ripgrep.subsystemInfo.crates]]
+name = "grep-searcher"
+relPath = "crates/searcher"
+version = "0.1.8"
+

--- a/examples/rust_set-rust-toolchain/flake.nix
+++ b/examples/rust_set-rust-toolchain/flake.nix
@@ -23,12 +23,7 @@
       systems = [system];
       config.projectRoot = ./.;
       source = src;
-      settings = [
-        {
-          builder = "crane";
-          translator = "cargo-lock";
-        }
-      ];
+      projects = ./projects.toml;
       packageOverrides = {
         # override all packages and set a toolchain
         "^.*" = {

--- a/examples/rust_set-rust-toolchain/projects.toml
+++ b/examples/rust_set-rust-toolchain/projects.toml
@@ -1,0 +1,15 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[linemd]
+name = "linemd"
+relPath = ""
+subsystem = "rust"
+translator = "cargo-lock"
+
+[[linemd.subsystemInfo.crates]]
+name = "linemd"
+relPath = ""
+version = "0.4.0"
+

--- a/src/apps/detect-projects/default.nix
+++ b/src/apps/detect-projects/default.nix
@@ -13,9 +13,10 @@ utils.writePureShellScriptBin
 ''
   set -e
 
-  export source=$(realpath .)
+  # Use $1 as source if set. Otherwise default to ./.
+  export source=$(realpath ''${1:-.})
 
   ${apps.callNixWithD2N} eval --json \
-    "dream2nix.framework.functions.discoverers.discoverProjects2 {source = builtins.getEnv \"source\";}" \
+    "dream2nix.functions.discoverers.discoverProjects2 {source = builtins.getEnv \"source\";}" \
     | yq --toml-output
 ''

--- a/src/apps/detect-projects/default.nix
+++ b/src/apps/detect-projects/default.nix
@@ -18,5 +18,6 @@ utils.writePureShellScriptBin
 
   ${apps.callNixWithD2N} eval --json \
     "dream2nix.functions.discoverers.discoverProjects2 {source = builtins.getEnv \"source\";}" \
-    | yq --toml-output
+    | yq --toml-output \
+    | (cat ${./template.toml} && echo "" && cat)
 ''

--- a/src/apps/detect-projects/default.nix
+++ b/src/apps/detect-projects/default.nix
@@ -1,0 +1,21 @@
+{
+  pkgs,
+  utils,
+  apps,
+  ...
+}:
+utils.writePureShellScriptBin
+"detect-projects"
+(with pkgs; [
+  coreutils
+  yq
+])
+''
+  set -e
+
+  export source=$(realpath .)
+
+  ${apps.callNixWithD2N} eval --json \
+    "dream2nix.framework.functions.discoverers.discoverProjects2 {source = builtins.getEnv \"source\";}" \
+    | yq --toml-output
+''

--- a/src/apps/detect-projects/template.toml
+++ b/src/apps/detect-projects/template.toml
@@ -1,0 +1,3 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project

--- a/src/apps/detect-projects/template.toml
+++ b/src/apps/detect-projects/template.toml
@@ -1,3 +1,9 @@
+# projects.toml file describing inputs for dream2nix
+#
 # To re-generate this file, run:
-#   nix run github:nix-community/dream2nix#detect-projects $source
+#   nix run .#detect-projects $source
 # ... where `$source` points to the source of your project.
+#
+# If the local flake is unavailable, alternatively execute the app from the
+# upstream dream2nix flake:
+#   nix run github:nix-community/dream2nix#detect-projects $source

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -182,7 +182,12 @@
             ;
         };
       in
-        allOutputs)
+        framework.dlib.recursiveUpdateUntilDrv
+        allOutputs
+        {
+          apps.detect-projects =
+            dream2nixFor.${system}.flakeApps.detect-projects;
+        })
       allPkgs;
 
     flakifiedOutputsList =

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -75,8 +75,8 @@
     Please pass `projects` to makeFlakeOutputs.
     `projects` can be:
       - an attrset
-      - a path to a .toml file
-      - a path to a .json file
+      - a path to a .toml file (not empty & added to git)
+      - a path to a .json file (not empty & added to git)
 
     To generate a projects.toml file automatically:
       1. execute:

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -195,12 +195,8 @@
       (allOutputs: output: lib.recursiveUpdate allOutputs output)
       {}
       flakifiedOutputsList;
-
-    flakeOutputs =
-      {projectsJson = l.toJSON finalProjects;}
-      // flakeOutputsBuilders;
   in
-    flakeOutputs;
+    flakeOutputsBuilders;
 
   makeFlakeOutputsForIndexes = {
     systems ? [],

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -71,6 +71,24 @@
   }:
     initDream2nix (loadConfig config) pkgs;
 
+  missingProjectsError = ''
+    Please pass `projects` to makeFlakeOutputs.
+    `projects` can be:
+      - an attrset
+      - a path to a .toml file
+      - a path to a .json file
+
+    To generate a projects.toml file automatically:
+      1. execute:
+        nix run github:nix-community/dream2nix#discover-projects > projects.toml
+      2. review the ./projects.toml and edit it if necessary.
+      3. pass `projects = ./projects.toml` to makeFlakeOutputs.
+
+    Alternatively pass `autoProjects = true` to makeFlakeOutputs.
+    This is not recommended as it doesn't allow you to review or filter the list
+      of detected projects.
+  '';
+
   makeFlakeOutputs = {
     source,
     pkgs ? null,
@@ -81,6 +99,7 @@
     pname ? throw "Please pass `pname` to makeFlakeOutputs",
     packageOverrides ? {},
     projects ? {},
+    autoProjects ? false,
     settings ? [],
     sourceOverrides ? oldSources: {},
   } @ args: let
@@ -100,6 +119,21 @@
           inherit config;
           file = systemsFromFile;
         };
+
+    # if projects provided via `.json` or `.toml` file, parse to attrset
+    projects = let
+      givenProjects = args.projects or {};
+    in
+      if autoProjects && args ? projects
+      then throw "Don't pass `projects` to makeFlakeOutputs when `autoProjects = true`"
+      else if l.isPath givenProjects
+      then
+        if ! l.pathExists givenProjects
+        then throw missingProjectsError
+        else if l.hasSuffix ".toml" (l.toString givenProjects)
+        then l.fromTOML (l.readFile givenProjects)
+        else l.fromJSON (l.readFile givenProjects)
+      else givenProjects;
 
     allPkgs = makeNixpkgs pkgs systems;
 
@@ -128,7 +162,9 @@
               proj
               (l.head projectsList);
           })
-      else discoveredProjects;
+      else if autoProjects == true
+      then discoveredProjects
+      else throw missingProjectsError;
 
     allBuilderOutputs =
       l.mapAttrs

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -71,7 +71,7 @@
   }:
     initDream2nix (loadConfig config) pkgs;
 
-  missingProjectsError = ''
+  missingProjectsError = source: ''
     Please pass `projects` to makeFlakeOutputs.
     `projects` can be:
       - an attrset
@@ -80,7 +80,7 @@
 
     To generate a projects.toml file automatically:
       1. execute:
-        nix run github:nix-community/dream2nix#discover-projects > projects.toml
+        nix run github:nix-community/dream2nix#detect-projects ${source} > projects.toml
       2. review the ./projects.toml and edit it if necessary.
       3. pass `projects = ./projects.toml` to makeFlakeOutputs.
 
@@ -129,7 +129,7 @@
       else if l.isPath givenProjects
       then
         if ! l.pathExists givenProjects
-        then throw missingProjectsError
+        then throw (missingProjectsError source)
         else if l.hasSuffix ".toml" (l.toString givenProjects)
         then l.fromTOML (l.readFile givenProjects)
         else l.fromJSON (l.readFile givenProjects)
@@ -164,7 +164,7 @@
           })
       else if autoProjects == true
       then discoveredProjects
-      else throw missingProjectsError;
+      else throw (missingProjectsError source);
 
     allBuilderOutputs =
       l.mapAttrs

--- a/src/modules/apps/implementation.nix
+++ b/src/modules/apps/implementation.nix
@@ -19,10 +19,11 @@ in {
       {
         inherit
           (config.apps)
-          install
-          translate
-          runNixCmdInSrc
+          detect-projects
           index
+          install
+          runNixCmdInSrc
+          translate
           translate-index
           ;
       };

--- a/src/modules/functions.discoverers/interface.nix
+++ b/src/modules/functions.discoverers/interface.nix
@@ -3,6 +3,9 @@
   t = l.types;
 in {
   options.functions.discoverers = {
+    discoverProjects2 = l.mkOption {
+      type = t.uniq (t.functionTo (t.listOf t.attrs));
+    };
     discoverProjects = l.mkOption {
       type = t.uniq (t.functionTo (t.listOf t.attrs));
     };

--- a/src/subsystems/rust/discoverers/cargo/default.nix
+++ b/src/subsystems/rust/discoverers/cargo/default.nix
@@ -5,25 +5,7 @@
 }: let
   l = lib // builtins;
 
-  discoverCrates = {tree}: let
-    cargoToml = tree.files."Cargo.toml".tomlContent or {};
-
-    subdirCrates =
-      l.flatten
-      (l.mapAttrsToList
-        (dirName: dir: discoverCrates {tree = dir;})
-        (tree.directories or {}));
-  in
-    if cargoToml ? package.name
-    then
-      [
-        {
-          inherit (cargoToml.package) name version;
-          inherit (tree) relPath;
-        }
-      ]
-      ++ subdirCrates
-    else subdirCrates;
+  discoverCrates = import ../../findAllCrates.nix {inherit lib dlib;};
 
   discoverProjects = {
     tree,

--- a/src/subsystems/rust/findAllCrates.nix
+++ b/src/subsystems/rust/findAllCrates.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  dlib,
+  ...
+}: let
+  discoverCrates = {tree}: let
+    cargoToml = tree.files."Cargo.toml".tomlContent or {};
+
+    subdirCrates =
+      lib.flatten
+      (lib.mapAttrsToList
+        (dirName: dir: discoverCrates {tree = dir;})
+        (tree.directories or {}));
+  in
+    if cargoToml ? package.name
+    then
+      [
+        {
+          inherit (cargoToml.package) name version;
+          inherit (tree) relPath;
+        }
+      ]
+      ++ subdirCrates
+    else subdirCrates;
+in
+  discoverCrates

--- a/src/subsystems/rust/translators/cargo-lock/default.nix
+++ b/src/subsystems/rust/translators/cargo-lock/default.nix
@@ -29,7 +29,7 @@ in {
     projectTree = rootTree.getNodeFromPath project.relPath;
     rootSource = rootTree.fullPath;
     projectSource = dlib.sanitizePath "${rootSource}/${project.relPath}";
-    subsystemInfo = project.subsystemInfo;
+    subsystemInfo = project.subsystemInfo or {};
 
     # Get the root toml
     rootToml = {

--- a/src/subsystems/rust/translators/cargo-lock/default.nix
+++ b/src/subsystems/rust/translators/cargo-lock/default.nix
@@ -30,6 +30,15 @@ in {
     rootSource = rootTree.fullPath;
     projectSource = dlib.sanitizePath "${rootSource}/${project.relPath}";
     subsystemInfo = project.subsystemInfo or {};
+    # pull all crates from subsystemInfo, if not find all of them
+    # this is mainly helpful when `projects` is defined manually in which case
+    # crates won't be available, so we will reduce burden on the user here.
+    allCrates =
+      subsystemInfo.crates
+      or (
+        (import ../../findAllCrates.nix {inherit lib dlib;})
+        {tree = rootTree;}
+      );
 
     # Get the root toml
     rootToml = {
@@ -330,7 +339,7 @@ in {
                 )
                 cargoPackages;
               workspaceCrate = findCrate workspaceCrates;
-              nonWorkspaceCrate = findCrate (subsystemInfo.crates or []);
+              nonWorkspaceCrate = findCrate allCrates;
             in
               if
                 (package.name == dependencyObject.name)

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -5,5 +5,6 @@
       systemsFromFile = ./nix_systems;
       config.projectRoot = ./.;
       source = ./.;
+      projects = ./projects.toml;
     };
 }

--- a/tests/integration-d2n-flakes/tests/nodejs_built-binary/flake.nix
+++ b/tests/integration-d2n-flakes/tests/nodejs_built-binary/flake.nix
@@ -23,5 +23,6 @@
     systems = ["x86_64-linux"];
     config.projectRoot = ./.;
     source = ./.;
+    autoProjects = true;
   });
 }

--- a/tests/integration-d2n-flakes/tests/nodejs_dependency-versions-mismatch/flake.nix
+++ b/tests/integration-d2n-flakes/tests/nodejs_dependency-versions-mismatch/flake.nix
@@ -24,5 +24,6 @@
       config.projectRoot = ./.;
       packageOverrides = {};
       source = ./.;
+      autoProjects = true;
     };
 }

--- a/tests/integration-d2n-flakes/tests/nodejs_direct-priority-over-transitive/flake.nix
+++ b/tests/integration-d2n-flakes/tests/nodejs_direct-priority-over-transitive/flake.nix
@@ -24,6 +24,7 @@
     systems = ["x86_64-linux"];
     config.projectRoot = ./.;
     source = ./.;
+    autoProjects = true;
     packageOverrides = {
       test = {
         "check-linked-bin-version" = {


### PR DESCRIPTION
fixes https://github.com/nix-community/dream2nix/issues/407

The diff seems large, but most of it is just modifications to the examples, adding the project.toml etc.
Only the last commit contains changes to the examples.

Changes the following for makeFlakeOutputs:
- adds flag `autoProjects` (bool; default = false)
- crashes if autoProjects is set false and no `projects` specified

Setting `autoProjects = false` restores the old behavior.

If projects are not specified, which will be the default after initializing the basic flake, the following error will be shown:
(`/nix/store/XXX-path-to-source` is replaced with the actual path pointing to the source, so the user can copy paste the command)
```
error: Please pass `projects` to makeFlakeOutputs.
       `projects` can be:
         - an attrset
         - a path to a .toml file (not empty & added to git)
         - a path to a .json file (not empty & added to git)

       To generate a projects.toml file automatically:
         1. execute:
           nix run github:nix-community/dream2nix#detect-projects /nix/store/XXX-path-to-source > projects.toml
         2. review the ./projects.toml and edit it if necessary.
         3. pass `projects = ./projects.toml` to makeFlakeOutputs.

       Alternatively pass `autoProjects = true` to makeFlakeOutputs.
       This is not recommended as it doesn't allow you to review or filter the list
         of detected projects.
```