### PR TITLE
examples(nodejs): allow prettier-devshell derivation to be built

### DIFF
--- a/v1/nix/modules/drvs/prettier-devshell/default.nix
+++ b/v1/nix/modules/drvs/prettier-devshell/default.nix
@@ -16,6 +16,8 @@ in {
       rev = "2.8.7-package-lock";
       sha256 = "sha256-zo+WRV3VHja8/noC+iPydtbte93s5GGc3cYaQgNhlEY=";
     };
+    # allow devshell to be built -> CI pipeline happy
+    buildPhase = "mkdir $out";
   };
 
   deps = {nixpkgs, ...}: {


### PR DESCRIPTION
Fixes a broken test surfaced via https://github.com/nix-community/dream2nix/pull/565