### PR TITLE
flake-parts: add builder option + don't expose packages automatically

### DIFF
--- a/examples/_d2n-flake-parts/flake.nix
+++ b/examples/_d2n-flake-parts/flake.nix
@@ -29,6 +29,9 @@
             };
           };
         };
+        packages = {
+          inherit (config.dream2nix.outputs.prettier.packages) prettier;
+        };
       };
     };
 }

--- a/src/modules/flake-parts/implementation.nix
+++ b/src/modules/flake-parts/implementation.nix
@@ -5,14 +5,6 @@
 }: let
   l = lib // builtins;
   d2n = config.dream2nix;
-
-  # make attrs default, so that users can override them without
-  # needing to use lib.mkOverride (usually, lib.mkForce)
-  mkDefaultRecursive = attrs:
-    l.mapAttrsRecursiveCond
-    d2n.lib.dlib.isNotDrvAttrs
-    (_: l.mkDefault)
-    attrs;
 in {
   config = {
     perSystem = {
@@ -29,20 +21,9 @@ in {
         l.mapAttrs
         (_: args: instance.dream2nix-interface.makeOutputs args)
         config.dream2nix.inputs;
-
-      getAttrFromOutputs = attrName:
-        l.mkMerge (
-          l.mapAttrsToList
-          (_: output: mkDefaultRecursive output.${attrName} or {})
-          outputs
-        );
     in {
       config = {
         dream2nix = {inherit instance outputs;};
-        # TODO(yusdacra): we could combine all the resolveImpure here if there are multiple
-        # TODO(yusdacra): maybe we could rename outputs with the same name to avoid collisions?
-        packages = getAttrFromOutputs "packages";
-        devShells = getAttrFromOutputs "devShells";
       };
     };
   };

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -37,6 +37,14 @@
         type = t.str;
       };
 
+      # TODO make an enum of all available builders?
+      builder = mkOption {
+        default = null;
+        description = ''Name of builder to use'';
+        example = "strict-builder";
+        type = t.nullOr t.str;
+      };
+
       subsystemInfo = mkOption {
         default = {};
         description = "Translator specific arguments";

--- a/tests/integration/tests/contribute/my-flake.nix
+++ b/tests/integration/tests/contribute/my-flake.nix
@@ -28,6 +28,9 @@
             translator = "my-pure-translator";
           };
         };
+        packages = {
+          inherit (config.dream2nix.outputs.niv.packages) default;
+        };
       };
     };
 }


### PR DESCRIPTION
This PR does 2 things:
- Adds an optional `builder` option to the flake-parts module to match the standard dream2nix interface
- Removes the module's behavior of automatically exposing all packages in the `perSystem.packages` set (same for devShells)
  - The previous logic was too strict as it resulted in running the entire translator logic just to evaluate `attrNames packages.${system}`. This is particularly problematic for larger flakes, where dream2nix and other packages are exposed together.