### PR TITLE
v1: manage all FOD hashes via `.#update-locks`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,10 @@ jobs:
         name: nix-community
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    - run: nix flake check
+    - run: |
+        nix run .#update-locks
+        git add .
+        nix flake check
 
   tests-integration:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679210066,
-        "narHash": "sha256-0t6UZrLmIEsH3R8Jk8mo2XFGIPJmSWLsCR6HlSp3va8=",
+        "lastModified": 1679549291,
+        "narHash": "sha256-I3kKsVZ6iuLpvSsR0ikKYMBjAMfnuQbeqt2rvHJRulc=",
         "owner": "davhau",
         "repo": "drv-parts",
-        "rev": "38f59f9eb2dbcf9ad6b939ec47c005033445f13e",
+        "rev": "025af1da98fd81546bf2f81b1902d1df0b0e5f0c",
         "type": "github"
       },
       "original": {

--- a/v1/nix/modules/drv-parts/fetch-pip/default.nix
+++ b/v1/nix/modules/drv-parts/fetch-pip/default.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  drv-parts,
+  name,
+  version,
+  ...
+}: let
+  l = lib // builtins;
+
+  fetchPip = import ../../../pkgs/fetchPip {
+    inherit lib;
+    inherit
+      (config.deps)
+      buildPackages
+      stdenv
+      ;
+  };
+in {
+  imports = [
+    ./interface.nix
+    drv-parts.modules.drv-parts.mkDerivation
+  ];
+
+  inherit name version;
+
+  package-func.outputs = ["out" "names"];
+
+  deps = {nixpkgs, ...}:
+    l.mapAttrs (_: l.mkDefault) {
+      inherit
+        (nixpkgs)
+        buildPackages
+        stdenv
+        ;
+      python = nixpkgs.python3;
+    };
+
+  package-func.func = fetchPip;
+  package-func.args = l.mkForce (
+    config.fetch-pip
+    // {
+      inherit (config) name;
+    }
+  );
+}

--- a/v1/nix/modules/drv-parts/fetch-pip/default.nix
+++ b/v1/nix/modules/drv-parts/fetch-pip/default.nix
@@ -14,6 +14,7 @@
       (config.deps)
       buildPackages
       stdenv
+      python3 # only used for proxy script
       ;
   };
 in {
@@ -32,6 +33,7 @@ in {
         (nixpkgs)
         buildPackages
         stdenv
+        python3 # only used for proxy script
         ;
       python = nixpkgs.python3;
     };
@@ -41,6 +43,9 @@ in {
     config.fetch-pip
     // {
       inherit (config) name;
+    }
+    // lib.optionalAttrs (config.mkDerivation.nativeBuildInputs != null) {
+      inherit (config.mkDerivation) nativeBuildInputs;
     }
   );
 }

--- a/v1/nix/modules/drv-parts/fetch-pip/interface.nix
+++ b/v1/nix/modules/drv-parts/fetch-pip/interface.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  l = lib // builtins;
+  t = l.types;
+in {
+  options.fetch-pip = {
+    hash = l.mkOption {
+      type = t.str;
+      description = ''
+        hash for the fixed output derivation
+      '';
+    };
+    maxDate = l.mkOption {
+      type = t.str;
+      description = ''
+        maximum release date for packages
+        Choose any date from the past.
+      '';
+      example = "2023-01-01";
+    };
+    nameSuffix = l.mkOption {
+      type = t.str;
+      default = "python-requirements";
+      description = ''
+        suffix of the fetcher derivation name
+      '';
+    };
+    onlyBinary = l.mkOption {
+      type = t.bool;
+      default = false;
+      description = ''
+        restrict to binary releases (.whl)
+        this allows buildPlatform independent fetching
+      '';
+    };
+    python = l.mkOption {
+      type = t.package;
+      default = config.deps.python;
+      description = ''
+        Specify the python version for which the packages should be downloaded.
+        Pip needs to be executed from that specific python version.
+        Pip accepts '--python-version', but this works only for wheel packages.
+      '';
+    };
+    pipFlags = l.mkOption {
+      type = t.listOf t.str;
+      description = ''
+        hash for the fixed output derivation
+      '';
+      default = [];
+    };
+    pipVersion = l.mkOption {
+      type = t.str;
+      default = "23.0";
+      description = ''
+        the pip version used for fetching
+      '';
+      example = "23.1";
+    };
+    requirementsList = l.mkOption {
+      type = t.listOf t.str;
+      default = [];
+      description = ''
+        list of strings of requirements.txt entries
+      '';
+    };
+    requirementsFiles = l.mkOption {
+      type = t.listOf t.path;
+      default = [];
+      description = ''
+        list of requirements.txt files
+      '';
+    };
+    writeDependencyTree = l.mkOption {
+      type = t.bool;
+      default = true;
+      description = ''
+        Write "dependencies.json" to $out, documenting which package depends on which.
+      '';
+    };
+  };
+}

