### PR TITLE
fix: python: remove spurious --ignore-installed

### DIFF
--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -68,7 +68,6 @@
           --no-warn-script-location \
           --prefix="$out" \
           --no-cache \
-          --ignore-installed \
           . \
           $pipInstallFlags
       '';


### PR DESCRIPTION
This arg was inadvertently added to `pip install` in #397; it breaks transitive dependencies on the packages we custom-install, like setuptools and wheel.

Per @phaer, it wasn't supposed to be there and has already been removed in the next set of larger changes, but this should fix those transitive dependencies in the meantime.