### PR TITLE
feat(rust): change default builder to crane

### DIFF
--- a/docs/src/subsystems/rust.md
+++ b/docs/src/subsystems/rust.md
@@ -14,11 +14,11 @@ Translates a `Cargo.toml` file to a dream2nix lockfile by generating a `Cargo.lo
 
 ## Builders
 
-### build-rust-package (pure) (default)
+### build-rust-package (pure)
 
 Builds a package using `buildRustPackage` from `nixpkgs`.
 
-### crane (ifd)
+### crane (ifd) (default)
 
 Builds a package using [`crane`](https://github.com/ipetkov/crane).
 This builder builds two separate derivations, one for dependencies and the other for your crate.
@@ -173,3 +173,19 @@ in
   # ...
 }
 ```
+
+### Specifying the `stdenv`
+
+`crane` supports specifying the `stdenv` like so:
+```nix
+{
+  # ...
+  packageOverrides = {
+    # change all derivations' stdenv to clangStdenv
+    "^.*".set-stdenv.override = old: {stdenv = pkgs.clangStdenv;};
+  };
+  # ...
+}
+```
+
+`build-rust-package` builder does not support specifying the `stdenv`.

--- a/src/modules/builders/implementation.nix
+++ b/src/modules/builders/implementation.nix
@@ -2,7 +2,7 @@
   l = config.lib;
   defaults = {
     # TODO: define a priority in each builder and remove the defaults here.
-    rust = "build-rust-package";
+    rust = "crane";
     nodejs = "granular-nodejs";
     python = "simple-python";
     php = "granular-php";


### PR DESCRIPTION
Changes default Rust builder to crane since it's easier to work with and is good enough to have as default. Also has more benefits compared to `buildRustPackage`, so it's better to have this as default until we get a granular builder for Rust.