### PR TITLE
Fix: flake-parts: type check on inject

### DIFF
--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -123,7 +123,7 @@ in {
 
     inject = mkOption {
       default = {};
-      type = t.lazyAttrsOf (t.listOf (t.listOf t.str));
+      type = t.lazyAttrsOf (t.lazyAttrsOf (t.listOf (t.listOf t.str)));
       description = "Inject missing dependencies into the dependency tree"; # TODO(antotocar34) find a suitable description
       example =
         l.literalExpression


### PR DESCRIPTION
The error when you tried to use inject with the flake-parts module:
```
error: A definition for option `perSystem.x86_64-linux.dream2nix.inputs.self.inject.project' is not of type `list of list of string'. Definition values:
       - In `/nix/store/lddrm4gcfbm2qbk4s5raahkii02xbb62-source/flake.nix, via option perSystem':
           {
             "0.0.1" = [
               "@nestjs/mapped-types"
               "1.2.2"
             ];
```