### PR TITLE
flake-parts: set default project name based on attribute name

### DIFF
--- a/examples/_d2n-flake-parts/flake.nix
+++ b/examples/_d2n-flake-parts/flake.nix
@@ -24,7 +24,6 @@
           source = src;
           projects = {
             prettier = {
-              name = "prettier";
               subsystem = "nodejs";
               translator = "yarn-lock";
             };

--- a/examples/python_pip-freeze/flake.nix
+++ b/examples/python_pip-freeze/flake.nix
@@ -27,7 +27,6 @@
         dream2nix.inputs."rosbags" = {
           source = src;
           projects.rosbags = {
-            name = "rosbags";
             subsystem = "python";
             translator = "pip-freeze";
             subsystemInfo.system = system;

--- a/examples/python_poetry/flake.nix
+++ b/examples/python_poetry/flake.nix
@@ -27,7 +27,6 @@
         dream2nix.inputs."my-project" = {
           source = src;
           projects.my-project = {
-            name = "my-project";
             subsystem = "python";
             translator = "poetry";
             subsystemInfo.system = system;

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -3,42 +3,45 @@
   t = l.types;
   mkOption = l.options.mkOption;
 
-  project.options = {
-    name = mkOption {
-      description = "Name of the project";
-      type = t.str;
-    };
+  project = {name, ...}: {
+    options = {
+      name = mkOption {
+        default = name;
+        description = "Name of the project";
+        type = t.str;
+      };
 
-    version = mkOption {
-      default = null;
-      description = "Version of the project";
-      type = t.nullOr t.str;
-    };
+      version = mkOption {
+        default = null;
+        description = "Version of the project";
+        type = t.nullOr t.str;
+      };
 
-    relPath = mkOption {
-      default = "";
-      description = "Relative path to project tree from source";
-      type = t.str;
-    };
+      relPath = mkOption {
+        default = "";
+        description = "Relative path to project tree from source";
+        type = t.str;
+      };
 
-    # TODO(antotocar34) make a smart enum of all available translators conditional on the given the subsystem? Is this possible?
-    translator = mkOption {
-      description = "Translators to use";
-      example = ["yarn-lock" "package-json"];
-      type = t.str;
-    };
+      # TODO(antotocar34) make a smart enum of all available translators conditional on the given the subsystem? Is this possible?
+      translator = mkOption {
+        description = "Translators to use";
+        example = ["yarn-lock" "package-json"];
+        type = t.str;
+      };
 
-    # TODO(antotocar34) make an enum of all available subsystems?
-    subsystem = mkOption {
-      description = ''Name of subsystem to use. Examples: rust, python, nodejs'';
-      example = "nodejs";
-      type = t.str;
-    };
+      # TODO(antotocar34) make an enum of all available subsystems?
+      subsystem = mkOption {
+        description = ''Name of subsystem to use. Examples: rust, python, nodejs'';
+        example = "nodejs";
+        type = t.str;
+      };
 
-    subsystemInfo = mkOption {
-      default = {};
-      description = "Translator specific arguments";
-      type = t.lazyAttrsOf (t.anything);
+      subsystemInfo = mkOption {
+        default = {};
+        description = "Translator specific arguments";
+        type = t.lazyAttrsOf (t.anything);
+      };
     };
   };
 in {


### PR DESCRIPTION
TL;DR it makes [this](https://github.com/nix-community/dream2nix/blob/9f6911c78dcb0832f7fcc955e847db1a5a9ce29a/examples/_d2n-flake-parts/flake.nix#L27) line unnecessary.