### PR TITLE
tests(pip): initialize unit tests via pytest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -224,7 +224,9 @@
 
             packages = [
               pkgs.alejandra
-              pkgs.python3.pkgs.black
+              (pkgs.python3.withPackages (ps: [
+                pkgs.python3.pkgs.black
+              ]))
             ];
 
             commands =

--- a/v1/nix/modules/flake-parts/packages.fetchPipMetadata.nix
+++ b/v1/nix/modules/flake-parts/packages.fetchPipMetadata.nix
@@ -1,0 +1,18 @@
+# evaluate packages from `/**/modules/drvs` and export them via `flake.packages`
+{
+  self,
+  inputs,
+  ...
+}: {
+  perSystem = {
+    system,
+    config,
+    lib,
+    pkgs,
+    ...
+  }: {
+    packages.fetchPipMetadata = pkgs.callPackage ../../pkgs/fetchPipMetadata/package.nix {
+      python = pkgs.python3;
+    };
+  };
+}

--- a/v1/nix/pkgs/fetchPipMetadata/fetchPipMetadata.nix
+++ b/v1/nix/pkgs/fetchPipMetadata/fetchPipMetadata.nix
@@ -49,7 +49,7 @@
   path = [nix git] ++ nativeBuildInputs;
 
   package = import ./package.nix {
-    inherit lib python;
+    inherit git lib python;
   };
 
   args = writeText "pip-args" (builtins.toJSON {

--- a/v1/nix/pkgs/fetchPipMetadata/package.nix
+++ b/v1/nix/pkgs/fetchPipMetadata/package.nix
@@ -4,12 +4,14 @@
   # Pip needs to be executed from that specific python version.
   # Pip accepts '--python-version', but this works only for wheel packages.
   python,
+  git,
 }: let
   package = python.pkgs.buildPythonPackage {
     name = "fetch_pip_metadata";
     format = "flit";
     src = ./src;
     nativeBuildInputs = [
+      git
       python.pkgs.pytestCheckHook
     ];
     propagatedBuildInputs = with python.pkgs; [

--- a/v1/nix/pkgs/fetchPipMetadata/package.nix
+++ b/v1/nix/pkgs/fetchPipMetadata/package.nix
@@ -9,7 +9,15 @@
     name = "fetch_pip_metadata";
     format = "flit";
     src = ./src;
-    propagatedBuildInputs = with python.pkgs; [packaging certifi python-dateutil pip];
+    nativeBuildInputs = [
+      python.pkgs.pytestCheckHook
+    ];
+    propagatedBuildInputs = with python.pkgs; [
+      packaging
+      certifi
+      python-dateutil
+      pip
+    ];
   };
 in
   package

--- a/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -64,12 +64,10 @@ def lock_info_from_path(full_path):
     # store path /nix/store/$hash-name/
     store_path = Path("/").joinpath(*full_path.parts[:4])
     if not Path("/nix/store") == store_path.parent:
-        print(
-            f"fatal: requirement '{full_path}' refers to something outside",
-            f"/nix/store and our local repo '{repo_root}'",
-            file=sys.stderr,
+        raise Exception(
+            f"fatal: requirement '{full_path}' refers to something outside "
+            f"/nix/store and our local repo '{repo_root}'"
         )
-        sys.exit(1)
 
     # Check if its a FOD, if so use nix to print the derivation of our
     # out_path in json and get hash and url from that
@@ -77,12 +75,10 @@ def lock_info_from_path(full_path):
     if drv_json:
         return lock_info_from_fod(store_path, drv_json)
     else:
-        print(
-            f"fatal: requirement '{full_path}' refers to something we",
-            "can't understand",
-            file=sys.stderr,
+        raise Exception(
+            f"fatal: requirement '{full_path}' refers to something we "
+            "can't understand"
         )
-        sys.exit(1)
 
 
 def lock_entry_from_report_entry(install):

--- a/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -10,13 +10,17 @@ from packaging.utils import (
 )
 
 
-def git_repo_root():
-    return subprocess.run(
+def git_repo_root(directory):
+    proc = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
-        check=True,
         text=True,
         stdout=subprocess.PIPE,
-    ).stdout.strip()
+        cwd=directory,
+    )
+    # fall back to the current directory if not a git repo
+    if proc.returncode == 128:
+        return str(Path(".").absolute())
+    return proc.stdout.strip()
 
 
 def nix_show_derivation(path):
@@ -56,7 +60,7 @@ def path_from_file_url(url):
 
 def lock_info_from_path(full_path):
     # See whether the path is relative to our local repo
-    repo_root = Path(git_repo_root())
+    repo_root = Path(git_repo_root("."))
     if repo_root in full_path.parents or repo_root == full_path:
         return str(full_path.relative_to(repo_root)), None
 

--- a/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -40,12 +40,10 @@ def lock_info_from_fod(store_path, drv_json):
     url = drv_json.get("env", {}).get("urls")  # TODO multiple? commas?
     sha256 = drv_out.get("hash")
     if not (url and sha256):
-        print(
-            f"fatal: requirement '{store_path}' does not seem to be a FOD.\n",
-            f"No URL ({url}) or hash ({sha256}) found.",
-            file=sys.stderr,
+        raise Exception(
+            f"fatal: requirement '{store_path}' does not seem to be a FOD.\n"
+            f"No URL ({url}) or hash ({sha256}) found."
         )
-        sys.exit(1)
     return url, sha256
 
 

--- a/v1/nix/pkgs/fetchPipMetadata/src/pyproject.toml
+++ b/v1/nix/pkgs/fetchPipMetadata/src/pyproject.toml
@@ -13,3 +13,8 @@ authors = [{name = "Paul Haerle", email = "hello@phaer.org"}]
 dynamic = ["version"]
 dependencies = ["packaging", "certifi", "python-dateutil"]
 scripts = {fetch_pip_metadata = "fetch_pip_metadata:fetch_pip_metadata"}
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "fetch_pip_metadata"
+]

--- a/v1/nix/pkgs/fetchPipMetadata/src/shell.nix
+++ b/v1/nix/pkgs/fetchPipMetadata/src/shell.nix
@@ -7,6 +7,7 @@
   python = pkgs.python3;
   package = import ../package.nix {
     inherit lib python;
+    inherit (pkgs) git;
   };
   pythonWithDeps = python.withPackages (
     ps:

--- a/v1/nix/pkgs/fetchPipMetadata/src/shell.nix
+++ b/v1/nix/pkgs/fetchPipMetadata/src/shell.nix
@@ -14,6 +14,7 @@
       ++ [
         ps.black
         ps.pytest
+        ps.pytest-cov
       ]
   );
   devShell = pkgs.mkShell {

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/conftest.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+import subprocess as sp
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+@pytest.fixture(scope="module")
+def git_repo_path():
+    repo = TemporaryDirectory()
+    sp.run(["git", "init"], cwd=repo.name)
+    path = Path(repo.name).absolute()
+    return path
+
+
+@pytest.fixture(scope="module")
+def fod_store_path():
+    nixexpr = """
+        derivation {
+            name = "test";
+            system = builtins.currentSystem;
+            builder = "/bin/sh";
+            args = ["-c" "echo test > $out"];
+            urls = "https://example.com";
+            outputHashMode = "recursive";
+            outputHashAlgo = "sha256";
+            outputHash = "3a3f9b030dcb0974ef85969c37f570349df9d74fb8abf34ed86fc5aae0bef42b";
+        }
+    """
+    proc = sp.run(
+        ["nix", "build", "--impure", "--print-out-paths", "--expr", nixexpr],
+        capture_output=True,
+    )
+    print(proc.stderr)
+    assert proc.returncode == 0
+    return proc.stdout.decode().strip()

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/conftest.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/conftest.py
@@ -1,35 +1,11 @@
+from os import environ
 import pytest
 import subprocess as sp
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-@pytest.fixture(scope="module")
-def git_repo_path():
-    repo = TemporaryDirectory()
-    sp.run(["git", "init"], cwd=repo.name)
-    path = Path(repo.name).absolute()
-    return path
-
-
-@pytest.fixture(scope="module")
-def fod_store_path():
-    nixexpr = """
-        derivation {
-            name = "test";
-            system = builtins.currentSystem;
-            builder = "/bin/sh";
-            args = ["-c" "echo test > $out"];
-            urls = "https://example.com";
-            outputHashMode = "recursive";
-            outputHashAlgo = "sha256";
-            outputHash = "3a3f9b030dcb0974ef85969c37f570349df9d74fb8abf34ed86fc5aae0bef42b";
-        }
-    """
-    proc = sp.run(
-        ["nix", "build", "--impure", "--print-out-paths", "--expr", nixexpr],
-        capture_output=True,
-    )
-    print(proc.stderr)
-    assert proc.returncode == 0
-    return proc.stdout.decode().strip()
+@pytest.fixture()
+def git_repo_path(tmp_path):
+    sp.run(["git", "init"], cwd=tmp_path)
+    return tmp_path

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_evaluate_extras.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_evaluate_extras.py
@@ -1,0 +1,33 @@
+import pytest
+from packaging.requirements import Requirement
+
+import lock_file_from_report as l
+
+
+@pytest.fixture
+def env():
+    return dict(python_version="3.10")
+
+
+def test_marker_match(env):
+    env = dict(python_version="3.10")
+    requirement = Requirement("requests; python_version == '3.10'")
+    assert l.evaluate_extras(requirement, None, env) == True
+
+
+def test_marker_mismatch(env):
+    env = dict(python_version="3.10")
+    requirement = Requirement("requests; python_version >= '3.11'")
+    assert l.evaluate_extras(requirement, None, env) == False
+
+
+def test_marker_extra_match(env):
+    requirement = Requirement("requests; extra == 'security'")
+    extras = ["security"]
+    assert l.evaluate_extras(requirement, extras, {}) == True
+
+
+def test_marker_extra_mismatch(env):
+    requirement = Requirement("requests; extra == 'security'")
+    extras = []
+    assert l.evaluate_extras(requirement, extras, {}) == False

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_evaluate_requirements.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_evaluate_requirements.py
@@ -1,0 +1,70 @@
+import pytest
+from packaging.requirements import Requirement
+
+import lock_file_from_report as l
+
+
+def test_noop():
+    result = l.evaluate_requirements(
+        env={},
+        reqs=dict(
+            root_package={Requirement("requests")},
+            requests=set(),
+        ),
+        dependencies=dict(),
+        root_name="root_package",
+        extras=None,
+        seen=[],
+    )
+    assert result == dict(
+        root_package={"requests"},
+        requests=set(),
+    )
+
+
+def test_extra_not_selected():
+    result = l.evaluate_requirements(
+        env={},
+        reqs=dict(
+            root_package={Requirement("requests; extra == 'http'")},
+            requests=set(),
+        ),
+        dependencies=dict(),
+        root_name="root_package",
+        extras=None,
+        seen=[],
+    )
+    assert result == dict(root_package=set())
+
+
+def test_extra_selected():
+    result = l.evaluate_requirements(
+        env={},
+        reqs=dict(
+            root_package={Requirement("requests; extra == 'http'")},
+            requests=set(),
+        ),
+        dependencies=dict(),
+        root_name="root_package",
+        extras=["http"],
+        seen=[],
+    )
+    assert result == dict(
+        root_package={"requests"},
+        requests=set(),
+    )
+
+
+def test_platform_mismatch():
+    result = l.evaluate_requirements(
+        env=dict(sys_paltform="linux"),
+        reqs=dict(
+            root_package={Requirement("requests; sys_platform == 'darwin'")},
+            requests=set(),
+        ),
+        dependencies=dict(),
+        root_name="root_package",
+        extras=None,
+        seen=[],
+    )
+    assert result == dict(root_package=set())

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_git_repo_root.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_git_repo_root.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+from packaging.requirements import Requirement
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import lock_file_from_report as l
+
+
+def test_not_in_repo():
+    with TemporaryDirectory() as tmpdir:
+        assert l.git_repo_root(str(tmpdir)) == str(Path(".").absolute())
+
+
+def test_in_repo_root(git_repo_path):
+    assert l.git_repo_root(git_repo_path) == str(git_repo_path)

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
@@ -1,0 +1,93 @@
+import pytest
+from packaging.requirements import Requirement
+
+import lock_file_from_report as l
+
+
+def test_url_no_hash():
+    install = dict(
+        metadata=dict(
+            name="test",
+            version="0.0.0",
+        ),
+        download_info=dict(url="https://example.com"),
+    )
+    expected = "test", dict(
+        url=install["download_info"]["url"],
+        version=install["metadata"]["version"],
+        sha256=None,
+    )
+    assert l.lock_entry_from_report_entry(install) == expected
+
+
+def test_url_with_hash():
+    install = dict(
+        metadata=dict(
+            name="test",
+            version="0.0.0",
+        ),
+        download_info=dict(
+            url="https://example.com",
+            archive_info=dict(hash=f"sha256=example_hash"),
+        ),
+    )
+    expected = "test", dict(
+        url=install["download_info"]["url"],
+        version=install["metadata"]["version"],
+        sha256="example_hash",
+    )
+    assert l.lock_entry_from_report_entry(install) == expected
+
+
+def test_path_external():
+    install = dict(
+        metadata=dict(
+            name="test",
+            version="0.0.0",
+        ),
+        download_info=dict(
+            url="/foo/bar",
+        ),
+    )
+    expected = "test", dict(
+        url=install["download_info"]["url"],
+        version=install["metadata"]["version"],
+        sha256=None,
+    )
+    assert l.lock_entry_from_report_entry(install) == expected
+
+
+def test_path_in_repo(git_repo_path):
+    install = dict(
+        metadata=dict(
+            name="test",
+            version="0.0.0",
+        ),
+        download_info=dict(
+            url=git_repo_path.name,
+        ),
+    )
+    expected = "test", dict(
+        url=install["download_info"]["url"],
+        version=install["metadata"]["version"],
+        sha256=None,
+    )
+    assert l.lock_entry_from_report_entry(install) == expected
+
+
+def test_path_in_nix_store(fod_store_path):
+    install = dict(
+        metadata=dict(
+            name="test",
+            version="0.0.0",
+        ),
+        download_info=dict(
+            url=fod_store_path,
+        ),
+    )
+    expected = "test", dict(
+        url=install["download_info"]["url"],
+        version=install["metadata"]["version"],
+        sha256=None,
+    )
+    assert l.lock_entry_from_report_entry(install) == expected

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
@@ -75,14 +75,14 @@ def test_path_in_repo(git_repo_path):
     assert l.lock_entry_from_report_entry(install) == expected
 
 
-def test_path_in_nix_store(fod_store_path):
+def test_path_in_nix_store():
     install = dict(
         metadata=dict(
             name="test",
             version="0.0.0",
         ),
         download_info=dict(
-            url=fod_store_path,
+            url="/nix/store/test",
         ),
     )
     expected = "test", dict(

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_file_from_report.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_file_from_report.py
@@ -1,0 +1,33 @@
+import pytest
+import lock_file_from_report as l
+
+
+def test_simple():
+    report = dict(
+        environment=dict(),
+        install=[
+            dict(
+                requested=True,
+                metadata=dict(
+                    name="test",
+                    version="0.0.0",
+                ),
+                download_info=dict(url="https://example.com"),
+            )
+        ],
+    )
+    expected = dict(
+        sources=dict(
+            test=dict(
+                sha256=None,
+                url="https://example.com",
+                version="0.0.0",
+            )
+        ),
+        targets=dict(
+            default=dict(
+                test=[],
+            ),
+        ),
+    )
+    assert l.lock_file_from_report(report) == expected

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_fod.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_fod.py
@@ -3,7 +3,12 @@ import lock_file_from_report as l
 
 
 @pytest.fixture
-def drv_json():
+def store_path():
+    return "blablub"
+
+
+@pytest.fixture
+def drv_json(store_path):
     return dict(
         env=dict(
             urls="https://example.com",
@@ -12,18 +17,29 @@ def drv_json():
             out=dict(
                 hash="xxx",
                 hashAlgo="r:sha256",
-                path="blablub",
+                path=store_path,
             )
         ),
     )
 
 
-def test_bad_store_path(drv_json):
+def test_mismatching_store_path(drv_json):
     with pytest.raises(AssertionError):
         store_path = ""
         l.lock_info_from_fod(store_path, drv_json)
 
 
-def test_valid_store_path(drv_json):
-    store_path = "blablub"
+def test_matching_store_path(store_path, drv_json):
     l.lock_info_from_fod(store_path, drv_json)
+
+
+def test_no_fod(store_path, drv_json):
+    drv_json["env"]["urls"] = ""
+    drv_json["outputs"]["out"]["hash"] = ""
+    with pytest.raises(Exception):
+        l.lock_info_from_fod(store_path, drv_json)
+
+
+def test_invalid_drv(store_path):
+    with pytest.raises(AssertionError):
+        l.lock_info_from_fod(store_path, {})

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_fod.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_fod.py
@@ -1,0 +1,29 @@
+import pytest
+import lock_file_from_report as l
+
+
+@pytest.fixture
+def drv_json():
+    return dict(
+        env=dict(
+            urls="https://example.com",
+        ),
+        outputs=dict(
+            out=dict(
+                hash="xxx",
+                hashAlgo="r:sha256",
+                path="blablub",
+            )
+        ),
+    )
+
+
+def test_bad_store_path(drv_json):
+    with pytest.raises(AssertionError):
+        store_path = ""
+        l.lock_info_from_fod(store_path, drv_json)
+
+
+def test_valid_store_path(drv_json):
+    store_path = "blablub"
+    l.lock_info_from_fod(store_path, drv_json)

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
@@ -1,0 +1,25 @@
+import pytest
+from pathlib import Path
+
+import lock_file_from_report as l
+
+
+def test_path_in_repo_root(monkeypatch, git_repo_path):
+    def git_repo_root():
+        return git_repo_path
+
+    monkeypatch.setattr(l, "git_repo_root", git_repo_root)
+    assert l.lock_info_from_path(git_repo_path / "foo") == ("foo", None)
+
+
+def test_path_not_in_store_or_repo():
+    with pytest.raises(Exception) as exc_info:
+        l.lock_info_from_path(Path("/foo/bar"))
+    assert "refers to something outside /nix/store" in str(exc_info.value)
+
+
+def test_path_is_fod_output(monkeypatch, fod_store_path):
+    assert l.lock_info_from_path(Path(fod_store_path)) == (
+        "https://example.com",
+        "3a3f9b030dcb0974ef85969c37f570349df9d74fb8abf34ed86fc5aae0bef42b",
+    )

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
@@ -5,7 +5,7 @@ import lock_file_from_report as l
 
 
 def test_path_in_repo_root(monkeypatch, git_repo_path):
-    def git_repo_root():
+    def git_repo_root(path):
         return git_repo_path
 
     monkeypatch.setattr(l, "git_repo_root", git_repo_root)
@@ -18,7 +18,24 @@ def test_path_not_in_store_or_repo():
     assert "refers to something outside /nix/store" in str(exc_info.value)
 
 
-def test_path_is_fod_output(monkeypatch, fod_store_path):
+def test_path_is_fod_output(monkeypatch):
+    fod_store_path = "/nix/store/test"
+
+    def nix_show_derivation(store_path):
+        return dict(
+            env=dict(
+                urls="https://example.com",
+            ),
+            outputs=dict(
+                out=dict(
+                    hash="3a3f9b030dcb0974ef85969c37f570349df9d74fb8abf34ed86fc5aae0bef42b",
+                    hashAlgo="r:sha256",
+                    path=fod_store_path,
+                )
+            ),
+        )
+
+    monkeypatch.setattr(l, "nix_show_derivation", nix_show_derivation)
     assert l.lock_info_from_path(Path(fod_store_path)) == (
         "https://example.com",
         "3a3f9b030dcb0974ef85969c37f570349df9d74fb8abf34ed86fc5aae0bef42b",

--- a/v1/nix/pkgs/fetchPipMetadata/src/tests/test_path_from_file_url.py
+++ b/v1/nix/pkgs/fetchPipMetadata/src/tests/test_path_from_file_url.py
@@ -1,0 +1,19 @@
+import pytest
+import lock_file_from_report as l
+from pathlib import Path
+
+
+def test_wrong_prefix():
+    assert l.path_from_file_url("http://") == None
+
+
+def test_relative_path():
+    url = "file://foo/bar"
+    expected = Path("./foo/bar").absolute()
+    assert l.path_from_file_url(url) == expected
+
+
+def test_absolute_path():
+    url = "file:///foo/bar"
+    expected = Path("/foo/bar")
+    assert l.path_from_file_url(url) == expected


### PR DESCRIPTION
- initialize unit tests for `lock_file_from_report.py`
- add tests for all functions in `lock_file_from_report.py`
- refactor some stuff slightly, to make it more testable:
  - raise exceptions instead of sys.exit(1)
  - allow execution outside of git repos (git_repo_root() now falls back to current directory if not inside a git repo)