### PR TITLE
crane: 0.10.0 -> 0.12.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     "crane": {
       "flake": false,
       "locked": {
-        "lastModified": 1670900067,
-        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
+        "lastModified": 1681175776,
+        "narHash": "sha256-7SsUy9114fryHAZ8p1L6G6YSu7jjz55FddEwa2U8XZc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
+        "rev": "445a3d222947632b5593112bb817850e8a9cf737",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
+        "ref": "v0.12.1",
         "repo": "crane",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
 
     # required for builder rust/crane
     crane = {
-      url = "github:ipetkov/crane";
+      url = "github:ipetkov/crane/v0.12.1";
       flake = false;
     };
 

--- a/src/modules/externals/implementation.nix
+++ b/src/modules/externals/implementation.nix
@@ -75,6 +75,7 @@ in {
             inherit crateNameFromCargoToml vendorCargoDeps;
           };
           buildDepsOnly = importLibFile "buildDepsOnly" {
+            inherit (pkgs) lib;
             inherit
               mkCargoDerivation
               crateNameFromCargoToml


### PR DESCRIPTION
This updates crane and its bindings and pins it to the current release.