### PR TITLE
packages: allow all systems...

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,25 +5,6 @@ on:
 
 jobs:
 
-  tests-pure:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: cachix/install-nix-action@v22
-      with:
-        install_url: https://nixos-nix-install-tests.cachix.org/serve/8i0c4nnvddybdq6a684ffybc5p7ziif0/install
-        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          max-jobs = 10
-    - uses: cachix/cachix-action@v12
-      with:
-        name: nix-community
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-    - run: |
-        nix flake check
-
   tests-format:
     runs-on: ubuntu-latest
     steps:

--- a/v1/nix/modules/flake-parts/packages.nix
+++ b/v1/nix/modules/flake-parts/packages.nix
@@ -10,48 +10,45 @@
     lib,
     pkgs,
     ...
-  }:
-    if system != "x86_64-linux"
-    then {}
-    else let
-      # A module imported into every package setting up the eval cache
-      setup = {config, ...}: {
-        lock.lockFileRel = "/v1/nix/modules/drvs/${config.name}/lock-${system}.json";
-        lock.repoRoot = self;
-        eval-cache.cacheFileRel = "/v1/nix/modules/drvs/${config.name}/cache-${system}.json";
-        eval-cache.repoRoot = self;
-        eval-cache.enable = true;
-        deps.npm = inputs.nixpkgsV1.legacyPackages.${system}.nodejs.pkgs.npm.override (old: rec {
-          version = "8.19.4";
-          src = builtins.fetchTarball {
-            url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
-            sha256 = "0xmvjkxgfavlbm8cj3jx66mlmc20f9kqzigjqripgj71j6b2m9by";
-          };
-        });
-      };
-
-      # evalautes the package behind a given module
-      makeDrv = module: let
-        evaled = lib.evalModules {
-          modules = [
-            inputs.drv-parts.modules.drv-parts.core
-            inputs.drv-parts.modules.drv-parts.docs
-            module
-            ../drv-parts/eval-cache
-            ../drv-parts/lock
-            setup
-          ];
-          specialArgs.packageSets = {
-            nixpkgs = inputs.nixpkgsV1.legacyPackages.${system};
-            writers = config.writers;
-          };
-          specialArgs.drv-parts = inputs.drv-parts;
-          specialArgs.dream2nix = self;
+  }: let
+    # A module imported into every package setting up the eval cache
+    setup = {config, ...}: {
+      lock.lockFileRel = "/v1/nix/modules/drvs/${config.name}/lock-${system}.json";
+      lock.repoRoot = self;
+      eval-cache.cacheFileRel = "/v1/nix/modules/drvs/${config.name}/cache-${system}.json";
+      eval-cache.repoRoot = self;
+      eval-cache.enable = true;
+      deps.npm = inputs.nixpkgsV1.legacyPackages.${system}.nodejs.pkgs.npm.override (old: rec {
+        version = "8.19.4";
+        src = builtins.fetchTarball {
+          url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
+          sha256 = "0xmvjkxgfavlbm8cj3jx66mlmc20f9kqzigjqripgj71j6b2m9by";
         };
-      in
-        evaled.config.public;
-    in {
-      # map all modules in ../drvs to a package output in the flake.
-      packages = lib.mapAttrs (_: drvModule: makeDrv drvModule) self.modules.drvs;
+      });
     };
+
+    # evalautes the package behind a given module
+    makeDrv = module: let
+      evaled = lib.evalModules {
+        modules = [
+          inputs.drv-parts.modules.drv-parts.core
+          inputs.drv-parts.modules.drv-parts.docs
+          module
+          ../drv-parts/eval-cache
+          ../drv-parts/lock
+          setup
+        ];
+        specialArgs.packageSets = {
+          nixpkgs = inputs.nixpkgsV1.legacyPackages.${system};
+          writers = config.writers;
+        };
+        specialArgs.drv-parts = inputs.drv-parts;
+        specialArgs.dream2nix = self;
+      };
+    in
+      evaled.config.public;
+  in {
+    # map all modules in ../drvs to a package output in the flake.
+    packages = lib.mapAttrs (_: drvModule: makeDrv drvModule) self.modules.drvs;
+  };
 }


### PR DESCRIPTION
..and don't filter them. I think the original idea was to prevent evaluation errors on untested platforms, but we didn't achieve that goal on current main anyway and i think its more useful to tackle that issue on the CI front.