### PR TITLE
Fix error when src is a local directory in pip-freeze

### DIFF
--- a/src/subsystems/python/builders/simple-python/default.nix
+++ b/src/subsystems/python/builders/simple-python/default.nix
@@ -97,11 +97,9 @@
     });
 
     devShell = pkgs.mkShell {
-      buildInputs = [
-        # a drv with all dependencies without the main package
-        (package.overrideAttrs (old: {
-          src = ".";
-        }))
+      # a drv with all dependencies without the main package
+      inputsFrom = [
+        package
       ];
     };
   in {


### PR DESCRIPTION
I encountered the following error when running `nix develop`
```
       > Cannot copy . to .: destination already exists!
       > Did you specify two "srcs" with the same "name"?
       > do not know how to unpack source archive .
       For full logs, run 'nix log /nix/store/fy1mpipp9xb7ds1m081q5x7f3c53j8i2-python3.10-default.drv'.
```

The error can be fixed with this PR. See https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell-usage