### PR TITLE
Bump nixpkgs to commit that fixed poetry on m1. Update nodjs_alternat…

### DIFF
--- a/examples/nodejs_alternative_builder/flake.nix
+++ b/examples/nodejs_alternative_builder/flake.nix
@@ -16,7 +16,7 @@ Building 'Prettier@2.4.1'.
     src,
   }:
     (dream2nix.lib.makeFlakeOutputs {
-      systems = ["x86_64-linux"];
+      systems = ["x86_64-linux" "aarch64-darwin"];
       config.projectRoot = ./.;
       source = src;
       projects = ./projects.toml;

--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665580254,
-        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
+        "lastModified": 1666441811,
+        "narHash": "sha256-lRzsWGqZXg6c3FA66pdc1gdNO9WSZAr0JFWJvO6Jc8I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
+        "rev": "c1989c17e2658f721df7b0027cbc3d8959f914cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Based on #519. Instead of changing the flake.nix instead just modified the flake.lock to refer to the newer commit per @phaer 