### PR TITLE
rust: add rustc to crane's defaultToolchain and to crane devshell

### DIFF
--- a/docs/src/subsystems/rust.md
+++ b/docs/src/subsystems/rust.md
@@ -95,7 +95,6 @@ You can also of course override the toolchain for only certain crates:
 
 #### `crane` notes
 
-The crane builder does not require a `rustc` package in the toolchain specified, only a `cargo` package is needed.
 If cross-compiling, keep in mind that it also takes `cargo` packages like so:
 
 ```nix

--- a/src/subsystems/rust/builders/crane/default.nix
+++ b/src/subsystems/rust/builders/crane/default.nix
@@ -41,7 +41,7 @@
       utils.mkBuildWithToolchain
       (toolchain: (mkCrane toolchain).buildPackage);
     defaultToolchain = {
-      inherit (pkgs) cargo;
+      inherit (pkgs) cargo rustc;
     };
 
     buildPackage = pname: version: let
@@ -148,7 +148,9 @@
         name: version: let
           pkg = allPackages.${name}.${version};
         in
-          mkShellForDrvs [pkg.passthru.dependencies pkg]
+          (mkShellForDrvs [pkg.passthru.dependencies pkg]).overrideAttrs (old: {
+            nativeBuildInputs = old.nativeBuildInputs ++ [pkg.passthru.rustToolchain.rustc];
+          })
       )
       args.packages;
 


### PR DESCRIPTION
This is useful for creating a devshell (when using crane) that includes `rustc` so rust-analyzer works properly.