--- a/v1/nix/modules/drv-parts/lock/default.nix
+++ b/v1/nix/modules/drv-parts/lock/default.nix
@@ -53,6 +53,7 @@
     drvPath = l.unsafeDiscardStringContext fod.drvPath;
   in
     config.deps.writePython3 "update-FOD-hash-${config.name}" {} ''
+      import codecs
       import json
       import os
       import re
@@ -88,6 +89,8 @@
       result = subprocess.run(show_derivation, stdout=subprocess.PIPE)
       drv = json.loads(result.stdout.decode())
       checksum = drv[drv_path]["outputs"]["out"]["hash"]
+      checksum = codecs.encode(codecs.decode(checksum, 'hex'), 'base64').decode()
+      checksum = f"sha256-{checksum}".strip()
       print(f"Found hash: {checksum}")
       with open(out_path, 'w') as f:
           json.dump(checksum, f, indent=2)

--- a/v1/nix/modules/drv-parts/lock/default.nix
+++ b/v1/nix/modules/drv-parts/lock/default.nix
@@ -86,11 +86,12 @@
       # At this point the derivation was built successfully and we can just read
       #   the hash from the drv file.
       show_derivation = ["${config.deps.nix}/bin/nix", "show-derivation", drv_path]  # noqa: E501
-      result = subprocess.run(show_derivation, stdout=subprocess.PIPE)
-      drv = json.loads(result.stdout.decode())
+      result = subprocess.run(show_derivation, stdout=subprocess.PIPE, text=True)
+      drv = json.loads(result.stdout)
       checksum = drv[drv_path]["outputs"]["out"]["hash"]
-      checksum = codecs.encode(codecs.decode(checksum, 'hex'), 'base64').decode()
-      checksum = f"sha256-{checksum}".strip()
+      checksum =\
+          codecs.encode(codecs.decode(checksum, 'hex'), 'base64').decode().strip()
+      checksum = f"sha256-{checksum}"
       print(f"Found hash: {checksum}")
       with open(out_path, 'w') as f:
           json.dump(checksum, f, indent=2)

