### PR TITLE
Make hash a required field for `http` type in dream-lock-schema.json.

### DIFF
--- a/src/specifications/dream-lock-schema.json
+++ b/src/specifications/dream-lock-schema.json
@@ -91,7 +91,7 @@
                       "type": { "type": "string" },
                       "dir": { "type": "string" }
                     },
-                    "required": ["type", "url"],
+                      "required": ["type", "url", "hash"],
                     "additionalProperties": false
                   }
                 },


### PR DESCRIPTION
I noticed that `hash` is a required field in the documentation for fetchers (which makes complete sense). However, it's not required according to the json schema.

I have edited the schema manually as part of this PR. Let me know if there's another source of truth that I should edit.

There might be other places in which the `hash` is missing. If this change is appropriate, I'll happily add those in.