### PR TITLE
feat(v1/nodejs): add modules nodejs-node-modules and nodejs-devshell

### DIFF
--- a/v1/nix/modules/drv-parts/nodejs-devshell/default.nix
+++ b/v1/nix/modules/drv-parts/nodejs-devshell/default.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  lib,
+  dream2nix,
+  packageSets,
+  ...
+}: let
+  l = lib // builtins;
+
+  cfg = config.nodejs-devshell;
+
+  nodeModulesDrv = dream2nix.lib.evalModules {
+    inherit packageSets;
+    modules = [
+      dream2nix.modules.drv-parts.nodejs-node-modules
+      {inherit (config) nodejs-package-lock name version;}
+      {mkDerivation.src = l.mkForce null;}
+    ];
+  };
+
+  nodeModulesDir = "${nodeModulesDrv}/lib/node_modules/${config.name}/node_modules";
+  binDir = "${nodeModulesDrv}/lib/node_modules/.bin";
+in {
+  imports = [
+    dream2nix.modules.drv-parts.mkDerivation
+    dream2nix.modules.drv-parts.nodejs-package-lock
+  ];
+
+  # rsync the node_modules folder
+  # - tracks node-modules store path via .dream2nix/.node_modules_id
+  # - omits copying if store path did not change
+  # - if store path changes, only replaces updated files
+  # - rsync can be restarted from any point, if failed or aborted mid execution.
+  # Options:
+  # -a            -> all files recursive, preserve symlinks, etc.
+  # --delete      -> removes deleted files
+  # --chmod=+ug+w -> make folder writeable by user+group
+  mkDerivation.shellHook = ''
+    ID=${nodeModulesDir}
+    currID=$(cat .dream2nix/.node_modules_id 2> /dev/null)
+
+    mkdir -p .dream2nix
+    if [[ "$ID" != "$currID" || ! -d "node_modules"  ]];
+    then
+      ${config.deps.rsync}/bin/rsync -a --chmod=ug+w  --delete ${nodeModulesDir}/ ./node_modules/
+      mkdir -p ./node_modules/.bin
+      for executablePath in ${binDir}/*; do
+        binaryName=$(basename $executablePath)
+        target=$(realpath $executablePath)
+        echo linking binary $binaryName to nix store: $target
+        ln -s $target ./node_modules/.bin/$binaryName
+      done
+      echo -n $ID > .dream2nix/.node_modules_id
+      echo "Ok: node_modules updated"
+    fi
+  '';
+}

--- a/v1/nix/modules/drv-parts/nodejs-node-modules/default.nix
+++ b/v1/nix/modules/drv-parts/nodejs-node-modules/default.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  dream2nix,
+  ...
+}: let
+  l = lib // builtins;
+
+  cfg = config.nodejs-devshell;
+in {
+  imports = [
+    dream2nix.modules.drv-parts.mkDerivation
+    dream2nix.modules.drv-parts.nodejs-package-lock
+    dream2nix.modules.drv-parts.nodejs-granular
+  ];
+
+  mkDerivation = {
+    dontUnpack = true;
+    dontPatch = true;
+    dontBuild = true;
+    dontInstall = true;
+    dontFixup = true;
+    preBuildPhases = l.mkForce [];
+    preInstallPhases = l.mkForce [];
+  };
+
+  env = {
+    # Prepare node_modules installation to $out/lib/node_modules
+    patchPhaseNodejs = l.mkForce ''
+      nodeModules=$out/lib/node_modules
+      mkdir -p $nodeModules/$packageName
+      cd $nodeModules/$packageName
+    '';
+  };
+
+  nodejs-granular = {
+    installMethod = "copy";
+  };
+}

--- a/v1/nix/modules/drvs/prettier-devshell/default.nix
+++ b/v1/nix/modules/drvs/prettier-devshell/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  l = lib // builtins;
+in {
+  imports = [
+    ../../drv-parts/nodejs-devshell
+  ];
+
+  mkDerivation = {
+    src = config.deps.fetchFromGitHub {
+      owner = "davhau";
+      repo = "prettier";
+      rev = "2.8.7-package-lock";
+      sha256 = "sha256-zo+WRV3VHja8/noC+iPydtbte93s5GGc3cYaQgNhlEY=";
+    };
+  };
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      mkShell
+      rsync
+      stdenv
+      ;
+  };
+
+  name = l.mkForce "prettier";
+  version = l.mkForce "2.8.7";
+}

--- a/v1/nix/modules/drvs/prettier-node-modules/default.nix
+++ b/v1/nix/modules/drvs/prettier-node-modules/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  l = lib // builtins;
+in {
+  imports = [
+    ../../drv-parts/nodejs-node-modules
+  ];
+
+  mkDerivation = {
+    src = config.deps.fetchFromGitHub {
+      owner = "davhau";
+      repo = "prettier";
+      rev = "2.8.7-package-lock";
+      sha256 = "sha256-zo+WRV3VHja8/noC+iPydtbte93s5GGc3cYaQgNhlEY=";
+    };
+  };
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      mkShell
+      stdenv
+      ;
+  };
+
+  name = l.mkForce "prettier";
+  version = l.mkForce "2.8.7";
+}


### PR DESCRIPTION
This adds two new modules for nodejs:
- nodejs-node-modules (has 2x `node` in name. is just `nodejs-modules` better?)
- nodejs-devshell

The shellHook logic for the dev-shell was largely copied from the current `strict-nodejs` builder.
It currently uses a derivation to create a full copy of the nodejs dependency tree, similar to how npm would do it.
The `shellHook` then rsyncs that store-path (if changed) to `./node_modules` and creates `./node_modules/.bin`.

This is not necessarily the final solution, but it delivers a writable `./node_modules` allowing the user to execute npm for simple operations like `npm install <package name>` for example.

We have been discussing a read-only, symlinked `node_modules` which would be even quicker to install and potentially cleaner in some scenarios, but this would require some more engineering in order to retain a working `npm` command or to provide an alternative command. We can still improve the mechanism in the future.
 
Also an example is added for testing the new modules on prettier.