### PR TITLE
fix: nodejs: strict-builder: patch shebangs

### DIFF
--- a/src/subsystems/nodejs/builders/strict-builder/default.nix
+++ b/src/subsystems/nodejs/builders/strict-builder/default.nix
@@ -192,7 +192,8 @@
             runHook preConfigure
 
             cp -r ${nodeModules} ./node_modules
-            chmod -R +w node_modules
+            chmod -R +xw node_modules
+            patchShebangs ./node_modules
 
             export NODE_PATH="$NODE_PATH:./node_modules"
             export PATH="$PATH:node_modules/.bin"


### PR DESCRIPTION
The shebangs were not patched for build time in the strict-builder.  That lead to `no such file or directory` in the sandbox. 
reference: https://matrix.to/#/!PrIEtcffTLLzUWvJOS:matrix.org/$zslZWYi4HF0xramEQum6xf808-VQbbJIkN4kbgGFqt0?via=nixos.org&via=matrix.org&via=nixos.dev

Also, the bins weren't runnable permissions.

