### PR TITLE
fix(rust): normalize dependencies inherited from workspace

### DIFF
--- a/src/subsystems/rust/builders/patch-workspace-deps.jq
+++ b/src/subsystems/rust/builders/patch-workspace-deps.jq
@@ -1,0 +1,48 @@
+def normalizeWorkspaceDep:
+  if ($workspaceDependencies."\(.key)" | type) == "object"
+  then [., $workspaceDependencies."\(.key)"] | add
+  else [., {"version":$workspaceDependencies."\(.key)"}] | add
+  end
+  # remove workspace option from the dependency
+  | del(.workspace)
+;
+
+# normalizes workspace inherited dependencies for one list
+def mapWorkspaceDepsFor(name):
+  if has(name)
+  then
+    ."\(name)" = (
+      ."\(name)"
+      | to_entries
+      | map(
+        if (.value | type) == "object" and .value.workspace == true
+        then .value = (.value | normalizeWorkspaceDep)
+        else .
+        end
+      )
+      | from_entries
+    )
+  else .
+  end
+;
+
+# shorthand for normalizing all the dependencies list
+def mapWorkspaceDeps:
+  mapWorkspaceDepsFor("dependencies")
+  | mapWorkspaceDepsFor("dev-dependencies")
+  | mapWorkspaceDepsFor("build-dependencies")
+;
+
+# normalize workspace inherited deps
+mapWorkspaceDeps
+| if has("target")
+  then
+    # normalize workspace inherited deps in target specific deps
+    .target = (
+      .target
+      | to_entries
+      | map(.value = (.value | mapWorkspaceDeps))
+      | from_entries
+    )
+  else .
+  end


### PR DESCRIPTION
This fixes issues like https://github.com/rust-lang/cargo/issues/11192 occurring in dream2nix Rust builders.