--- a/v1/nix/modules/drv-parts/lock/interface.nix
+++ b/v1/nix/modules/drv-parts/lock/interface.nix
@@ -31,8 +31,27 @@ in {
     };
 
     fields = l.mkOption {
-      type = t.attrs;
-      description = "Fields to manage via a lock file";
+      type = t.attrsOf (t.submodule [
+        {
+          options = {
+            script = l.mkOption {
+              type = t.path;
+              description = ''
+                A script to refresh the value of this lock file field.
+                The script should write the result as json file to $out.
+              '';
+            };
+            default = l.mkOption {
+              type = t.nullOr t.anything;
+              description = ''
+                The default value in case the lock file doesn't exist or doesn't yet contain the field.
+              '';
+              default = null;
+            };
+          };
+        }
+      ]);
+      description = "Fields of the lock file";
       default = {};
       example = {
         pname = true;

--- a/v1/nix/modules/drv-parts/mach-nix-xs/default.nix
+++ b/v1/nix/modules/drv-parts/mach-nix-xs/default.nix
@@ -157,6 +157,11 @@ in {
   ];
 
   config = {
+    # use lock file to manage hash for fetchPip
+    lock.fields.fetchPipHash =
+      config.lock.lib.computeFODHash
+      config.mach-nix.pythonSources;
+
     mach-nix.drvs = (l.mapAttrs makeModuleFromDerivation preparedWheels.patchedWheels) // preparedWheels.builtWheels;
     mach-nix.dists =
       l.mapAttrs
@@ -164,6 +169,14 @@ in {
       (l.readDir cfg.pythonSources.names);
 
     mach-nix.dependencyTree = dependencyTree;
+
+    mach-nix.pythonSources = {
+      imports = [../../drv-parts/fetch-pip];
+      deps.python = config.deps.python;
+      fetch-pip = {
+        hash = config.lock.content.fetchPipHash;
+      };
+    };
 
     deps = {nixpkgs, ...}:
       l.mapAttrs (_: l.mkDefault) {

--- a/v1/nix/modules/drv-parts/mach-nix-xs/default.nix
+++ b/v1/nix/modules/drv-parts/mach-nix-xs/default.nix
@@ -158,9 +158,12 @@ in {
 
   config = {
     # use lock file to manage hash for fetchPip
-    lock.fields.fetchPipHash =
-      config.lock.lib.computeFODHash
-      config.mach-nix.pythonSources;
+    lock.fields.fetchPipHash = {
+      script =
+        config.lock.lib.computeFODHash
+        config.mach-nix.pythonSources;
+      default = l.fakeSha256;
+    };
 
     mach-nix.drvs = (l.mapAttrs makeModuleFromDerivation preparedWheels.patchedWheels) // preparedWheels.builtWheels;
     mach-nix.dists =

--- a/v1/nix/modules/drv-parts/mach-nix-xs/interface.nix
+++ b/v1/nix/modules/drv-parts/mach-nix-xs/interface.nix
@@ -7,12 +7,22 @@
 }: let
   l = lib // builtins;
   t = l.types;
+
+  drvPartsTypes = import (drv-parts + /types) {
+    inherit lib;
+    specialArgs = {
+      inherit dependencySets drv-parts;
+      inherit (config) name version;
+    };
+  };
 in {
   options.mach-nix = {
     pythonSources = l.mkOption {
-      type = t.package;
+      type = drvPartsTypes.drvPartOrPackage;
+      # if module given, convert to derivation
+      apply = val: val.public or val;
       description = ''
-        A package that contains fetched python sources.
+        A derivation or drv-part that outputs fetched python sources.
         Each single python source must be located in a subdirectory named after the package name.
       '';
     };

--- a/v1/nix/modules/drvs/ansible/default.nix
+++ b/v1/nix/modules/drvs/ansible/default.nix
@@ -10,11 +10,6 @@ in {
     ../../drv-parts/mach-nix-xs
   ];
 
-  # use lock file to manage hash for fetchPip
-  lock.fields.fetchPipHash =
-    config.lock.lib.computeFODHash
-    config.mach-nix.pythonSources;
-
   deps = {nixpkgs, ...}: {
     python = nixpkgs.python39;
     inherit (nixpkgs.writers) writePython3;
@@ -38,12 +33,9 @@ in {
   };
 
   mach-nix.pythonSources = {
-    imports = [../../drv-parts/fetch-pip];
-    deps.python = config.deps.python;
     fetch-pip = {
       maxDate = "2023-01-01";
       requirementsList = ["${config.name}==${config.version}"];
-      hash = config.lock.content.fetchPipHash;
     };
   };
 }

--- a/v1/nix/modules/drvs/ansible/default.nix
+++ b/v1/nix/modules/drvs/ansible/default.nix
@@ -12,7 +12,8 @@ in {
 
   # use lock file to manage hash for fetchPip
   lock.fields.fetchPipHash =
-    config.lock.lib.computeFODHash config.mach-nix.pythonSources;
+    config.lock.lib.computeFODHash
+    config.mach-nix.pythonSources;
 
   deps = {nixpkgs, ...}: {
     python = nixpkgs.python39;
@@ -36,11 +37,13 @@ in {
     ];
   };
 
-  mach-nix.pythonSources = config.deps.fetchPip {
-    inherit python;
-    name = config.name;
-    requirementsList = ["${config.name}==${config.version}"];
-    hash = config.lock.content.fetchPipHash;
-    maxDate = "2023-01-01";
+  mach-nix.pythonSources = {
+    imports = [../../drv-parts/fetch-pip];
+    deps.python = config.deps.python;
+    fetch-pip = {
+      maxDate = "2023-01-01";
+      requirementsList = ["${config.name}==${config.version}"];
+      hash = config.lock.content.fetchPipHash;
+    };
   };
 }

--- a/v1/nix/modules/drvs/ansible/default.nix
+++ b/v1/nix/modules/drvs/ansible/default.nix
@@ -4,7 +4,6 @@
   ...
 }: let
   l = lib // builtins;
-  python = config.deps.python;
 in {
   imports = [
     ../../drv-parts/mach-nix-xs
@@ -12,7 +11,6 @@ in {
 
   deps = {nixpkgs, ...}: {
     python = nixpkgs.python39;
-    inherit (nixpkgs.writers) writePython3;
   };
 
   name = "ansible";
@@ -32,10 +30,8 @@ in {
     ];
   };
 
-  mach-nix.pythonSources = {
-    fetch-pip = {
-      maxDate = "2023-01-01";
-      requirementsList = ["${config.name}==${config.version}"];
-    };
+  mach-nix.pythonSources.fetch-pip = {
+    maxDate = "2023-01-01";
+    requirementsList = ["${config.name}==${config.version}"];
   };
 }

--- a/v1/nix/modules/drvs/ansible/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/ansible/lock-x86_64-linux.json
@@ -1,3 +1,3 @@
 {
-  "fetchPipHash": "742a359651dc0a216b04e11dea65a1c2ac15825b0dda0ad26dc7418fc3b32836"
+  "fetchPipHash": "sha256-dCo1llHcCiFrBOEd6mWhwqwVglsN2grSbcdBj8OzKDY="
 }

--- a/v1/nix/modules/drvs/ansible/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/ansible/lock-x86_64-linux.json
@@ -1,3 +1,3 @@
 {
-  "fetchPipHash": "sha256-dCo1llHcCiFrBOEd6mWhwqwVglsN2grSbcdBj8OzKDY="
+  "fetchPipHash": "742a359651dc0a216b04e11dea65a1c2ac15825b0dda0ad26dc7418fc3b32836"
 }

--- a/v1/nix/modules/drvs/apache-airflow/default.nix
+++ b/v1/nix/modules/drvs/apache-airflow/default.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  drv-parts,
   ...
 }: let
   l = lib // builtins;
@@ -54,14 +53,11 @@ in {
       ;
   };
 
-  mach-nix.pythonSources = config.deps.fetchPip {
-    inherit (config.deps) python;
-    name = config.name;
+  mach-nix.pythonSources.fetch-pip = {
+    maxDate = "2023-01-01";
     requirementsList = [
       "apache-airflow"
     ];
-    hash = "sha256-o5Gu069nB54/cI1muPfzrMX4m/Nm+pPOu1nUarNqeHM=";
-    maxDate = "2023-01-01";
   };
 
   # Replace some python packages entirely with candidates from nixpkgs, because

--- a/v1/nix/modules/drvs/apache-airflow/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/apache-airflow/lock-x86_64-linux.json
@@ -1,0 +1,3 @@
+{
+  "fetchPipHash": "8be191cd605a5fb0e74ca56c527556db353ec0036927030a545092ee3b4766b3"
+}

--- a/v1/nix/modules/drvs/apache-airflow/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/apache-airflow/lock-x86_64-linux.json
@@ -1,3 +1,3 @@
 {
-  "fetchPipHash": "8be191cd605a5fb0e74ca56c527556db353ec0036927030a545092ee3b4766b3"
+  "fetchPipHash": "sha256-i+GRzWBaX7DnTKVsUnVW2zU+wANpJwMKVFCS7jtHZrM="
 }

--- a/v1/nix/modules/drvs/odoo/default.nix
+++ b/v1/nix/modules/drvs/odoo/default.nix
@@ -32,15 +32,16 @@ in {
     };
   };
 
-  mach-nix.pythonSources = config.deps.fetchPip {
-    inherit (config.deps) python;
-    name = config.name;
-    requirementsFiles = ["${config.mkDerivation.src}/requirements.txt"];
-    hash = "sha256-E9wNvBakm+R5TSsFsnGpSaziYpi2otm0iBiyphUVSFI=";
-    maxDate = "2023-01-01";
-    nativeBuildInputs = with config.deps; [
-      postgresql
-    ];
+  mach-nix.pythonSources = {
+    fetch-pip = {
+      maxDate = "2023-01-01";
+      requirementsFiles = ["${config.mkDerivation.src}/requirements.txt"];
+    };
+    mkDerivation = {
+      nativeBuildInputs = with config.deps; [
+        postgresql
+      ];
+    };
   };
 
   # Replace some python packages entirely with candidates from nixpkgs, because

--- a/v1/nix/modules/drvs/odoo/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/odoo/lock-x86_64-linux.json
@@ -1,0 +1,3 @@
+{
+  "fetchPipHash": "sha256-ZmRX8gqpIKbmkMsrEJJJIaTTJoMDuwNUlcWvLCTEDLc="
+}

--- a/v1/nix/modules/drvs/pillow/default.nix
+++ b/v1/nix/modules/drvs/pillow/default.nix
@@ -6,7 +6,6 @@
   ...
 }: let
   l = lib // builtins;
-  python = config.deps.python;
 in {
   imports = [
     ../../drv-parts/mach-nix-xs
@@ -47,12 +46,9 @@ in {
     ];
   };
 
-  mach-nix.pythonSources = config.deps.fetchPip {
-    inherit python;
-    name = config.name;
-    requirementsList = ["${config.name}==${config.version}"];
-    hash = "sha256-eS81pqSjU6mgBL6tXadSxkGdafsVFThByOQcOf8FkF0=";
+  mach-nix.pythonSources.fetch-pip = {
     maxDate = "2023-01-01";
+    requirementsList = ["${config.name}==${config.version}"];
     pipFlags = [
       "--no-binary"
       ":all:"

--- a/v1/nix/modules/drvs/pillow/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/pillow/lock-x86_64-linux.json
@@ -1,0 +1,3 @@
+{
+  "fetchPipHash": "sha256-eS81pqSjU6mgBL6tXadSxkGdafsVFThByOQcOf8FkF0="
+}

--- a/v1/nix/modules/drvs/tensorflow/default.nix
+++ b/v1/nix/modules/drvs/tensorflow/default.nix
@@ -4,7 +4,6 @@
   ...
 }: let
   l = lib // builtins;
-  python = config.deps.python;
 in {
   imports = [
     ../../drv-parts/mach-nix-xs
@@ -34,11 +33,8 @@ in {
     ];
   };
 
-  mach-nix.pythonSources = config.deps.fetchPip {
-    inherit (config.deps) python;
-    name = config.name;
-    requirementsList = ["${config.name}==${config.version}"];
-    hash = "sha256-PDUrECFjoPznqXwqi2e1djx63t+kn/kAyM9JqQrTmd0=";
+  mach-nix.pythonSources.fetch-pip = {
     maxDate = "2023-01-01";
+    requirementsList = ["${config.name}==${config.version}"];
   };
 }

--- a/v1/nix/modules/drvs/tensorflow/lock-x86_64-linux.json
+++ b/v1/nix/modules/drvs/tensorflow/lock-x86_64-linux.json
@@ -1,0 +1,3 @@
+{
+  "fetchPipHash": "sha256-PDUrECFjoPznqXwqi2e1djx63t+kn/kAyM9JqQrTmd0="
+}

--- a/v1/nix/modules/flake-parts/apps.update-caches.nix
+++ b/v1/nix/modules/flake-parts/apps.update-caches.nix
@@ -15,7 +15,7 @@
   }: let
     l = lib // builtins;
 
-    allNewFileCommands =
+    scripts =
       l.flatten
       (l.mapAttrsToList
         (name: pkg: pkg.config.eval-cache.refresh or [])
@@ -30,7 +30,7 @@
       ])
       (
         "set -x\n"
-        + (l.concatStringsSep "\n" allNewFileCommands)
+        + (l.concatStringsSep "\n" scripts)
       );
 
     toApp = script: {

--- a/v1/nix/modules/flake-parts/apps.update-locks.nix
+++ b/v1/nix/modules/flake-parts/apps.update-locks.nix
@@ -15,7 +15,7 @@
   }: let
     l = lib // builtins;
 
-    allNewFileCommands =
+    scripts =
       l.flatten
       (l.mapAttrsToList
         (name: pkg: pkg.config.lock.refresh or [])
@@ -30,7 +30,7 @@
       ])
       (
         "set -x\n"
-        + (l.concatStringsSep "/bin/refresh\n" allNewFileCommands)
+        + (l.concatStringsSep "/bin/refresh\n" scripts)
         + "/bin/refresh"
       );
 

--- a/v1/nix/modules/flake-parts/apps.update-locks.nix
+++ b/v1/nix/modules/flake-parts/apps.update-locks.nix
@@ -1,0 +1,48 @@
+# custom app to update the eval-cache of each exported package.
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  perSystem = {
+    config,
+    self',
+    inputs',
+    pkgs,
+    system,
+    ...
+  }: let
+    l = lib // builtins;
+
+    allNewFileCommands =
+      l.flatten
+      (l.mapAttrsToList
+        (name: pkg: pkg.config.lock.refresh or [])
+        self'.packages);
+
+    update-locks =
+      config.writers.writePureShellScript
+      (with pkgs; [
+        coreutils
+        git
+        nix
+      ])
+      (
+        "set -x\n"
+        + (l.concatStringsSep "/bin/refresh\n" allNewFileCommands)
+        + "/bin/refresh"
+      );
+
+    toApp = script: {
+      type = "app";
+      program = "${script}";
+    };
+  in {
+    apps = l.mapAttrs (_: toApp) {
+      inherit
+        update-locks
+        ;
+    };
+  };
+}

--- a/v1/nix/modules/flake-parts/packages.nix
+++ b/v1/nix/modules/flake-parts/packages.nix
@@ -35,15 +35,7 @@
     evaled.config.public;
 
   packages = lib.mapAttrs (_: drvModule: makeDrv drvModule) self.modules.drvs;
-
-  packagesFiltered =
-    builtins.intersectAttrs
-    {
-      ansible = true;
-      pillow = true;
-    }
-    packages;
 in {
   # map all modules in ../drvs to a package output in the flake.
-  flake.packages.${system} = packagesFiltered;
+  flake.packages.${system} = packages;
 }

--- a/v1/nix/pkgs/fetchPip/fetchPip.nix
+++ b/v1/nix/pkgs/fetchPip/fetchPip.nix
@@ -13,6 +13,10 @@
   buildPackages,
   lib,
   stdenv,
+  # Use the nixpkgs default python version for the proxy script.
+  # The python version select by the user below might be too old for the
+  #   dependencies required by the proxy
+  python3,
 }: {
   # Specify the python version for which the packages should be downloaded.
   # Pip needs to be executed from that specific python version.
@@ -89,7 +93,7 @@
 
   # we use mitmproxy to filter the pypi responses
   pythonWithMitmproxy =
-    python.withPackages
+    python3.withPackages
     (ps: [ps.mitmproxy ps.python-dateutil ps.pkginfo ps.packaging]);
 
   pythonMajorAndMinorVer =


### PR DESCRIPTION
- adds module `fetch-pip`
- use fetch-pip for mach-nix.pythonSources + set defaults 
- make all packages use the module for pythonSources
- re-export all packages 
- add script .#update-locks that updates the lock files for all packages

@phaer 