### PR TITLE
Bump version of nixpkgs to include the fix for poetry on m1 macbooks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,16 +192,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665580254,
-        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
+        "lastModified": 1666441811,
+        "narHash": "sha256-lRzsWGqZXg6c3FA66pdc1gdNO9WSZAr0JFWJvO6Jc8I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
+        "rev": "c1989c17e2658f721df7b0027cbc3d8959f914cb",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "rev": "c1989c17e2658f721df7b0027cbc3d8959f914cb",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "nixpkgs/c1989c17e2658f721df7b0027cbc3d8959f914cb";
     nixpkgsV1.url = "nixpkgs/nixos-22.11";
 
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
The node strict-builder uses poetry to build itself. On the version of nixpkgs that is used poetry fails its check phase for m1 macbooks. This PR bumps the version up ~10 days to the point where that fix was merged in. 

Running on m1 with this commit the nodejs alternative builder example should succeed now.