### PR TITLE
nodejs: fix symlink issues

### DIFF
--- a/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
+++ b/src/subsystems/haskell/translators/cabal/fixup-dream-lock.py
@@ -3,12 +3,12 @@ import os
 import sys
 
 lock = json.load(sys.stdin)
-source = os.environ.get('source')
+source = os.environ.get("source")
 
-name = lock['_generic']['defaultPackage']
-version = lock['_generic']['packages'][name]
+name = lock["_generic"]["defaultPackage"]
+version = lock["_generic"]["packages"][name]
 
 # follow the original source file
-lock['sources'][name][version]['path'] = source
+lock["sources"][name][version]["path"] = source
 
 print(json.dumps(lock, indent=2))

--- a/src/subsystems/nodejs/builders/strict-builder/python-builder/app/lib/node_modules.py
+++ b/src/subsystems/nodejs/builders/strict-builder/python-builder/app/lib/node_modules.py
@@ -51,7 +51,12 @@ def _create_package_from_derivation(
         elif install_method == InstallMethod.symlink:
             target.mkdir(parents=True, exist_ok=True)
             for entry in os.listdir(dep.derivation):
-                (target / Path(entry)).symlink_to(dep.derivation / Path(entry))
+                if not (target / Path(entry)).exists():
+                    (target / Path(entry)).symlink_to(dep.derivation / Path(entry))
+                else:
+                    logger.info(
+                        f"skipping: file {(target / Path(entry))} already exists."
+                    )
 
         binaries = get_bins(dep)
         for name, rel_path in binaries.items():
@@ -61,7 +66,7 @@ def _create_package_from_derivation(
 class Passthrough(TypedDict):
     """
     Wrapper class
-    Holds global informations during recursion in <_make_folders_rec>
+    Holds global information during recursion in <_make_folders_rec>
     """
 
     all_deps: dict[str, Dependency]


### PR DESCRIPTION
Fixes #471 

Resolves edge-cases where the "package.json" file is not created yet in the directory but its nested node_modules are already created. Thus it creates a conflict, when trying to install the node_modules again.

Emits an Info into the logs just in case we need to further inspect this in the future.

@irisjae can you test if that works for your test case. Your project didnt provide any examples i could test other than building all dependencies. 

