### PR TITLE
PHP: don't set rootName for `dist` type `path`

### DIFF
--- a/src/subsystems/php/translators/composer-lock/default.nix
+++ b/src/subsystems/php/translators/composer-lock/default.nix
@@ -306,8 +306,8 @@ in {
           then {
             inherit (rawObj.dist) type;
             path = rawObj.dist.url;
-            rootName = finalObj.name;
-            rootVersion = finalObj.version;
+            rootName = null;
+            rootVersion = null;
           }
           else
             l.abort ''


### PR DESCRIPTION
It looks like `rootName` should be set to the *parent* name, but currently points at the name of the dependency component.

Fixes #488, though it seems this was changed intentionally by @tinybeachthor in #311 (specifically 156d7e0f50d37127d1aa5dae1cdc316aabe7eb2e), so this might break something else?