### PR TITLE
haskell: add impure cabal-plan translator based on hackage translator

### DIFF
--- a/examples/haskell_cabal/flake.nix
+++ b/examples/haskell_cabal/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    src.url = "github:davhau/cabal2json/plan-json";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    src,
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
+      pkgs = dream2nix.inputs.nixpkgs.legacyPackages.x86_64-linux;
+      source = src;
+      config.projectRoot = ./.;
+      projects = ./projects.toml;
+    })
+    // {
+      # checks.x86_64-linux.cabal2json = self.packages.x86_64-linux.cabal2json.overrideAttrs (old: {
+      #   doCheck = false;
+      # });
+    };
+}

--- a/examples/haskell_cabal/projects.toml
+++ b/examples/haskell_cabal/projects.toml
@@ -2,8 +2,8 @@
 #   nix run github:nix-community/dream2nix#detect-projects $source
 # ... where `$source` points to the source of your project.
 
-[main]
-name = "main"
+[cabal2json]
+name = "cabal2json"
 relPath = ""
 subsystem = "haskell"
 translator = "cabal"

--- a/examples/haskell_cabal/projects.toml
+++ b/examples/haskell_cabal/projects.toml
@@ -1,0 +1,9 @@
+# To re-generate this file, run:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+# ... where `$source` points to the source of your project.
+
+[main]
+name = "main"
+relPath = ""
+subsystem = "haskell"
+translator = "cabal"

--- a/src/subsystems/haskell/translators/cabal/default.nix
+++ b/src/subsystems/haskell/translators/cabal/default.nix
@@ -1,0 +1,110 @@
+{
+  pkgs,
+  utils,
+  translators,
+  ...
+}: {
+  type = "impure";
+
+  # A derivation which outputs a single executable at `$out`.
+  # The executable will be called by dream2nix for translation
+  # The input format is specified in /specifications/translator-call-example.json.
+  # The first arg `$1` will be a json file containing the input parameters
+  # like defined in /src/specifications/translator-call-example.json and the
+  # additional arguments required according to extraArgs
+  #
+  # The program is expected to create a file at the location specified
+  # by the input parameter `outFile`.
+  # The output file must contain the dream lock data encoded as json.
+  # See /src/specifications/dream-lock-example.json
+  translateBin =
+    utils.writePureShellScript
+    (with pkgs; [
+      bash
+      coreutils
+      curl
+      gnutar
+      gzip
+      haskellPackages.cabal-install
+      haskellPackages.ghc
+      jq
+      moreutils
+      nix
+      python3
+      util-linux
+    ])
+    ''
+      # accroding to the spec, the translator reads the input from a json file
+      jsonInput=$1
+
+      # read the json input
+      outputFile=$(realpath -m $(jq '.outputFile' -c -r $jsonInput))
+      name=$(jq '.project.name' -c -r $jsonInput)
+      version=$(jq '.project.version' -c -r $jsonInput)
+      source=$(jq '.source' -c -r $jsonInput)
+      relPath=$(jq '.project.relPath' -c -r $jsonInput)
+
+      # update the cabal index if older than 1 day
+      (
+        flock 9 || exit 1
+        # ... commands executed under lock ...
+        cabalIndex="$HOME/.cabal/packages/hackage.haskell.org/01-index.cache"
+        set -x
+        if [ -e "$cabalIndex" ]; then
+          indexTime=$(stat -c '%Y' "$cabalIndex")
+          age=$(( $(date +%s) - $indexTime ))
+          if [ "$age" -gt "$((60*60*24))" ]; then
+            cabal update
+          fi
+        else
+          cabal update
+        fi
+      ) 9>/tmp/cabal-lock
+
+      pushd $TMPDIR
+
+      # download and unpack package source
+      mkdir source
+      url="https://hackage.haskell.org/package/$name-$version/$name-$version.tar.gz"
+      echo "downloading $url"
+      curl -L "$url" > $TMPDIR/tarball
+      cd source
+      cat $TMPDIR/tarball | tar xz --strip-components 1
+      # trigger creation of `dist-newstyle` directory
+      cabal freeze
+      cd -
+
+      # generate arguments for cabal-plan translator
+      echo "{
+        \"source\": \"$TMPDIR/source\",
+        \"outputFile\": \"$outputFile\",
+        \"project\": {
+          \"relPath\": \"\",
+          \"subsystemInfo\": {}
+        }
+      }" > $TMPDIR/newJsonInput
+
+      popd
+
+      # execute cabal-plan translator
+      ${translators.cabal-plan.finalTranslateBin} $TMPDIR/newJsonInput
+
+      # finalize dream-lock. Add source and export default package
+      # set correct package version under `packages`
+      export version
+      export hash=$(sha256sum $TMPDIR/tarball | cut -d " " -f 1)
+      cat $outputFile \
+        | python3 ${./fixup-dream-lock.py} $TMPDIR/sourceInfo.json \
+        | sponge $outputFile
+
+    '';
+
+  # If the translator requires additional arguments, specify them here.
+  # When users run the CLI, they will be asked to specify these arguments.
+  # There are only two types of arguments:
+  #   - string argument (type = "argument")
+  #   - boolean flag (type = "flag")
+  # String arguments contain a default value and examples. Flags do not.
+  extraArgs = {
+  };
+}

