### PR TITLE
flake-parts: add `version` option to the `project` submodule

### DIFF
--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -9,6 +9,12 @@
       type = t.str;
     };
 
+    version = mkOption {
+      default = null;
+      description = "Version of the project";
+      type = t.nullOr t.str;
+    };
+
     relPath = mkOption {
       default = "";
       description = "Relative path to project tree from source";


### PR DESCRIPTION
This might have been overlooked. The hackage haskell translator requires this option, but it's impossible to set using the flake-parts module.

This PR makes the option available.