### PR TITLE
Docs: Better highlighting of nix code in docs

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,8 @@ language = "en"
 multilingual = false
 src = "src"
 title = "dream2nix documentation"
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "navy"
+additional-css = ["theme/highlight-dark.css"]

--- a/docs/theme/highlight-dark.css
+++ b/docs/theme/highlight-dark.css
@@ -1,4 +1,4 @@
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   pre code.hljs {
     display: block;
     overflow-x: auto;
@@ -7,18 +7,18 @@
   code.hljs {
     padding: 3px 5px;
   } /*!
-  Theme: GitHub
-  Description: Light theme as seen on github.com
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
   Author: github.com
   Maintainer: @Hirse
   Updated: 2021-05-15
 
-  Outdated base version: https://github.com/primer/github-syntax-light
+  Outdated base version: https://github.com/primer/github-syntax-dark
   Current colors taken from GitHub's CSS
 */
   .hljs {
-    color: #24292e;
-    background: #fff;
+    color: #c9d1d9;
+    background: #0d1117;
   }
   .hljs-doctag,
   .hljs-keyword,
@@ -27,13 +27,13 @@
   .hljs-template-variable,
   .hljs-type,
   .hljs-variable.language_ {
-    color: #d73a49;
+    color: #ff7b72;
   }
   .hljs-title,
   .hljs-title.class_,
   .hljs-title.class_.inherited__,
   .hljs-title.function_ {
-    color: #6f42c1;
+    color: #d2a8ff;
   }
   .hljs-attr,
   .hljs-attribute,
@@ -45,52 +45,52 @@
   .hljs-selector-class,
   .hljs-selector-id,
   .hljs-variable {
-    color: #005cc5;
+    color: #79c0ff;
   }
   .hljs-meta .hljs-string,
   .hljs-regexp,
   .hljs-string {
-    color: #032f62;
+    color: #a5d6ff;
   }
   .hljs-built_in,
   .hljs-symbol {
-    color: #e36209;
+    color: #ffa657;
   }
   .hljs-code,
   .hljs-comment,
   .hljs-formula {
-    color: #6a737d;
+    color: #8b949e;
   }
   .hljs-name,
   .hljs-quote,
   .hljs-selector-pseudo,
   .hljs-selector-tag {
-    color: #22863a;
+    color: #7ee787;
   }
   .hljs-subst {
-    color: #24292e;
+    color: #c9d1d9;
   }
   .hljs-section {
-    color: #005cc5;
+    color: #1f6feb;
     font-weight: 700;
   }
   .hljs-bullet {
-    color: #735c0f;
+    color: #f2cc60;
   }
   .hljs-emphasis {
-    color: #24292e;
+    color: #c9d1d9;
     font-style: italic;
   }
   .hljs-strong {
-    color: #24292e;
+    color: #c9d1d9;
     font-weight: 700;
   }
   .hljs-addition {
-    color: #22863a;
-    background-color: #f0fff4;
+    color: #aff5b4;
+    background-color: #033a16;
   }
   .hljs-deletion {
-    color: #b31d28;
-    background-color: #ffeef0;
+    color: #ffdcd7;
+    background-color: #67060c;
   }
 }

--- a/docs/theme/highlight.css
+++ b/docs/theme/highlight.css
@@ -1,0 +1,94 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+} /*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+.hljs {
+  color: #24292e;
+  background: #fff;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #d73a49;
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: #6f42c1;
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id,
+.hljs-variable {
+  color: #005cc5;
+}
+.hljs-meta .hljs-string,
+.hljs-regexp,
+.hljs-string {
+  color: #032f62;
+}
+.hljs-built_in,
+.hljs-symbol {
+  color: #e36209;
+}
+.hljs-code,
+.hljs-comment,
+.hljs-formula {
+  color: #6a737d;
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-pseudo,
+.hljs-selector-tag {
+  color: #22863a;
+}
+.hljs-subst {
+  color: #24292e;
+}
+.hljs-section {
+  color: #005cc5;
+  font-weight: 700;
+}
+.hljs-bullet {
+  color: #735c0f;
+}
+.hljs-emphasis {
+  color: #24292e;
+  font-style: italic;
+}
+.hljs-strong {
+  color: #24292e;
+  font-weight: 700;
+}
+.hljs-addition {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+.hljs-deletion {
+  color: #b31d28;
+  background-color: #ffeef0;
+}


### PR DESCRIPTION
# Things done

- Add better highlight.js `nix` stylesheet
- Add dark-mode highlighting
- Turn on dark-mode in `book.toml`

## Details 

Currently we use highlight.js@10.1.2 where mdBook applies its custom theme.
All in all looks not so great. Meanwhile the community released highlight.js@11.7.0 which doesnt work properly with mdBook anymore.

However the new (11.7.0) .css stylesheets do work backwards with our old highlight.js version.  

So i propose the `github` and `github-dark` styling as new theme for nix code highlighting. 

As it has gotten way better syntax support in the meanwhile.

- [x] Light mode
- [x] Dark mode