### PR TITLE
Some whitespace for lock file error formatting

### DIFF
--- a/v1/nix/modules/drv-parts/buildPythonPackage/interface.nix
+++ b/v1/nix/modules/drv-parts/buildPythonPackage/interface.nix
@@ -76,7 +76,7 @@ in {
       boolOpt
       // {
         default = true;
-        decsription = ''
+        description = ''
           Remove bytecode from bin folder.
           When a Python script has the extension `.py`, bytecode is generated
           Typically, executables in bin have no extension, so no bytecode is generated.

--- a/v1/nix/modules/drv-parts/lock/default.nix
+++ b/v1/nix/modules/drv-parts/lock/default.nix
@@ -103,18 +103,28 @@
     '';
 
   errorMissingFile = ''
-    The lock file ${cfg.repoRoot}${cfg.lockFileRel} for drv-parts module '${config.name}' is missing.
+    The lock file ${cfg.repoRoot}${cfg.lockFileRel}
+      for drv-parts module '${config.name}' is missing.
+
     To update it using flakes:
+
       nix run -L .#${config.name}.config.lock.refresh
+
     To update it without flakes:
+
       bash -c $(nix-build ${config.lock.refresh.drvPath} --no-link)/bin/refresh
   '';
 
   errorOutdated = field: ''
-    The lock file ${cfg.repoRoot}${cfg.lockFileRel} for drv-parts module '${config.name}' does not contain field `${field}`.
+    The lock file ${cfg.repoRoot}${cfg.lockFileRel}
+      for drv-parts module '${config.name}' does not contain field `${field}`.
+
     To update it using flakes:
+
       nix run -L .#${config.name}.config.lock.refresh
+
     To update it without flakes:
+
       bash -c $(nix-build ${config.lock.refresh.drvPath} --no-link)/bin/refresh
 
   '';


### PR DESCRIPTION
Before this commit, the error messages for missing or outdated lock files read rather dense, compared to the stack trace above.