### PR TITLE
haskell builder: add a `--constraint` to `configureFlags` for each dependency

### DIFF
--- a/src/subsystems/haskell/builders/simple-haskell/default.nix
+++ b/src/subsystems/haskell/builders/simple-haskell/default.nix
@@ -128,6 +128,8 @@ in {
           # FIXME: this skips over the default package if its name isn't set properly
           configureFlags =
             (subsystemAttrs.cabalFlags."${name}"."${version}" or [])
+            # Pin dependency versions to circumvent https://github.com/nix-community/dream2nix/issues/437
+            # There is probably a better solution for this.
             ++ (map
               (dep: "--constraint=${dep.name}==${dep.version}")
               (getDependencies name version));

--- a/src/subsystems/haskell/builders/simple-haskell/default.nix
+++ b/src/subsystems/haskell/builders/simple-haskell/default.nix
@@ -126,7 +126,11 @@ in {
           doBenchmark = false;
 
           # FIXME: this skips over the default package if its name isn't set properly
-          configureFlags = subsystemAttrs.cabalFlags."${name}"."${version}" or [];
+          configureFlags =
+            (subsystemAttrs.cabalFlags."${name}"."${version}" or [])
+            ++ (map
+              (dep: "--constraint=${dep.name}==${dep.version}")
+              (getDependencies name version));
 
           libraryToolDepends = libraryHaskellDepends;
           executableHaskellDepends = libraryHaskellDepends;


### PR DESCRIPTION
This is one solution for #437.

We add a constraint to `configureFlags` for each dependency with the version specified in our dream-lock.

This fixes the issue, but it's a bit hacky. I don't know enough about the haskell toolchain to know whether there's a better solution.

This will probably at least be a good stop-gap until there's a better solution.