--- a/src/subsystems/haskell/translators/cabal/default.nix
+++ b/src/subsystems/haskell/translators/cabal/default.nix
@@ -22,9 +22,6 @@
     (with pkgs; [
       bash
       coreutils
-      curl
-      gnutar
-      gzip
       haskellPackages.cabal-install
       haskellPackages.ghc
       jq
@@ -63,13 +60,11 @@
 
       pushd $TMPDIR
 
-      # download and unpack package source
-      mkdir source
-      url="https://hackage.haskell.org/package/$name-$version/$name-$version.tar.gz"
-      echo "downloading $url"
-      curl -L "$url" > $TMPDIR/tarball
+      # copy source
+      echo "copying source"
+      cp -drT --no-preserve=mode,ownership "$source" source
+
       cd source
-      cat $TMPDIR/tarball | tar xz --strip-components 1
       # trigger creation of `dist-newstyle` directory
       cabal freeze
       cd -
@@ -91,8 +86,7 @@
 
       # finalize dream-lock. Add source and export default package
       # set correct package version under `packages`
-      export version
-      export hash=$(sha256sum $TMPDIR/tarball | cut -d " " -f 1)
+      export source
       cat $outputFile \
         | python3 ${./fixup-dream-lock.py} $TMPDIR/sourceInfo.json \
         | sponge $outputFile

--- a/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
+++ b/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
@@ -1,0 +1,17 @@
+import json
+import os
+import sys
+
+lock = json.load(sys.stdin)
+version = os.environ.get('version')
+hash = os.environ.get('hash')
+
+# set default package version correctly
+name = lock['_generic']['defaultPackage']
+lock['sources'][name][version] = dict(
+  type="http",
+  url=f"https://hackage.haskell.org/package/{name}-{version}/{name}-{version}.tar.gz",
+  hash=f"sha256:{hash}",
+)
+
+print(json.dumps(lock, indent=2))

--- a/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
+++ b/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
@@ -3,15 +3,12 @@ import os
 import sys
 
 lock = json.load(sys.stdin)
-version = os.environ.get('version')
-hash = os.environ.get('hash')
+source = os.environ.get('source')
 
-# set default package version correctly
 name = lock['_generic']['defaultPackage']
-lock['sources'][name][version] = dict(
-  type="http",
-  url=f"https://hackage.haskell.org/package/{name}-{version}/{name}-{version}.tar.gz",
-  hash=f"sha256:{hash}",
-)
+version = lock['_generic']['packages'][name]
+
+# follow the original source file
+lock['sources'][name][version]['path'] = source
 
 print(json.dumps(lock, indent=2))


### PR DESCRIPTION
The translator proposed here is basically an "impure wrapper" for the cabal-plan translator. It's a more general version of the hackage translator--all that's changed is that the source is pulled from the `source` option, instead of being downloaded from hackage using `name` and `version`.

The translator copies the source into a temporary directory, runs `cabal freeze`, runs the cabal-plan translator, and then patches in the original source (just like the hackage translator).