### PR TITLE
Document how to drop PHP target-dir attribute

### DIFF
--- a/docs/src/intro/override-system.md
+++ b/docs/src/intro/override-system.md
@@ -132,3 +132,29 @@ patches
   };
 }
 ```
+
+# Example for PHP flake override
+
+This example overrides `prePatch` for the `ml/iri` package to drop the
+unsupported `target-dir` attribute from composer.json:
+
+```
+{
+  inputs.dream2nix.url = "github:nix-community/dream2nix";
+
+  outputs = inp:
+    inp.dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      source = ./.;
+      projects = ./projects.toml;
+      packageOverrides = {
+        "^ml.iri.*".updated.overrideAttrs = old: {
+          prePatch = ''
+            cat composer.json | grep -v target-dir | sponge composer.json
+          '';
+        };
+      };
+    };
+}
+```

--- a/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/composer.json
+++ b/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "raboof/php_transitive_with_target_dir",
+    "type": "project",
+    "require": {
+        "ml/json-ld": "^1.1"
+    },
+    "authors": [
+        {
+            "name": "Arnout Engelen",
+            "email": "arnout@bzzt.net"
+        }
+    ]
+}

--- a/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/composer.lock
+++ b/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/composer.lock
@@ -1,0 +1,123 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4d38647ca76a14d3b8421dd8b0d462b7",
+    "packages": [
+        {
+            "name": "ml/iri",
+            "version": "1.1.4",
+            "target-dir": "ML/IRI",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lanthaler/IRI.git",
+                "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lanthaler/IRI/zipball/cbd44fa913e00ea624241b38cefaa99da8d71341",
+                "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": ">=4.0",
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "ML\\IRI": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Lanthaler",
+                    "email": "mail@markus-lanthaler.com",
+                    "homepage": "http://www.markus-lanthaler.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "IRI handling for PHP",
+            "homepage": "http://www.markus-lanthaler.com",
+            "keywords": [
+                "URN",
+                "iri",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/lanthaler/IRI/issues",
+                "source": "https://github.com/lanthaler/IRI/tree/master"
+            },
+            "time": "2014-01-21T13:43:39+00:00"
+        },
+        {
+            "name": "ml/json-ld",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lanthaler/JsonLD.git",
+                "reference": "537e68e87a6bce23e57c575cd5dcac1f67ce25d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lanthaler/JsonLD/zipball/537e68e87a6bce23e57c575cd5dcac1f67ce25d8",
+                "reference": "537e68e87a6bce23e57c575cd5dcac1f67ce25d8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ml/iri": "^1.1.1",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "json-ld/tests": "1.0",
+                "phpunit/phpunit": "^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ML\\JsonLD\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Lanthaler",
+                    "email": "mail@markus-lanthaler.com",
+                    "homepage": "http://www.markus-lanthaler.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "JSON-LD Processor for PHP",
+            "homepage": "http://www.markus-lanthaler.com",
+            "keywords": [
+                "JSON-LD",
+                "jsonld"
+            ],
+            "support": {
+                "issues": "https://github.com/lanthaler/JsonLD/issues",
+                "source": "https://github.com/lanthaler/JsonLD/tree/1.2.1"
+            },
+            "time": "2022-09-29T08:45:17+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/flake.nix
+++ b/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/flake.nix
@@ -1,0 +1,25 @@
+# ml/json-ld depends on ml/iri, and ml/iri uses the (deprecated)
+# `target-dir` attribute, which appears to cause a mismatch between
+# dream2nix and composer behavior and makes the build fail.
+#
+# Since target-dir is deprecated and will be removed in a future
+# version of ml/iri anyway, a neat solution is to override the
+# package and add a prePatch phase that drops the attribute,
+# fixing the build:
+{
+  inputs.dream2nix.url = "github:nix-community/dream2nix";
+  outputs = inp:
+    inp.dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      source = ./.;
+      projects = ./projects.toml;
+      packageOverrides = {
+        "^ml.iri.*".updated.overrideAttrs = old: {
+          prePatch = ''
+            cat composer.json | grep -v target-dir | sponge composer.json
+          '';
+        };
+      };
+    };
+}

--- a/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/projects.toml
+++ b/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/projects.toml
@@ -1,0 +1,18 @@
+# projects.toml file describing inputs for dream2nix
+#
+# To re-generate this file, run:
+#   nix run .#detect-projects $source
+# ... where `$source` points to the source of your project.
+#
+# If the local flake is unavailable, alternatively execute the app from the
+# upstream dream2nix flake:
+#   nix run github:nix-community/dream2nix#detect-projects $source
+
+["raboof/php_transitive_with_target_dir"]
+name = "raboof/php_transitive_with_target_dir"
+relPath = ""
+subsystem = "php"
+translator = "composer-lock"
+translators = [ "composer-lock", "composer-json",]
+
+["raboof/php_transitive_with_target_dir".subsystemInfo]

--- a/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/test.php
+++ b/tests/integration-d2n-flakes/tests/php_transitive_with_target_dir/test.php
@@ -1,0 +1,5 @@
+<?
+require __DIR__ . '/vendor/autoload.php';
+
+$doc = new ML\JsonLD\Document('iri');
+?>


### PR DESCRIPTION
Fixes #491 by documenting how to use flake `packageOverrides` to drop the attribute