### PR TITLE
Add `version` option to the `project` submodule for the flake module

### DIFF
--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -9,6 +9,12 @@
       type = t.str;
     };
 
+    version = mkOption {
+      default = null;
+      description = "Version of the project";
+      type = t.nullOr t.str;
+    };
+
     relPath = mkOption {
       default = "";
       description = "Relative path to project tree from source";


### PR DESCRIPTION
This seems like it might have been overlooked. I'm currently blocked on trying this API out with the `hackage` haskell translator because this option is missing.