### PR TITLE
PHP: don't override patchPhase

### DIFF
--- a/src/subsystems/php/builders/granular-php/default.nix
+++ b/src/subsystems/php/builders/granular-php/default.nix
@@ -181,20 +181,11 @@
           # set name & version
           jq \
             "(.name = \"${name}\") | \
-             (.version = \"${versionString}\")" \
+             (.version = \"${versionString}\") | \
+             (.extra.patches = {})" \
              composer.json | sponge composer.json
 
           runHook postUnpack
-        '';
-        patchPhase = ''
-          runHook prePatch
-
-          # fixup composer.json
-          jq \
-             "(.extra.patches = {})" \
-             composer.json | sponge composer.json
-
-          runHook postPatch
         '';
         configurePhase = ''
           runHook preConfigure

--- a/src/subsystems/php/builders/simple-php/default.nix
+++ b/src/subsystems/php/builders/simple-php/default.nix
@@ -176,20 +176,11 @@
           # set name & version
           jq \
             "(.name = \"${name}\") | \
-             (.version = \"${versionString}\")" \
+             (.version = \"${versionString}\") | \
+             (.extra.patches = {})" \
              composer.json | sponge composer.json
 
           runHook postUnpack
-        '';
-        patchPhase = ''
-          runHook prePatch
-
-          # fixup composer.json
-          jq \
-             "(.extra.patches = {})" \
-             composer.json | sponge composer.json
-
-          runHook postPatch
         '';
         configurePhase = ''
           runHook preConfigure


### PR DESCRIPTION
Perform the patching in `postPatch` instead.

The advantage is that this means the original `patchPhase` becomes available again, so people can use `patches` in overrides. They can also still override `postPatch` if they want, and invoke the 'original' `postPatch` if they also want to keep the php builders' behavior.