### PR TITLE
haskell: add zlib override

### DIFF
--- a/overrides/haskell/default.nix
+++ b/overrides/haskell/default.nix
@@ -1,0 +1,7 @@
+{pkgs, ...}: {
+  zlib = {
+    add-deps = {
+      buildInputs = old: old ++ [pkgs.zlib];
+    };
+  };
+}


### PR DESCRIPTION
Add `pkgs.zlib` to haskell's `zlib` `buildInputs`.