### PR TITLE
Expose writers

### DIFF
--- a/v1/nix/modules/flake-parts/lib.writers.nix
+++ b/v1/nix/modules/flake-parts/lib.writers.nix
@@ -1,0 +1,7 @@
+{
+  self,
+  lib,
+  ...
+}: {
+  flake.lib.writers = pkgs: pkgs.callPackage ../../pkgs/writers {};
+}

--- a/v1/nix/modules/flake-parts/packages.nix
+++ b/v1/nix/modules/flake-parts/packages.nix
@@ -10,48 +10,45 @@
     lib,
     pkgs,
     ...
-  }:
-    if system != "x86_64-linux"
-    then {}
-    else let
-      # A module imported into every package setting up the eval cache
-      setup = {config, ...}: {
-        lock.lockFileRel = "/v1/nix/modules/drvs/${config.name}/lock-${system}.json";
-        lock.repoRoot = self;
-        eval-cache.cacheFileRel = "/v1/nix/modules/drvs/${config.name}/cache-${system}.json";
-        eval-cache.repoRoot = self;
-        eval-cache.enable = true;
-        deps.npm = inputs.nixpkgsV1.legacyPackages.${system}.nodejs.pkgs.npm.override (old: rec {
-          version = "8.19.4";
-          src = builtins.fetchTarball {
-            url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
-            sha256 = "0xmvjkxgfavlbm8cj3jx66mlmc20f9kqzigjqripgj71j6b2m9by";
-          };
-        });
-      };
-
-      # evalautes the package behind a given module
-      makeDrv = module: let
-        evaled = lib.evalModules {
-          modules = [
-            inputs.drv-parts.modules.drv-parts.core
-            inputs.drv-parts.modules.drv-parts.docs
-            module
-            ../drv-parts/eval-cache
-            ../drv-parts/lock
-            setup
-          ];
-          specialArgs.packageSets = {
-            nixpkgs = inputs.nixpkgsV1.legacyPackages.${system};
-            writers = config.writers;
-          };
-          specialArgs.drv-parts = inputs.drv-parts;
-          specialArgs.dream2nix = self;
+  }: let
+    # A module imported into every package setting up the eval cache
+    setup = {config, ...}: {
+      lock.lockFileRel = "/v1/nix/modules/drvs/${config.name}/lock-${system}.json";
+      lock.repoRoot = self;
+      eval-cache.cacheFileRel = "/v1/nix/modules/drvs/${config.name}/cache-${system}.json";
+      eval-cache.repoRoot = self;
+      eval-cache.enable = true;
+      deps.npm = inputs.nixpkgsV1.legacyPackages.${system}.nodejs.pkgs.npm.override (old: rec {
+        version = "8.19.4";
+        src = builtins.fetchTarball {
+          url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
+          sha256 = "0xmvjkxgfavlbm8cj3jx66mlmc20f9kqzigjqripgj71j6b2m9by";
         };
-      in
-        evaled.config.public;
-    in {
-      # map all modules in ../drvs to a package output in the flake.
-      packages = lib.mapAttrs (_: drvModule: makeDrv drvModule) self.modules.drvs;
+      });
     };
+
+    # evalautes the package behind a given module
+    makeDrv = module: let
+      evaled = lib.evalModules {
+        modules = [
+          inputs.drv-parts.modules.drv-parts.core
+          inputs.drv-parts.modules.drv-parts.docs
+          module
+          ../drv-parts/eval-cache
+          ../drv-parts/lock
+          setup
+        ];
+        specialArgs.packageSets = {
+          nixpkgs = inputs.nixpkgsV1.legacyPackages.${system};
+          writers = config.writers;
+        };
+        specialArgs.drv-parts = inputs.drv-parts;
+        specialArgs.dream2nix = self;
+      };
+    in
+      evaled.config.public;
+  in {
+    # map all modules in ../drvs to a package output in the flake.
+    packages = lib.mapAttrs (_: drvModule: makeDrv drvModule) self.modules.drvs;
+  };
 }

--- a/v1/nix/modules/flake-parts/writers.nix
+++ b/v1/nix/modules/flake-parts/writers.nix
@@ -1,12 +1,11 @@
 {
   perSystem = {
+    self,
     config,
     lib,
     pkgs,
     ...
-  }: let
-    writers = pkgs.callPackage ../../pkgs/writers {};
-  in {
+  }: {
     options.writers = {
       writePureShellScript = lib.mkOption {
         type = lib.types.functionTo lib.types.anything;
@@ -18,7 +17,7 @@
 
     config.writers = {
       inherit
-        (writers)
+        (self.lib.writers pkgs)
         writePureShellScript
         writePureShellScriptBin
         ;


### PR DESCRIPTION
You'd need them for most of our examples yet, but they aren't available to external flake except for importing them via the path directly.

Builds on https://github.com/nix-community/dream2nix/pull/547 atm, but i am happy to change that if needed.