### PR TITLE
Add PLTADDONDIR environment variable to racket binaries.

### DIFF
--- a/src/subsystems/racket/builders/simple-racket/default.nix
+++ b/src/subsystems/racket/builders/simple-racket/default.nix
@@ -82,24 +82,24 @@
 
           $racket/bin/racket -t ${./make-new-config.rkt}
 
-          export TMP_RACO_HOME=$out/tmp-raco-home
-          mkdir -p $TMP_RACO_HOME
+          export TMP_PLTADDONDIR=$TMP/pltaddondir
+          mkdir -p $TMP_PLTADDONDIR
 
           chmod +w -R $TMP/unpack
-          HOME=$TMP_RACO_HOME $racket/bin/raco pkg install --copy $(ls -d $TMP/unpack/*/)
+          PLTADDONDIR=$TMP_PLTADDONDIR $racket/bin/raco pkg install --copy $(ls -d $TMP/unpack/*/)
 
-          for SUBPATH in $(ls -d $TMP_RACO_HOME/.local/share/racket/*/); # there is only one SUBPATH (whose name is the version number of Racket)
+          for SUBPATH in $(ls -d $TMP_PLTADDONDIR/*/); # there is only one SUBPATH (whose name is the version number of Racket)
           do
-              cp -r -t $PLTCONFIGDIR $SUBPATH/*
+              cp -r -t $PLTCONFIGDIR $SUBPATH
           done
 
-          rm -rf $TMP_RACO_HOME
+          export PLTADDONDIR=$PLTCONFIGDIR;
 
           mkdir -p $out/bin
           for EXE in $racket/bin/* $out/etc/bin/*;
           do
             NAME=$(basename "$EXE")
-            makeWrapper "$EXE" "$out/bin/$NAME" --set PLTCONFIGDIR "$PLTCONFIGDIR"
+            makeWrapper "$EXE" "$out/bin/$NAME" --set PLTCONFIGDIR "$PLTCONFIGDIR" --set PLTADDONDIR "$PLTADDONDIR"
           done
         '');
   in {

--- a/src/subsystems/racket/builders/simple-racket/make-new-config.rkt
+++ b/src/subsystems/racket/builders/simple-racket/make-new-config.rkt
@@ -14,7 +14,7 @@
                          (pkgs-search-dirs . "pkgs/")
                          (share-search-dirs . "share/"))]
        [make-path-string (lambda (subpath)
-                           (path->string (cleanse-path (build-path (find-config-dir) subpath))))]
+                           (path->string (cleanse-path (build-path (find-config-dir) (version) subpath))))]
        [final-config-ht (foldl (match-lambda**
                                 [((cons key subpath) accum)
                                  (hash-update accum


### PR DESCRIPTION
The PLTADDONDIR contains [user-specific Racket configuration](https://docs.racket-lang.org/reference/Filesystem.html#%28idx._%28gentag._356._%28lib._scribblings%2Freference%2Freference..scrbl%29%29%29).

For example, is used by `raco` to install and locate a user’s `raco-commands`.

For the current builder, it defaults to the user’s home directory `$TMP_RACO_HOME`. The built `raco` binary, however, defaults to the homeless shelter. This means that the built `raco` can't locate any `raco-commands` in packages installed by the builder.

This commit creates a `PLTADDONDIR` directory structure in `etc` and sets it as an environment variable to all binaries. The paths in `config.rkdt` also point to this directory structure.

There might be a better way to address this - if so, please feel free to point me in the right direction.