### PR TITLE
sourceOverrides: fix types and add documentation about the version

### DIFF
--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -102,7 +102,7 @@ in {
 
     sourceOverrides = mkOption {
       default = old: {};
-      type = t.functionTo (t.lazyAttrsOf (t.listOf t.package));
+      type = t.functionTo (t.lazyAttrsOf (t.attrsOf t.package));
       description = ''
         Override the sources of dependencies or top-level packages.
         For more details, refer to

--- a/src/modules/flake-parts/makeOutputsArgs.nix
+++ b/src/modules/flake-parts/makeOutputsArgs.nix
@@ -105,6 +105,7 @@ in {
       type = t.functionTo (t.lazyAttrsOf (t.attrsOf t.package));
       description = ''
         Override the sources of dependencies or top-level packages.
+        Refer to the `dream-lock.json` for the package version to override.
         For more details, refer to
         https://nix-community.github.io/dream2nix/intro/override-system.html
       '';


### PR DESCRIPTION
This PR fixes the type specification of the `sourceOverrides` option to match the example and implementation, and add a line in the description to instruct users to look up the relevant version in `dream-lock.json`.