### PR TITLE
CI: build all systems in hercules

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,9 +3,28 @@ let
   flakeCompatSrc = b.fetchurl "https://raw.githubusercontent.com/edolstra/flake-compat/12c64ca55c1014cdc1b16ed5a804aa8576601ff2/default.nix";
   flake = (import flakeCompatSrc {src = ./.;}).defaultNix;
   pkgs = import flake.inputs.nixpkgs {};
-  recurseIntoAll = b.mapAttrs (name: val: pkgs.recurseIntoAttrs val);
+  mapRecurse = attrs: f:
+    b.mapAttrs f attrs
+    // {
+      recurseForDerivations = true;
+    };
 in
-  recurseIntoAll {
-    checks = flake.checks.x86_64-linux;
-    packages = flake.packages.x86_64-linux;
+  mapRecurse
+  {
+    x86_64-linux = {};
+    x86_64-darwin = {};
+    aarch64-darwin = {
+      knownIssues = {
+        "odoo" = "TODO github issue link here";
+      };
+    };
   }
+  (
+    system: {knownIssues ? {}}:
+      mapRecurse
+      {
+        checks = flake.checks.${system};
+        packages = pkgs.lib.filterAttrs (n: v: ! b.hasAttr n knownIssues) flake.packages.${system};
+      }
+      (_name: val: pkgs.recurseIntoAttrs val)
+  )

--- a/ci.nix
+++ b/ci.nix
@@ -11,10 +11,13 @@ let
 in
   mapRecurse
   {
+    # FIXME: We can't lock via remote-builders yet, and I don't have a aarch64-linux
+    # machine here, so we lack lock files for the evaluation atm.
+    # aarch64-linux = {};
     x86_64-linux = {};
-    aarch64-linux = {};
     x86_64-darwin = {};
     aarch64-darwin = {
+      # FIXME: hercules requireFailure might be a better solution?
       knownIssues = {
         "odoo" = "TODO github issue link here";
       };

--- a/ci.nix
+++ b/ci.nix
@@ -12,6 +12,7 @@ in
   mapRecurse
   {
     x86_64-linux = {};
+    aarch64-linux = {};
     x86_64-darwin = {};
     aarch64-darwin = {
       knownIssues = {

--- a/ci.nix
+++ b/ci.nix
@@ -16,12 +16,7 @@ in
     # aarch64-linux = {};
     x86_64-linux = {};
     x86_64-darwin = {};
-    aarch64-darwin = {
-      # FIXME: hercules requireFailure might be a better solution?
-      knownIssues = {
-        "odoo" = "TODO github issue link here";
-      };
-    };
+    aarch64-darwin = {};
   }
   (
     system: {knownIssues ? {}}:

--- a/v1/nix/modules/drvs/ansible/lock-aarch64-darwin.json
+++ b/v1/nix/modules/drvs/ansible/lock-aarch64-darwin.json
@@ -1,0 +1,101 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "ansible": {
+        "sha256": "e7953472347fcc6dca10839111b576a9f790e00056344f2dcf448e6c452fe939",
+        "url": "https://files.pythonhosted.org/packages/ec/ee/1494474b59c6e9cccdfde32da1364b94cdb280ff96b1493deaf4f3ae55f8/ansible-2.7.1.tar.gz",
+        "version": "2.7.1"
+      },
+      "bcrypt": {
+        "sha256": "b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f",
+        "url": "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "4.0.1"
+      },
+      "cffi": {
+        "sha256": "fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0",
+        "url": "https://files.pythonhosted.org/packages/3a/75/a162315adeaf47e94a3b7f886a8e31d77b9e525a387eef2d6f0efc96a7c8/cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl",
+        "version": "1.15.1"
+      },
+      "cryptography": {
+        "sha256": "2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70",
+        "url": "https://files.pythonhosted.org/packages/75/7a/2ea7dd2202638cf1053aaa8fbbaddded0b78c78832b3d03cafa0416a6c84/cryptography-38.0.4-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "38.0.4"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "markupsafe": {
+        "sha256": "e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+        "url": "https://files.pythonhosted.org/packages/06/7f/d5e46d7464360b6ac39c5b0b604770dba937e3d7cab485d2f3298454717b/MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl",
+        "version": "2.1.1"
+      },
+      "paramiko": {
+        "sha256": "b2df1a6325f6996ef55a8789d0462f5b502ea83b3c990cbb5bbe57345c6812c4",
+        "url": "https://files.pythonhosted.org/packages/71/6d/95777fd66507106d2f8f81d005255c237187951644f85a5bd0baeec8a88f/paramiko-2.12.0-py2.py3-none-any.whl",
+        "version": "2.12.0"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "pynacl": {
+        "sha256": "401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
+        "url": "https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "1.5.0"
+      },
+      "pyyaml": {
+        "sha256": "e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+        "url": "https://files.pythonhosted.org/packages/67/d4/b95266228a25ef5bd70984c08b4efce2c035a4baa5ccafa827b266e3dc36/PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl",
+        "version": "6.0"
+      },
+      "setuptools": {
+        "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+        "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl",
+        "version": "65.6.3"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      }
+    },
+    "targets": {
+      "default": {
+        "ansible": [
+          "cryptography",
+          "jinja2",
+          "paramiko",
+          "pyyaml",
+          "setuptools"
+        ],
+        "bcrypt": [],
+        "cffi": [
+          "pycparser"
+        ],
+        "cryptography": [
+          "cffi"
+        ],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "markupsafe": [],
+        "paramiko": [
+          "bcrypt",
+          "cryptography",
+          "pynacl",
+          "six"
+        ],
+        "pycparser": [],
+        "pynacl": [
+          "cffi"
+        ],
+        "pyyaml": [],
+        "setuptools": [],
+        "six": []
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/ansible/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/ansible/lock-x86_64-darwin.json
@@ -1,0 +1,101 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "ansible": {
+        "sha256": "e7953472347fcc6dca10839111b576a9f790e00056344f2dcf448e6c452fe939",
+        "url": "https://files.pythonhosted.org/packages/ec/ee/1494474b59c6e9cccdfde32da1364b94cdb280ff96b1493deaf4f3ae55f8/ansible-2.7.1.tar.gz",
+        "version": "2.7.1"
+      },
+      "bcrypt": {
+        "sha256": "b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f",
+        "url": "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "4.0.1"
+      },
+      "cffi": {
+        "sha256": "54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+        "url": "https://files.pythonhosted.org/packages/18/8f/5ff70c7458d61fa8a9752e5ee9c9984c601b0060aae0c619316a1e1f1ee5/cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl",
+        "version": "1.15.1"
+      },
+      "cryptography": {
+        "sha256": "1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb",
+        "url": "https://files.pythonhosted.org/packages/52/1b/49ebc2b59e9126f1f378ae910e98704d54a3f48b78e2d6d6c8cfe6fbe06f/cryptography-38.0.4-cp36-abi3-macosx_10_10_x86_64.whl",
+        "version": "38.0.4"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "markupsafe": {
+        "sha256": "b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+        "url": "https://files.pythonhosted.org/packages/26/03/2c11ba1a8b2327adea3f59f1c9c9ee9c59e86023925f929e63c4f028b10a/MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl",
+        "version": "2.1.1"
+      },
+      "paramiko": {
+        "sha256": "b2df1a6325f6996ef55a8789d0462f5b502ea83b3c990cbb5bbe57345c6812c4",
+        "url": "https://files.pythonhosted.org/packages/71/6d/95777fd66507106d2f8f81d005255c237187951644f85a5bd0baeec8a88f/paramiko-2.12.0-py2.py3-none-any.whl",
+        "version": "2.12.0"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "pynacl": {
+        "sha256": "401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
+        "url": "https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "1.5.0"
+      },
+      "pyyaml": {
+        "sha256": "055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+        "url": "https://files.pythonhosted.org/packages/f5/6f/b8b4515346af7c33d3b07cd8ca8ea0700ca72e8d7a750b2b87ac0268ca4e/PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl",
+        "version": "6.0"
+      },
+      "setuptools": {
+        "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+        "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl",
+        "version": "65.6.3"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      }
+    },
+    "targets": {
+      "default": {
+        "ansible": [
+          "cryptography",
+          "jinja2",
+          "paramiko",
+          "pyyaml",
+          "setuptools"
+        ],
+        "bcrypt": [],
+        "cffi": [
+          "pycparser"
+        ],
+        "cryptography": [
+          "cffi"
+        ],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "markupsafe": [],
+        "paramiko": [
+          "bcrypt",
+          "cryptography",
+          "pynacl",
+          "six"
+        ],
+        "pycparser": [],
+        "pynacl": [
+          "cffi"
+        ],
+        "pyyaml": [],
+        "setuptools": [],
+        "six": []
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/apache-airflow/lock-aarch64-darwin.json
+++ b/v1/nix/modules/drvs/apache-airflow/lock-aarch64-darwin.json
@@ -1,0 +1,897 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "alembic": {
+        "sha256": "a9781ed0979a20341c2cbb56bd22bd8db4fc1913f955e705444bd3a97c59fa32",
+        "url": "https://files.pythonhosted.org/packages/67/8d/694d5c1de901de71cd6d5fb2d0e19cad29b5615c6b56dabcf0a4aaf34082/alembic-1.9.1-py3-none-any.whl",
+        "version": "1.9.1"
+      },
+      "anyio": {
+        "sha256": "fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3",
+        "url": "https://files.pythonhosted.org/packages/77/2b/b4c0b7a3f3d61adb1a1e0b78f90a94e2b6162a043880704b7437ef297cad/anyio-3.6.2-py3-none-any.whl",
+        "version": "3.6.2"
+      },
+      "apache-airflow": {
+        "sha256": "fb2c2768e3a233e60b110431b907045256a224cffaf01fa475ccef3db8d6edd3",
+        "url": "https://files.pythonhosted.org/packages/94/3a/3d050e3decaf7c1064e6e0e5e06f5f9be6c7476b438f8d25e458421e2e13/apache_airflow-2.5.0-py3-none-any.whl",
+        "version": "2.5.0"
+      },
+      "apache-airflow-providers-common-sql": {
+        "sha256": "352e7303149083687635b1d8b401b0925bccaeb7c493a9dc1416b828d9891fc7",
+        "url": "https://files.pythonhosted.org/packages/9f/65/8127df3048051278b7f3f8a0ba834533ead54fc6a292ec498ec636268703/apache_airflow_providers_common_sql-1.3.1-py3-none-any.whl",
+        "version": "1.3.1"
+      },
+      "apache-airflow-providers-ftp": {
+        "sha256": "b2eee640f7eaf0fff3ebeeacc83fe0c315aa297de8780a5a6aededfeeb7e11e0",
+        "url": "https://files.pythonhosted.org/packages/9b/cf/d4368604feca0b93dd29dce04c19ae4e5a62071ad44faf9d13210ace3a3c/apache_airflow_providers_ftp-3.2.0-py3-none-any.whl",
+        "version": "3.2.0"
+      },
+      "apache-airflow-providers-http": {
+        "sha256": "c424945876ba3d40ef108e73973aba646509336f589f9d0a11a44786e6dac2b7",
+        "url": "https://files.pythonhosted.org/packages/48/74/ec2dcbc3a8dc442b5d427658e516f8b7410bcc4823bb091c8be2823a4a67/apache_airflow_providers_http-4.1.0-py3-none-any.whl",
+        "version": "4.1.0"
+      },
+      "apache-airflow-providers-imap": {
+        "sha256": "79da5956637788c19fd3a152bb20fb476c980fdad80724fec8ade02abe47834b",
+        "url": "https://files.pythonhosted.org/packages/63/41/bcf07b9be7802a8ff18b2ae6e1f8b5c3ae3aa119c5739b1f0aac8e865734/apache_airflow_providers_imap-3.1.0-py3-none-any.whl",
+        "version": "3.1.0"
+      },
+      "apache-airflow-providers-sqlite": {
+        "sha256": "f282247f29a3130eae6c05d8c41cee012e1b7d482c6a7ed058deef01e9af1c43",
+        "url": "https://files.pythonhosted.org/packages/e3/cf/dcacb9649a4f0004871d040ddbce429404a6af82df18b964432790022f0a/apache_airflow_providers_sqlite-3.3.1-py3-none-any.whl",
+        "version": "3.3.1"
+      },
+      "apispec": {
+        "sha256": "a1df9ec6b2cd0edf45039ef025abd7f0660808fa2edf737d3ba1cf5ef1a4625b",
+        "url": "https://files.pythonhosted.org/packages/35/a2/80a82b22296c942a5298bb760e8e21c86ace3342de840ff3df8938af4272/apispec-3.3.2-py2.py3-none-any.whl",
+        "version": "3.3.2"
+      },
+      "argcomplete": {
+        "sha256": "cffa11ea77999bb0dd27bb25ff6dc142a6796142f68d45b1a26b11f58724561e",
+        "url": "https://files.pythonhosted.org/packages/d3/e5/c5509683462e51b070df9e83e7f72c1ccfe3f733f328b4a0f06804c27278/argcomplete-2.0.0-py2.py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "attrs": {
+        "sha256": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+        "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl",
+        "version": "22.2.0"
+      },
+      "babel": {
+        "sha256": "1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe",
+        "url": "https://files.pythonhosted.org/packages/92/f7/86301a69926e11cd52f73396d169554d09b20b1723a040c2dcc1559ef588/Babel-2.11.0-py3-none-any.whl",
+        "version": "2.11.0"
+      },
+      "blinker": {
+        "sha256": "1eb563df6fdbc39eeddc177d953203f99f097e9bf0e2b8f9f3cf18b6ca425e36",
+        "url": "https://files.pythonhosted.org/packages/30/41/caa5da2dbe6d26029dfe11d31dfa8132b4d6d30b6d6b61a24824075a5f06/blinker-1.5-py2.py3-none-any.whl",
+        "version": "1.5"
+      },
+      "cachelib": {
+        "sha256": "811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3",
+        "url": "https://files.pythonhosted.org/packages/93/70/58e525451478055b0fd2859b22226888a6985d404fe65e014fc4893d3b75/cachelib-0.9.0-py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "cattrs": {
+        "sha256": "bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21",
+        "url": "https://files.pythonhosted.org/packages/43/3b/1d34fc4449174dfd2bc5ad7047a23edb6558b2e4b5a41b25a8ad6655c6c7/cattrs-22.2.0-py3-none-any.whl",
+        "version": "22.2.0"
+      },
+      "certifi": {
+        "sha256": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+        "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl",
+        "version": "2022.12.7"
+      },
+      "cffi": {
+        "sha256": "285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+        "url": "https://files.pythonhosted.org/packages/ea/be/c4ad40ad441ac847b67c7a37284ae3c58f39f3e638c6b0f85fb662233825/cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl",
+        "version": "1.15.1"
+      },
+      "charset-normalizer": {
+        "sha256": "83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f",
+        "url": "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl",
+        "version": "2.1.1"
+      },
+      "click": {
+        "sha256": "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
+        "url": "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl",
+        "version": "8.1.3"
+      },
+      "clickclick": {
+        "sha256": "c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5",
+        "url": "https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl",
+        "version": "20.10.2"
+      },
+      "colorama": {
+        "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+        "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+        "version": "0.4.6"
+      },
+      "colorlog": {
+        "sha256": "3dd15cb27e8119a24c1a7b5c93f9f3b455855e0f73993b1c25921b2f646f1dcd",
+        "url": "https://files.pythonhosted.org/packages/51/62/61449c6bb74c2a3953c415b2cdb488e4f0518ac67b35e2b03a6d543035ca/colorlog-4.8.0-py2.py3-none-any.whl",
+        "version": "4.8.0"
+      },
+      "commonmark": {
+        "sha256": "da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9",
+        "url": "https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl",
+        "version": "0.9.1"
+      },
+      "configupdater": {
+        "sha256": "805986dbeba317886c7a8d348b2e34986dc9e3128cd3761ecc35decbd372b286",
+        "url": "https://files.pythonhosted.org/packages/4d/13/6791bba527baf3648be8aabaf6d3775027c3ebbf4000f2ae16867911b879/ConfigUpdater-3.1.1-py2.py3-none-any.whl",
+        "version": "3.1.1"
+      },
+      "connexion": {
+        "sha256": "f343717241b4c4802a694c38fee66fb1693c897fe4ea5a957fa9b3b07caf6394",
+        "url": "https://files.pythonhosted.org/packages/de/ce/1ed67157e4d5fae496be1a82e0c1003bcef944dad0f902c4f6c3fd1c8f4d/connexion-2.14.1-py2.py3-none-any.whl",
+        "version": "2.14.1"
+      },
+      "cron-descriptor": {
+        "sha256": "a8554e91483f9977c3e5fa90a3c7a06fb97472ec9b160df6fe89f3114658236d",
+        "url": "https://files.pythonhosted.org/packages/7d/4f/fc70577320a99982006ab4ee11f5d5fb0f819aff2e5fff0b6bc54ff19c96/cron_descriptor-1.2.32.tar.gz",
+        "version": "1.2.32"
+      },
+      "croniter": {
+        "sha256": "d6ed8386d5f4bbb29419dc1b65c4909c04a2322bd15ec0dc5b2877bfa1b75c7a",
+        "url": "https://files.pythonhosted.org/packages/0f/4d/0cc5a7f4bdcefecebdf8a95c8372606c13d3355e8536d9cd3e7070e94269/croniter-1.3.8-py2.py3-none-any.whl",
+        "version": "1.3.8"
+      },
+      "cryptography": {
+        "sha256": "2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70",
+        "url": "https://files.pythonhosted.org/packages/75/7a/2ea7dd2202638cf1053aaa8fbbaddded0b78c78832b3d03cafa0416a6c84/cryptography-38.0.4-cp36-abi3-macosx_10_10_universal2.whl",
+        "version": "38.0.4"
+      },
+      "deprecated": {
+        "sha256": "64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d",
+        "url": "https://files.pythonhosted.org/packages/51/6a/c3a0408646408f7283b7bc550c30a32cc791181ec4618592eec13e066ce3/Deprecated-1.2.13-py2.py3-none-any.whl",
+        "version": "1.2.13"
+      },
+      "dill": {
+        "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
+        "url": "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl",
+        "version": "0.3.6"
+      },
+      "dnspython": {
+        "sha256": "a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f",
+        "url": "https://files.pythonhosted.org/packages/9b/ed/28fb14146c7033ba0e89decd92a4fa16b0b69b84471e2deab3cc4337cc35/dnspython-2.2.1-py3-none-any.whl",
+        "version": "2.2.1"
+      },
+      "docutils": {
+        "sha256": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc",
+        "url": "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl",
+        "version": "0.19"
+      },
+      "email-validator": {
+        "sha256": "816073f2a7cffef786b29928f58ec16cdac42710a53bb18aa94317e3e145ec5c",
+        "url": "https://files.pythonhosted.org/packages/e7/d3/88997ca4903c70fb6eec2e29501a35f84aaf34790f207febdf188e374377/email_validator-1.3.0-py2.py3-none-any.whl",
+        "version": "1.3.0"
+      },
+      "exceptiongroup": {
+        "sha256": "327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+        "url": "https://files.pythonhosted.org/packages/e8/14/9c6a7e5f12294ccd6975a45e02899ed25468cd7c2c86f3d9725f387f9f5f/exceptiongroup-1.1.0-py3-none-any.whl",
+        "version": "1.1.0"
+      },
+      "flask": {
+        "sha256": "b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526",
+        "url": "https://files.pythonhosted.org/packages/0f/43/15f4f9ab225b0b25352412e8daa3d0e3d135fcf5e127070c74c3632c8b4c/Flask-2.2.2-py3-none-any.whl",
+        "version": "2.2.2"
+      },
+      "flask-appbuilder": {
+        "sha256": "682e18fab43ccec8f4aac696f090ae45326b0ee1f3ad9608896111ff8405a7a4",
+        "url": "https://files.pythonhosted.org/packages/3b/28/9acebe45a02908193b28668867b8e948e747e37cb95937ee5f0281d71e27/Flask_AppBuilder-4.1.4-py3-none-any.whl",
+        "version": "4.1.4"
+      },
+      "flask-babel": {
+        "sha256": "e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468",
+        "url": "https://files.pythonhosted.org/packages/ab/3e/02331179ffab8b79e0383606a028b6a60fb1b4419b84935edd43223406a0/Flask_Babel-2.0.0-py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "flask-caching": {
+        "sha256": "703df847cbe904d8ddffd5f5fb320e236a31cb7bebac4a93d6b1701dd16dbf37",
+        "url": "https://files.pythonhosted.org/packages/8b/3c/9b767cd054aa23283b55f45fca0bc6afc74c425ea15b67c8cd324ead9c06/Flask_Caching-2.0.1-py3-none-any.whl",
+        "version": "2.0.1"
+      },
+      "flask-jwt-extended": {
+        "sha256": "a85eebfa17c339a7260c4643475af444784ba6de5588adda67406f0a75599553",
+        "url": "https://files.pythonhosted.org/packages/83/5a/f688f884d9bd10b0cf1b34373b5634ddc340f2b1a099d014bc3c997bf562/Flask_JWT_Extended-4.4.4-py2.py3-none-any.whl",
+        "version": "4.4.4"
+      },
+      "flask-login": {
+        "sha256": "1ef79843f5eddd0f143c2cd994c1b05ac83c0401dc6234c143495af9a939613f",
+        "url": "https://files.pythonhosted.org/packages/a6/94/01b658bef1863a07f4738a322cce87d97be4362645255dc1182f7f5c075a/Flask_Login-0.6.2-py3-none-any.whl",
+        "version": "0.6.2"
+      },
+      "flask-session": {
+        "sha256": "1e3f8a317005db72c831f85d884a5a9d23145f256c730d80b325a3150a22c3db",
+        "url": "https://files.pythonhosted.org/packages/83/ae/13f06537405f8e04868f578295fa94bd46f0c1764431417a4059e2b54c91/Flask_Session-0.4.0-py2.py3-none-any.whl",
+        "version": "0.4.0"
+      },
+      "flask-sqlalchemy": {
+        "sha256": "f12c3d4cc5cc7fdcc148b9527ea05671718c3ea45d50c7e732cceb33f574b390",
+        "url": "https://files.pythonhosted.org/packages/26/2c/9088b6bd95bca539230bbe9ad446737ed391aab9a83aff403e18dded3e75/Flask_SQLAlchemy-2.5.1-py2.py3-none-any.whl",
+        "version": "2.5.1"
+      },
+      "flask-wtf": {
+        "sha256": "9d733658c80be551ce7d5bc13c7a7ac0d80df509be1e23827c847d9520f4359a",
+        "url": "https://files.pythonhosted.org/packages/3a/26/3803ee692eb9a8d21bf7ba1cecd649ce3a55899c65467bdfc1bad13ec50f/Flask_WTF-1.0.1-py3-none-any.whl",
+        "version": "1.0.1"
+      },
+      "graphviz": {
+        "sha256": "587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977",
+        "url": "https://files.pythonhosted.org/packages/de/5e/fcbb22c68208d39edff467809d06c9d81d7d27426460ebc598e55130c1aa/graphviz-0.20.1-py3-none-any.whl",
+        "version": "0.20.1"
+      },
+      "gunicorn": {
+        "sha256": "9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e",
+        "url": "https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl",
+        "version": "20.1.0"
+      },
+      "h11": {
+        "sha256": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761",
+        "url": "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl",
+        "version": "0.14.0"
+      },
+      "httpcore": {
+        "sha256": "da1fb708784a938aa084bde4feb8317056c55037247c787bd7e19eb2c2949dc0",
+        "url": "https://files.pythonhosted.org/packages/04/7e/ef97af4623024e8159993b3114ce208de4f677098ae058ec5882a1bf7605/httpcore-0.16.3-py3-none-any.whl",
+        "version": "0.16.3"
+      },
+      "httpx": {
+        "sha256": "0b9b1f0ee18b9978d637b0776bfd7f54e2ca278e063e3586d8f01cda89e042a8",
+        "url": "https://files.pythonhosted.org/packages/e1/74/cdce73069e021ad5913451b86c2707b027975cf302016ca557686d87eb41/httpx-0.23.1-py3-none-any.whl",
+        "version": "0.23.1"
+      },
+      "idna": {
+        "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+        "version": "3.4"
+      },
+      "inflection": {
+        "sha256": "f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2",
+        "url": "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl",
+        "version": "0.5.1"
+      },
+      "itsdangerous": {
+        "sha256": "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
+        "url": "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl",
+        "version": "2.1.2"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "jsonschema": {
+        "sha256": "a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6",
+        "url": "https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl",
+        "version": "4.17.3"
+      },
+      "lazy-object-proxy": {
+        "sha256": "c219a00245af0f6fa4e95901ed28044544f50152840c5b6a3e7b2568db34d156",
+        "url": "https://files.pythonhosted.org/packages/74/37/591f89e8a09ae4574391bdf8a5eecd34a3dbe545917333e625c9de9a66b0/lazy-object-proxy-1.8.0.tar.gz",
+        "version": "1.8.0"
+      },
+      "linkify-it-py": {
+        "sha256": "1bff43823e24e507a099e328fc54696124423dd6320c75a9da45b4b754b748ad",
+        "url": "https://files.pythonhosted.org/packages/fa/1a/2280e2eb892162ef5c0480a131d1d176b61f5f24abdce8dd9862454f7d14/linkify_it_py-2.0.0-py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "lockfile": {
+        "sha256": "6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa",
+        "url": "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl",
+        "version": "0.12.2"
+      },
+      "mako": {
+        "sha256": "c97c79c018b9165ac9922ae4f32da095ffd3c4e6872b45eded42926deea46818",
+        "url": "https://files.pythonhosted.org/packages/03/3b/68690a035ba7347860f1b8c0cde853230ba69ff41df5884ea7d89fe68cd3/Mako-1.2.4-py3-none-any.whl",
+        "version": "1.2.4"
+      },
+      "markdown": {
+        "sha256": "08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186",
+        "url": "https://files.pythonhosted.org/packages/86/be/ad281f7a3686b38dd8a307fa33210cdf2130404dfef668a37a4166d737ca/Markdown-3.4.1-py3-none-any.whl",
+        "version": "3.4.1"
+      },
+      "markdown-it-py": {
+        "sha256": "93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27",
+        "url": "https://files.pythonhosted.org/packages/f9/3f/ecd1b708973b9a3e4574b43cffc1ce8eb98696da34f1a1c44a68c3c0d737/markdown_it_py-2.1.0-py3-none-any.whl",
+        "version": "2.1.0"
+      },
+      "markupsafe": {
+        "sha256": "86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+        "url": "https://files.pythonhosted.org/packages/d9/60/94e9de017674f88a514804e2924bdede9a642aba179d2045214719d6ec76/MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl",
+        "version": "2.1.1"
+      },
+      "marshmallow": {
+        "sha256": "93f0958568da045b0021ec6aeb7ac37c81bfcccbb9a0e7ed8559885070b3a19b",
+        "url": "https://files.pythonhosted.org/packages/ae/53/980a20d789029329fdf1546c315f9c92bf862c7f3e7294e3667afcc464f5/marshmallow-3.19.0-py3-none-any.whl",
+        "version": "3.19.0"
+      },
+      "marshmallow-enum": {
+        "sha256": "57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072",
+        "url": "https://files.pythonhosted.org/packages/c6/59/ef3a3dc499be447098d4a89399beb869f813fee1b5a57d5d79dee2c1bf51/marshmallow_enum-1.5.1-py2.py3-none-any.whl",
+        "version": "1.5.1"
+      },
+      "marshmallow-oneofschema": {
+        "sha256": "bd29410a9f2f7457a2b428286e2a80ef76b8ddc3701527dc1f935a88914b02f2",
+        "url": "https://files.pythonhosted.org/packages/ca/eb/3f6d90ba82b2dd319c7d3534a90ba3f4bdf2e332e89c2399fdc818051589/marshmallow_oneofschema-3.0.1-py2.py3-none-any.whl",
+        "version": "3.0.1"
+      },
+      "marshmallow-sqlalchemy": {
+        "sha256": "ba7493eeb8669a3bf00d8f906b657feaa87a740ae9e4ecf829cfd6ddf763d276",
+        "url": "https://files.pythonhosted.org/packages/d1/84/1f4d7393d04f2ae0d4098791d1901a713f45ba70ff6f3c35ff2f7fd81f7b/marshmallow_sqlalchemy-0.26.1-py2.py3-none-any.whl",
+        "version": "0.26.1"
+      },
+      "mdit-py-plugins": {
+        "sha256": "36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9",
+        "url": "https://files.pythonhosted.org/packages/33/eb/c358112e8265f827cf8228eda36cf2a720ad933f5ca66f47f808edf4bb34/mdit_py_plugins-0.3.3-py3-none-any.whl",
+        "version": "0.3.3"
+      },
+      "mdurl": {
+        "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+        "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+        "version": "0.1.2"
+      },
+      "packaging": {
+        "sha256": "957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3",
+        "url": "https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl",
+        "version": "22.0"
+      },
+      "pathspec": {
+        "sha256": "7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+        "url": "https://files.pythonhosted.org/packages/42/ba/a9d64c7bcbc7e3e8e5f93a52721b377e994c22d16196e2b0f1236774353a/pathspec-0.9.0-py2.py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "pendulum": {
+        "sha256": "b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207",
+        "url": "https://files.pythonhosted.org/packages/db/15/6e89ae7cde7907118769ed3d2481566d05b5fd362724025198bb95faf599/pendulum-2.1.2.tar.gz",
+        "version": "2.1.2"
+      },
+      "pluggy": {
+        "sha256": "74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3",
+        "url": "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl",
+        "version": "1.0.0"
+      },
+      "prison": {
+        "sha256": "f90bab63fca497aa0819a852f64fb21a4e181ed9f6114deaa5dc04001a7555c5",
+        "url": "https://files.pythonhosted.org/packages/f1/bd/e55e14cd213174100be0353824f2add41e8996c6f32081888897e8ec48b5/prison-0.2.1-py2.py3-none-any.whl",
+        "version": "0.2.1"
+      },
+      "psutil": {
+        "sha256": "6001c809253a29599bc0dfd5179d9f8a5779f9dffea1da0f13c53ee568115e1e",
+        "url": "https://files.pythonhosted.org/packages/79/26/f026804298b933b11640cc2d15155a545805df732e5ead3a2ad7cf45a38b/psutil-5.9.4-cp38-abi3-macosx_11_0_arm64.whl",
+        "version": "5.9.4"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "pygments": {
+        "sha256": "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
+        "url": "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl",
+        "version": "2.13.0"
+      },
+      "pyjwt": {
+        "sha256": "d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14",
+        "url": "https://files.pythonhosted.org/packages/40/46/505f0dd53c14096f01922bf93a7abb4e40e29a06f858abbaa791e6954324/PyJWT-2.6.0-py3-none-any.whl",
+        "version": "2.6.0"
+      },
+      "pyrsistent": {
+        "sha256": "20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a",
+        "url": "https://files.pythonhosted.org/packages/ed/7b/7d032130a6838b179b46dff1ee88909c11d518a10ec9bc70c4b72c7c2f80/pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl",
+        "version": "0.19.3"
+      },
+      "python-daemon": {
+        "sha256": "01d26358598f8c3f5fc6de553e2f3080ffc59cf89102d7ee8098f33c72b3c04c",
+        "url": "https://files.pythonhosted.org/packages/89/38/c223036ee8104ae95118d4481b5cacccf4547d7e5b8d1ee1c63d2cd57e5d/python_daemon-2.3.2-py3-none-any.whl",
+        "version": "2.3.2"
+      },
+      "python-dateutil": {
+        "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+        "url": "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl",
+        "version": "2.8.2"
+      },
+      "python-nvd3": {
+        "sha256": "fbd75ff47e0ef255b4aa4f3a8b10dc8b4024aa5a9a7abed5b2406bd3cb817715",
+        "url": "https://files.pythonhosted.org/packages/0b/aa/97165daa6e319409c5c2582e62736a7353bda3c90d90fdcb0b11e116dd2d/python-nvd3-0.15.0.tar.gz",
+        "version": "0.15.0"
+      },
+      "python-slugify": {
+        "sha256": "003aee64f9fd955d111549f96c4b58a3f40b9319383c70fad6277a4974bbf570",
+        "url": "https://files.pythonhosted.org/packages/63/65/d0d7c085964fdf0cb294299663b407c38e2c8e8dd13bafcf5681798c12db/python_slugify-7.0.0-py2.py3-none-any.whl",
+        "version": "7.0.0"
+      },
+      "pytz": {
+        "sha256": "93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd",
+        "url": "https://files.pythonhosted.org/packages/3d/19/4de17f0d5cf5a0d87aa67532d4c2fa75e6e7d8df13c27635ff40fa6f4b76/pytz-2022.7-py2.py3-none-any.whl",
+        "version": "2022.7"
+      },
+      "pytzdata": {
+        "sha256": "e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f",
+        "url": "https://files.pythonhosted.org/packages/e0/4f/4474bda990ee740a020cbc3eb271925ef7daa7c8444240d34ff62c8442a3/pytzdata-2020.1-py2.py3-none-any.whl",
+        "version": "2020.1"
+      },
+      "pyyaml": {
+        "sha256": "9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+        "url": "https://files.pythonhosted.org/packages/91/49/d46d7b15cddfa98533e89f3832f391aedf7e31f37b4d4df3a7a7855a7073/PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl",
+        "version": "6.0"
+      },
+      "requests": {
+        "sha256": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
+        "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl",
+        "version": "2.28.1"
+      },
+      "requests-toolbelt": {
+        "sha256": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+        "url": "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl",
+        "version": "0.10.1"
+      },
+      "rfc3986": {
+        "sha256": "a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97",
+        "url": "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl",
+        "version": "1.5.0"
+      },
+      "rich": {
+        "sha256": "12b1d77ee7edf251b741531323f0d990f5f570a4e7c054d0bfb59fb7981ad977",
+        "url": "https://files.pythonhosted.org/packages/92/37/2732511fdd5c6e037af9e92b87dbb50049c02fd3a8c070bc75eed6c798b3/rich-13.0.0-py3-none-any.whl",
+        "version": "13.0.0"
+      },
+      "setproctitle": {
+        "sha256": "288943dec88e178bb2fd868adf491197cc0fc8b6810416b1c6775e686bab87fe",
+        "url": "https://files.pythonhosted.org/packages/04/a9/19a77c1ead9b0b3e9e366aafb64d8cdf31ed25e42a781dded07907332300/setproctitle-1.3.2-cp310-cp310-macosx_10_9_universal2.whl",
+        "version": "1.3.2"
+      },
+      "setuptools": {
+        "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+        "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl",
+        "version": "65.6.3"
+      },
+      "setuptools-scm": {
+        "sha256": "73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e",
+        "url": "https://files.pythonhosted.org/packages/1d/66/8f42c941be949ef2b22fe905d850c794e7c170a526023612aad5f3a121ad/setuptools_scm-7.1.0-py3-none-any.whl",
+        "version": "7.1.0"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      },
+      "sniffio": {
+        "sha256": "eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384",
+        "url": "https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl",
+        "version": "1.3.0"
+      },
+      "sqlalchemy": {
+        "sha256": "fd69850860093a3f69fefe0ab56d041edfdfe18510b53d9a2eaecba2f15fa795",
+        "url": "https://files.pythonhosted.org/packages/76/d5/9ce70fd0d2858c72ecacff0c0518e9ddfbbaf4753b85e49f6d94ad74de36/SQLAlchemy-1.4.45.tar.gz",
+        "version": "1.4.45"
+      },
+      "sqlalchemy-jsonfield": {
+        "sha256": "d6f1e5ee329a3c0d9d164e40d81a2143ac8332e09988fbbaff84179dac5503d4",
+        "url": "https://files.pythonhosted.org/packages/38/1c/283e6216c21827fb1358f2f409432828f9df4e402182cf590a1cc5a8874f/SQLAlchemy_JSONField-1.0.1.post0-py3-none-any.whl",
+        "version": "1.0.1.post0"
+      },
+      "sqlalchemy-utils": {
+        "sha256": "9da26a9b20c6979167772ba5dc2a1d01265648f18c82995f082279a399ea308b",
+        "url": "https://files.pythonhosted.org/packages/12/c2/131e1c6ff887fde1783c1f21e9d132fb799b9c5680abb88c35f40a32a26c/SQLAlchemy_Utils-0.39.0-py3-none-any.whl",
+        "version": "0.39.0"
+      },
+      "sqlparse": {
+        "sha256": "0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
+        "url": "https://files.pythonhosted.org/packages/97/d3/31dd2c3e48fc2060819f4acb0686248250a0f2326356306b38a42e059144/sqlparse-0.4.3-py3-none-any.whl",
+        "version": "0.4.3"
+      },
+      "swagger-ui-bundle": {
+        "sha256": "cea116ed81147c345001027325c1ddc9ca78c1ee7319935c3c75d3669279d575",
+        "url": "https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl",
+        "version": "0.0.9"
+      },
+      "tabulate": {
+        "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
+        "url": "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "tenacity": {
+        "sha256": "35525cd47f82830069f0d6b73f7eb83bc5b73ee2fff0437952cedf98b27653ac",
+        "url": "https://files.pythonhosted.org/packages/a5/94/933ce16d18450ccf518a6da5bd51418611e8776b992070b9f40b2f9cedff/tenacity-8.1.0-py3-none-any.whl",
+        "version": "8.1.0"
+      },
+      "termcolor": {
+        "sha256": "fa852e957f97252205e105dd55bbc23b419a70fec0085708fc0515e399f304fd",
+        "url": "https://files.pythonhosted.org/packages/c3/23/16f4cdb09368524cd7cf47c2950663dd197a6c180cd5b6db01dcb65c5135/termcolor-2.1.1-py3-none-any.whl",
+        "version": "2.1.1"
+      },
+      "text-unidecode": {
+        "sha256": "1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+        "url": "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl",
+        "version": "1.3"
+      },
+      "tomli": {
+        "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+        "version": "2.0.1"
+      },
+      "typing-extensions": {
+        "sha256": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
+        "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl",
+        "version": "4.4.0"
+      },
+      "uc-micro-py": {
+        "sha256": "316cfb8b6862a0f1d03540f0ae6e7b033ff1fa0ddbe60c12cbe0d4cec846a69f",
+        "url": "https://files.pythonhosted.org/packages/14/0e/738dbd15b1afe372d0d788e1e2112cfa67c9cf9e1c777360eaf9cd429caf/uc_micro_py-1.0.1-py3-none-any.whl",
+        "version": "1.0.1"
+      },
+      "unicodecsv": {
+        "sha256": "018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc",
+        "url": "https://files.pythonhosted.org/packages/6f/a4/691ab63b17505a26096608cc309960b5a6bdf39e4ba1a793d5f9b1a53270/unicodecsv-0.14.1.tar.gz",
+        "version": "0.14.1"
+      },
+      "urllib3": {
+        "sha256": "47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+        "url": "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl",
+        "version": "1.26.13"
+      },
+      "werkzeug": {
+        "sha256": "f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5",
+        "url": "https://files.pythonhosted.org/packages/c8/27/be6ddbcf60115305205de79c29004a0c6bc53cec814f733467b1bb89386d/Werkzeug-2.2.2-py3-none-any.whl",
+        "version": "2.2.2"
+      },
+      "wrapt": {
+        "sha256": "07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+        "url": "https://files.pythonhosted.org/packages/39/4d/34599a47c8a41b3ea4986e14f728c293a8a96cd6c23663fe33657c607d34/wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl",
+        "version": "1.14.1"
+      },
+      "wtforms": {
+        "sha256": "837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b",
+        "url": "https://files.pythonhosted.org/packages/eb/2e/199a0edf6577af771a68fbd950d98f0c1a16bb5fa956e45772005318c702/WTForms-3.0.1-py3-none-any.whl",
+        "version": "3.0.1"
+      }
+    },
+    "targets": {
+      "default": {
+        "alembic": [
+          "mako",
+          "sqlalchemy"
+        ],
+        "anyio": [
+          "idna",
+          "sniffio"
+        ],
+        "apache-airflow": [
+          "alembic",
+          "apache-airflow-providers-common-sql",
+          "apache-airflow-providers-ftp",
+          "apache-airflow-providers-http",
+          "apache-airflow-providers-imap",
+          "apache-airflow-providers-sqlite",
+          "argcomplete",
+          "attrs",
+          "blinker",
+          "cattrs",
+          "colorlog",
+          "configupdater",
+          "connexion",
+          "cron-descriptor",
+          "croniter",
+          "cryptography",
+          "deprecated",
+          "dill",
+          "flask",
+          "flask-appbuilder",
+          "flask-caching",
+          "flask-login",
+          "flask-session",
+          "flask-wtf",
+          "graphviz",
+          "gunicorn",
+          "httpx",
+          "itsdangerous",
+          "jinja2",
+          "jsonschema",
+          "lazy-object-proxy",
+          "linkify-it-py",
+          "lockfile",
+          "markdown",
+          "markdown-it-py",
+          "markupsafe",
+          "marshmallow-oneofschema",
+          "mdit-py-plugins",
+          "packaging",
+          "pathspec",
+          "pendulum",
+          "pluggy",
+          "psutil",
+          "pygments",
+          "pyjwt",
+          "python-daemon",
+          "python-dateutil",
+          "python-nvd3",
+          "python-slugify",
+          "rich",
+          "setproctitle",
+          "sqlalchemy",
+          "sqlalchemy-jsonfield",
+          "tabulate",
+          "tenacity",
+          "termcolor",
+          "typing-extensions",
+          "unicodecsv",
+          "werkzeug"
+        ],
+        "apache-airflow-providers-common-sql": [
+          "sqlparse"
+        ],
+        "apache-airflow-providers-ftp": [],
+        "apache-airflow-providers-http": [
+          "requests",
+          "requests-toolbelt"
+        ],
+        "apache-airflow-providers-imap": [],
+        "apache-airflow-providers-sqlite": [
+          "apache-airflow-providers-common-sql"
+        ],
+        "apispec": [
+          "pyyaml"
+        ],
+        "argcomplete": [],
+        "attrs": [],
+        "babel": [
+          "pytz"
+        ],
+        "blinker": [],
+        "cachelib": [],
+        "cattrs": [
+          "attrs",
+          "exceptiongroup"
+        ],
+        "certifi": [],
+        "cffi": [
+          "pycparser"
+        ],
+        "charset-normalizer": [],
+        "click": [],
+        "clickclick": [
+          "click",
+          "pyyaml"
+        ],
+        "colorama": [],
+        "colorlog": [],
+        "commonmark": [],
+        "configupdater": [],
+        "connexion": [
+          "clickclick",
+          "flask",
+          "inflection",
+          "itsdangerous",
+          "jsonschema",
+          "packaging",
+          "pyyaml",
+          "requests",
+          "swagger-ui-bundle",
+          "werkzeug"
+        ],
+        "cron-descriptor": [],
+        "croniter": [
+          "python-dateutil"
+        ],
+        "cryptography": [
+          "cffi"
+        ],
+        "deprecated": [
+          "wrapt"
+        ],
+        "dill": [],
+        "dnspython": [],
+        "docutils": [],
+        "email-validator": [
+          "dnspython",
+          "idna"
+        ],
+        "exceptiongroup": [],
+        "flask": [
+          "click",
+          "itsdangerous",
+          "jinja2",
+          "werkzeug"
+        ],
+        "flask-appbuilder": [
+          "apispec",
+          "click",
+          "colorama",
+          "email-validator",
+          "flask",
+          "flask-babel",
+          "flask-jwt-extended",
+          "flask-login",
+          "flask-sqlalchemy",
+          "flask-wtf",
+          "jsonschema",
+          "marshmallow",
+          "marshmallow-enum",
+          "marshmallow-sqlalchemy",
+          "prison",
+          "pyjwt",
+          "python-dateutil",
+          "sqlalchemy",
+          "sqlalchemy-utils",
+          "wtforms"
+        ],
+        "flask-babel": [
+          "babel",
+          "flask",
+          "jinja2",
+          "pytz"
+        ],
+        "flask-caching": [
+          "cachelib",
+          "flask"
+        ],
+        "flask-jwt-extended": [
+          "flask",
+          "pyjwt",
+          "werkzeug"
+        ],
+        "flask-login": [
+          "flask",
+          "werkzeug"
+        ],
+        "flask-session": [
+          "cachelib",
+          "flask"
+        ],
+        "flask-sqlalchemy": [
+          "flask",
+          "sqlalchemy"
+        ],
+        "flask-wtf": [
+          "flask",
+          "itsdangerous",
+          "wtforms"
+        ],
+        "graphviz": [],
+        "gunicorn": [
+          "setuptools"
+        ],
+        "h11": [],
+        "httpcore": [
+          "anyio",
+          "certifi",
+          "h11",
+          "sniffio"
+        ],
+        "httpx": [
+          "certifi",
+          "httpcore",
+          "rfc3986",
+          "sniffio"
+        ],
+        "idna": [],
+        "inflection": [],
+        "itsdangerous": [],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "jsonschema": [
+          "attrs",
+          "pyrsistent"
+        ],
+        "lazy-object-proxy": [],
+        "linkify-it-py": [
+          "uc-micro-py"
+        ],
+        "lockfile": [],
+        "mako": [
+          "markupsafe"
+        ],
+        "markdown": [],
+        "markdown-it-py": [
+          "mdurl"
+        ],
+        "markupsafe": [],
+        "marshmallow": [
+          "packaging"
+        ],
+        "marshmallow-enum": [
+          "marshmallow"
+        ],
+        "marshmallow-oneofschema": [
+          "marshmallow"
+        ],
+        "marshmallow-sqlalchemy": [
+          "marshmallow",
+          "sqlalchemy"
+        ],
+        "mdit-py-plugins": [
+          "markdown-it-py"
+        ],
+        "mdurl": [],
+        "packaging": [],
+        "pathspec": [],
+        "pendulum": [
+          "python-dateutil",
+          "pytzdata"
+        ],
+        "pluggy": [],
+        "prison": [
+          "six"
+        ],
+        "psutil": [],
+        "pycparser": [],
+        "pygments": [],
+        "pyjwt": [],
+        "pyrsistent": [],
+        "python-daemon": [
+          "docutils",
+          "lockfile",
+          "setuptools"
+        ],
+        "python-dateutil": [
+          "six"
+        ],
+        "python-nvd3": [
+          "jinja2",
+          "python-slugify"
+        ],
+        "python-slugify": [
+          "text-unidecode"
+        ],
+        "pytz": [],
+        "pytzdata": [],
+        "pyyaml": [],
+        "requests": [
+          "certifi",
+          "charset-normalizer",
+          "idna",
+          "urllib3"
+        ],
+        "requests-toolbelt": [
+          "requests"
+        ],
+        "rfc3986": [
+          "idna"
+        ],
+        "rich": [
+          "commonmark",
+          "pygments"
+        ],
+        "setproctitle": [],
+        "setuptools": [],
+        "setuptools-scm": [
+          "packaging",
+          "setuptools",
+          "tomli",
+          "typing-extensions"
+        ],
+        "six": [],
+        "sniffio": [],
+        "sqlalchemy": [],
+        "sqlalchemy-jsonfield": [
+          "sqlalchemy"
+        ],
+        "sqlalchemy-utils": [
+          "sqlalchemy"
+        ],
+        "sqlparse": [],
+        "swagger-ui-bundle": [
+          "jinja2"
+        ],
+        "tabulate": [],
+        "tenacity": [],
+        "termcolor": [],
+        "text-unidecode": [],
+        "tomli": [],
+        "typing-extensions": [],
+        "uc-micro-py": [],
+        "unicodecsv": [],
+        "urllib3": [],
+        "werkzeug": [
+          "markupsafe"
+        ],
+        "wrapt": [],
+        "wtforms": [
+          "markupsafe"
+        ]
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/apache-airflow/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/apache-airflow/lock-x86_64-darwin.json
@@ -1,0 +1,905 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "alembic": {
+        "sha256": "a9781ed0979a20341c2cbb56bd22bd8db4fc1913f955e705444bd3a97c59fa32",
+        "url": "https://files.pythonhosted.org/packages/67/8d/694d5c1de901de71cd6d5fb2d0e19cad29b5615c6b56dabcf0a4aaf34082/alembic-1.9.1-py3-none-any.whl",
+        "version": "1.9.1"
+      },
+      "anyio": {
+        "sha256": "fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3",
+        "url": "https://files.pythonhosted.org/packages/77/2b/b4c0b7a3f3d61adb1a1e0b78f90a94e2b6162a043880704b7437ef297cad/anyio-3.6.2-py3-none-any.whl",
+        "version": "3.6.2"
+      },
+      "apache-airflow": {
+        "sha256": "fb2c2768e3a233e60b110431b907045256a224cffaf01fa475ccef3db8d6edd3",
+        "url": "https://files.pythonhosted.org/packages/94/3a/3d050e3decaf7c1064e6e0e5e06f5f9be6c7476b438f8d25e458421e2e13/apache_airflow-2.5.0-py3-none-any.whl",
+        "version": "2.5.0"
+      },
+      "apache-airflow-providers-common-sql": {
+        "sha256": "352e7303149083687635b1d8b401b0925bccaeb7c493a9dc1416b828d9891fc7",
+        "url": "https://files.pythonhosted.org/packages/9f/65/8127df3048051278b7f3f8a0ba834533ead54fc6a292ec498ec636268703/apache_airflow_providers_common_sql-1.3.1-py3-none-any.whl",
+        "version": "1.3.1"
+      },
+      "apache-airflow-providers-ftp": {
+        "sha256": "b2eee640f7eaf0fff3ebeeacc83fe0c315aa297de8780a5a6aededfeeb7e11e0",
+        "url": "https://files.pythonhosted.org/packages/9b/cf/d4368604feca0b93dd29dce04c19ae4e5a62071ad44faf9d13210ace3a3c/apache_airflow_providers_ftp-3.2.0-py3-none-any.whl",
+        "version": "3.2.0"
+      },
+      "apache-airflow-providers-http": {
+        "sha256": "c424945876ba3d40ef108e73973aba646509336f589f9d0a11a44786e6dac2b7",
+        "url": "https://files.pythonhosted.org/packages/48/74/ec2dcbc3a8dc442b5d427658e516f8b7410bcc4823bb091c8be2823a4a67/apache_airflow_providers_http-4.1.0-py3-none-any.whl",
+        "version": "4.1.0"
+      },
+      "apache-airflow-providers-imap": {
+        "sha256": "79da5956637788c19fd3a152bb20fb476c980fdad80724fec8ade02abe47834b",
+        "url": "https://files.pythonhosted.org/packages/63/41/bcf07b9be7802a8ff18b2ae6e1f8b5c3ae3aa119c5739b1f0aac8e865734/apache_airflow_providers_imap-3.1.0-py3-none-any.whl",
+        "version": "3.1.0"
+      },
+      "apache-airflow-providers-sqlite": {
+        "sha256": "f282247f29a3130eae6c05d8c41cee012e1b7d482c6a7ed058deef01e9af1c43",
+        "url": "https://files.pythonhosted.org/packages/e3/cf/dcacb9649a4f0004871d040ddbce429404a6af82df18b964432790022f0a/apache_airflow_providers_sqlite-3.3.1-py3-none-any.whl",
+        "version": "3.3.1"
+      },
+      "apispec": {
+        "sha256": "a1df9ec6b2cd0edf45039ef025abd7f0660808fa2edf737d3ba1cf5ef1a4625b",
+        "url": "https://files.pythonhosted.org/packages/35/a2/80a82b22296c942a5298bb760e8e21c86ace3342de840ff3df8938af4272/apispec-3.3.2-py2.py3-none-any.whl",
+        "version": "3.3.2"
+      },
+      "argcomplete": {
+        "sha256": "cffa11ea77999bb0dd27bb25ff6dc142a6796142f68d45b1a26b11f58724561e",
+        "url": "https://files.pythonhosted.org/packages/d3/e5/c5509683462e51b070df9e83e7f72c1ccfe3f733f328b4a0f06804c27278/argcomplete-2.0.0-py2.py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "attrs": {
+        "sha256": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+        "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl",
+        "version": "22.2.0"
+      },
+      "babel": {
+        "sha256": "1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe",
+        "url": "https://files.pythonhosted.org/packages/92/f7/86301a69926e11cd52f73396d169554d09b20b1723a040c2dcc1559ef588/Babel-2.11.0-py3-none-any.whl",
+        "version": "2.11.0"
+      },
+      "blinker": {
+        "sha256": "1eb563df6fdbc39eeddc177d953203f99f097e9bf0e2b8f9f3cf18b6ca425e36",
+        "url": "https://files.pythonhosted.org/packages/30/41/caa5da2dbe6d26029dfe11d31dfa8132b4d6d30b6d6b61a24824075a5f06/blinker-1.5-py2.py3-none-any.whl",
+        "version": "1.5"
+      },
+      "cachelib": {
+        "sha256": "811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3",
+        "url": "https://files.pythonhosted.org/packages/93/70/58e525451478055b0fd2859b22226888a6985d404fe65e014fc4893d3b75/cachelib-0.9.0-py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "cattrs": {
+        "sha256": "bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21",
+        "url": "https://files.pythonhosted.org/packages/43/3b/1d34fc4449174dfd2bc5ad7047a23edb6558b2e4b5a41b25a8ad6655c6c7/cattrs-22.2.0-py3-none-any.whl",
+        "version": "22.2.0"
+      },
+      "certifi": {
+        "sha256": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+        "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl",
+        "version": "2022.12.7"
+      },
+      "cffi": {
+        "sha256": "39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+        "url": "https://files.pythonhosted.org/packages/e8/ff/c4b7a358526f231efa46a375c959506c87622fb4a2c5726e827c55e6adf2/cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "1.15.1"
+      },
+      "charset-normalizer": {
+        "sha256": "83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f",
+        "url": "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl",
+        "version": "2.1.1"
+      },
+      "click": {
+        "sha256": "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
+        "url": "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl",
+        "version": "8.1.3"
+      },
+      "clickclick": {
+        "sha256": "c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5",
+        "url": "https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl",
+        "version": "20.10.2"
+      },
+      "colorama": {
+        "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+        "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+        "version": "0.4.6"
+      },
+      "colorlog": {
+        "sha256": "3dd15cb27e8119a24c1a7b5c93f9f3b455855e0f73993b1c25921b2f646f1dcd",
+        "url": "https://files.pythonhosted.org/packages/51/62/61449c6bb74c2a3953c415b2cdb488e4f0518ac67b35e2b03a6d543035ca/colorlog-4.8.0-py2.py3-none-any.whl",
+        "version": "4.8.0"
+      },
+      "commonmark": {
+        "sha256": "da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9",
+        "url": "https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl",
+        "version": "0.9.1"
+      },
+      "configupdater": {
+        "sha256": "805986dbeba317886c7a8d348b2e34986dc9e3128cd3761ecc35decbd372b286",
+        "url": "https://files.pythonhosted.org/packages/4d/13/6791bba527baf3648be8aabaf6d3775027c3ebbf4000f2ae16867911b879/ConfigUpdater-3.1.1-py2.py3-none-any.whl",
+        "version": "3.1.1"
+      },
+      "connexion": {
+        "sha256": "f343717241b4c4802a694c38fee66fb1693c897fe4ea5a957fa9b3b07caf6394",
+        "url": "https://files.pythonhosted.org/packages/de/ce/1ed67157e4d5fae496be1a82e0c1003bcef944dad0f902c4f6c3fd1c8f4d/connexion-2.14.1-py2.py3-none-any.whl",
+        "version": "2.14.1"
+      },
+      "cron-descriptor": {
+        "sha256": "a8554e91483f9977c3e5fa90a3c7a06fb97472ec9b160df6fe89f3114658236d",
+        "url": "https://files.pythonhosted.org/packages/7d/4f/fc70577320a99982006ab4ee11f5d5fb0f819aff2e5fff0b6bc54ff19c96/cron_descriptor-1.2.32.tar.gz",
+        "version": "1.2.32"
+      },
+      "croniter": {
+        "sha256": "d6ed8386d5f4bbb29419dc1b65c4909c04a2322bd15ec0dc5b2877bfa1b75c7a",
+        "url": "https://files.pythonhosted.org/packages/0f/4d/0cc5a7f4bdcefecebdf8a95c8372606c13d3355e8536d9cd3e7070e94269/croniter-1.3.8-py2.py3-none-any.whl",
+        "version": "1.3.8"
+      },
+      "cryptography": {
+        "sha256": "1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb",
+        "url": "https://files.pythonhosted.org/packages/52/1b/49ebc2b59e9126f1f378ae910e98704d54a3f48b78e2d6d6c8cfe6fbe06f/cryptography-38.0.4-cp36-abi3-macosx_10_10_x86_64.whl",
+        "version": "38.0.4"
+      },
+      "deprecated": {
+        "sha256": "64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d",
+        "url": "https://files.pythonhosted.org/packages/51/6a/c3a0408646408f7283b7bc550c30a32cc791181ec4618592eec13e066ce3/Deprecated-1.2.13-py2.py3-none-any.whl",
+        "version": "1.2.13"
+      },
+      "dill": {
+        "sha256": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
+        "url": "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl",
+        "version": "0.3.6"
+      },
+      "dnspython": {
+        "sha256": "a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f",
+        "url": "https://files.pythonhosted.org/packages/9b/ed/28fb14146c7033ba0e89decd92a4fa16b0b69b84471e2deab3cc4337cc35/dnspython-2.2.1-py3-none-any.whl",
+        "version": "2.2.1"
+      },
+      "docutils": {
+        "sha256": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc",
+        "url": "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl",
+        "version": "0.19"
+      },
+      "email-validator": {
+        "sha256": "816073f2a7cffef786b29928f58ec16cdac42710a53bb18aa94317e3e145ec5c",
+        "url": "https://files.pythonhosted.org/packages/e7/d3/88997ca4903c70fb6eec2e29501a35f84aaf34790f207febdf188e374377/email_validator-1.3.0-py2.py3-none-any.whl",
+        "version": "1.3.0"
+      },
+      "exceptiongroup": {
+        "sha256": "327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+        "url": "https://files.pythonhosted.org/packages/e8/14/9c6a7e5f12294ccd6975a45e02899ed25468cd7c2c86f3d9725f387f9f5f/exceptiongroup-1.1.0-py3-none-any.whl",
+        "version": "1.1.0"
+      },
+      "flask": {
+        "sha256": "b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526",
+        "url": "https://files.pythonhosted.org/packages/0f/43/15f4f9ab225b0b25352412e8daa3d0e3d135fcf5e127070c74c3632c8b4c/Flask-2.2.2-py3-none-any.whl",
+        "version": "2.2.2"
+      },
+      "flask-appbuilder": {
+        "sha256": "682e18fab43ccec8f4aac696f090ae45326b0ee1f3ad9608896111ff8405a7a4",
+        "url": "https://files.pythonhosted.org/packages/3b/28/9acebe45a02908193b28668867b8e948e747e37cb95937ee5f0281d71e27/Flask_AppBuilder-4.1.4-py3-none-any.whl",
+        "version": "4.1.4"
+      },
+      "flask-babel": {
+        "sha256": "e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468",
+        "url": "https://files.pythonhosted.org/packages/ab/3e/02331179ffab8b79e0383606a028b6a60fb1b4419b84935edd43223406a0/Flask_Babel-2.0.0-py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "flask-caching": {
+        "sha256": "703df847cbe904d8ddffd5f5fb320e236a31cb7bebac4a93d6b1701dd16dbf37",
+        "url": "https://files.pythonhosted.org/packages/8b/3c/9b767cd054aa23283b55f45fca0bc6afc74c425ea15b67c8cd324ead9c06/Flask_Caching-2.0.1-py3-none-any.whl",
+        "version": "2.0.1"
+      },
+      "flask-jwt-extended": {
+        "sha256": "a85eebfa17c339a7260c4643475af444784ba6de5588adda67406f0a75599553",
+        "url": "https://files.pythonhosted.org/packages/83/5a/f688f884d9bd10b0cf1b34373b5634ddc340f2b1a099d014bc3c997bf562/Flask_JWT_Extended-4.4.4-py2.py3-none-any.whl",
+        "version": "4.4.4"
+      },
+      "flask-login": {
+        "sha256": "1ef79843f5eddd0f143c2cd994c1b05ac83c0401dc6234c143495af9a939613f",
+        "url": "https://files.pythonhosted.org/packages/a6/94/01b658bef1863a07f4738a322cce87d97be4362645255dc1182f7f5c075a/Flask_Login-0.6.2-py3-none-any.whl",
+        "version": "0.6.2"
+      },
+      "flask-session": {
+        "sha256": "1e3f8a317005db72c831f85d884a5a9d23145f256c730d80b325a3150a22c3db",
+        "url": "https://files.pythonhosted.org/packages/83/ae/13f06537405f8e04868f578295fa94bd46f0c1764431417a4059e2b54c91/Flask_Session-0.4.0-py2.py3-none-any.whl",
+        "version": "0.4.0"
+      },
+      "flask-sqlalchemy": {
+        "sha256": "f12c3d4cc5cc7fdcc148b9527ea05671718c3ea45d50c7e732cceb33f574b390",
+        "url": "https://files.pythonhosted.org/packages/26/2c/9088b6bd95bca539230bbe9ad446737ed391aab9a83aff403e18dded3e75/Flask_SQLAlchemy-2.5.1-py2.py3-none-any.whl",
+        "version": "2.5.1"
+      },
+      "flask-wtf": {
+        "sha256": "9d733658c80be551ce7d5bc13c7a7ac0d80df509be1e23827c847d9520f4359a",
+        "url": "https://files.pythonhosted.org/packages/3a/26/3803ee692eb9a8d21bf7ba1cecd649ce3a55899c65467bdfc1bad13ec50f/Flask_WTF-1.0.1-py3-none-any.whl",
+        "version": "1.0.1"
+      },
+      "graphviz": {
+        "sha256": "587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977",
+        "url": "https://files.pythonhosted.org/packages/de/5e/fcbb22c68208d39edff467809d06c9d81d7d27426460ebc598e55130c1aa/graphviz-0.20.1-py3-none-any.whl",
+        "version": "0.20.1"
+      },
+      "greenlet": {
+        "sha256": "0722c9be0797f544a3ed212569ca3fe3d9d1a1b13942d10dd6f0e8601e484d26",
+        "url": "https://files.pythonhosted.org/packages/3b/c4/01247dcd15d3f9919760bc8c0846f97020e5bacc35b7899cf5cb02313a16/greenlet-2.0.1-cp310-cp310-macosx_10_15_x86_64.whl",
+        "version": "2.0.1"
+      },
+      "gunicorn": {
+        "sha256": "9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e",
+        "url": "https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl",
+        "version": "20.1.0"
+      },
+      "h11": {
+        "sha256": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761",
+        "url": "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl",
+        "version": "0.14.0"
+      },
+      "httpcore": {
+        "sha256": "da1fb708784a938aa084bde4feb8317056c55037247c787bd7e19eb2c2949dc0",
+        "url": "https://files.pythonhosted.org/packages/04/7e/ef97af4623024e8159993b3114ce208de4f677098ae058ec5882a1bf7605/httpcore-0.16.3-py3-none-any.whl",
+        "version": "0.16.3"
+      },
+      "httpx": {
+        "sha256": "0b9b1f0ee18b9978d637b0776bfd7f54e2ca278e063e3586d8f01cda89e042a8",
+        "url": "https://files.pythonhosted.org/packages/e1/74/cdce73069e021ad5913451b86c2707b027975cf302016ca557686d87eb41/httpx-0.23.1-py3-none-any.whl",
+        "version": "0.23.1"
+      },
+      "idna": {
+        "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+        "version": "3.4"
+      },
+      "inflection": {
+        "sha256": "f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2",
+        "url": "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl",
+        "version": "0.5.1"
+      },
+      "itsdangerous": {
+        "sha256": "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
+        "url": "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl",
+        "version": "2.1.2"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "jsonschema": {
+        "sha256": "a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6",
+        "url": "https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl",
+        "version": "4.17.3"
+      },
+      "lazy-object-proxy": {
+        "sha256": "4fd031589121ad46e293629b39604031d354043bb5cdf83da4e93c2d7f3389fe",
+        "url": "https://files.pythonhosted.org/packages/7c/0f/60db0efe9a1d61fc830cfd2806d54c5fb64761e8009b9d163bf0ede5b12d/lazy_object_proxy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "1.8.0"
+      },
+      "linkify-it-py": {
+        "sha256": "1bff43823e24e507a099e328fc54696124423dd6320c75a9da45b4b754b748ad",
+        "url": "https://files.pythonhosted.org/packages/fa/1a/2280e2eb892162ef5c0480a131d1d176b61f5f24abdce8dd9862454f7d14/linkify_it_py-2.0.0-py3-none-any.whl",
+        "version": "2.0.0"
+      },
+      "lockfile": {
+        "sha256": "6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa",
+        "url": "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl",
+        "version": "0.12.2"
+      },
+      "mako": {
+        "sha256": "c97c79c018b9165ac9922ae4f32da095ffd3c4e6872b45eded42926deea46818",
+        "url": "https://files.pythonhosted.org/packages/03/3b/68690a035ba7347860f1b8c0cde853230ba69ff41df5884ea7d89fe68cd3/Mako-1.2.4-py3-none-any.whl",
+        "version": "1.2.4"
+      },
+      "markdown": {
+        "sha256": "08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186",
+        "url": "https://files.pythonhosted.org/packages/86/be/ad281f7a3686b38dd8a307fa33210cdf2130404dfef668a37a4166d737ca/Markdown-3.4.1-py3-none-any.whl",
+        "version": "3.4.1"
+      },
+      "markdown-it-py": {
+        "sha256": "93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27",
+        "url": "https://files.pythonhosted.org/packages/f9/3f/ecd1b708973b9a3e4574b43cffc1ce8eb98696da34f1a1c44a68c3c0d737/markdown_it_py-2.1.0-py3-none-any.whl",
+        "version": "2.1.0"
+      },
+      "markupsafe": {
+        "sha256": "f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+        "url": "https://files.pythonhosted.org/packages/8c/96/7e608e1a942232cb8c81ca24093e71e07e2bacbeb2dad62a0f82da28ed54/MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "2.1.1"
+      },
+      "marshmallow": {
+        "sha256": "93f0958568da045b0021ec6aeb7ac37c81bfcccbb9a0e7ed8559885070b3a19b",
+        "url": "https://files.pythonhosted.org/packages/ae/53/980a20d789029329fdf1546c315f9c92bf862c7f3e7294e3667afcc464f5/marshmallow-3.19.0-py3-none-any.whl",
+        "version": "3.19.0"
+      },
+      "marshmallow-enum": {
+        "sha256": "57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072",
+        "url": "https://files.pythonhosted.org/packages/c6/59/ef3a3dc499be447098d4a89399beb869f813fee1b5a57d5d79dee2c1bf51/marshmallow_enum-1.5.1-py2.py3-none-any.whl",
+        "version": "1.5.1"
+      },
+      "marshmallow-oneofschema": {
+        "sha256": "bd29410a9f2f7457a2b428286e2a80ef76b8ddc3701527dc1f935a88914b02f2",
+        "url": "https://files.pythonhosted.org/packages/ca/eb/3f6d90ba82b2dd319c7d3534a90ba3f4bdf2e332e89c2399fdc818051589/marshmallow_oneofschema-3.0.1-py2.py3-none-any.whl",
+        "version": "3.0.1"
+      },
+      "marshmallow-sqlalchemy": {
+        "sha256": "ba7493eeb8669a3bf00d8f906b657feaa87a740ae9e4ecf829cfd6ddf763d276",
+        "url": "https://files.pythonhosted.org/packages/d1/84/1f4d7393d04f2ae0d4098791d1901a713f45ba70ff6f3c35ff2f7fd81f7b/marshmallow_sqlalchemy-0.26.1-py2.py3-none-any.whl",
+        "version": "0.26.1"
+      },
+      "mdit-py-plugins": {
+        "sha256": "36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9",
+        "url": "https://files.pythonhosted.org/packages/33/eb/c358112e8265f827cf8228eda36cf2a720ad933f5ca66f47f808edf4bb34/mdit_py_plugins-0.3.3-py3-none-any.whl",
+        "version": "0.3.3"
+      },
+      "mdurl": {
+        "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+        "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+        "version": "0.1.2"
+      },
+      "packaging": {
+        "sha256": "957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3",
+        "url": "https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl",
+        "version": "22.0"
+      },
+      "pathspec": {
+        "sha256": "7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+        "url": "https://files.pythonhosted.org/packages/42/ba/a9d64c7bcbc7e3e8e5f93a52721b377e994c22d16196e2b0f1236774353a/pathspec-0.9.0-py2.py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "pendulum": {
+        "sha256": "b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207",
+        "url": "https://files.pythonhosted.org/packages/db/15/6e89ae7cde7907118769ed3d2481566d05b5fd362724025198bb95faf599/pendulum-2.1.2.tar.gz",
+        "version": "2.1.2"
+      },
+      "pluggy": {
+        "sha256": "74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3",
+        "url": "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl",
+        "version": "1.0.0"
+      },
+      "prison": {
+        "sha256": "f90bab63fca497aa0819a852f64fb21a4e181ed9f6114deaa5dc04001a7555c5",
+        "url": "https://files.pythonhosted.org/packages/f1/bd/e55e14cd213174100be0353824f2add41e8996c6f32081888897e8ec48b5/prison-0.2.1-py2.py3-none-any.whl",
+        "version": "0.2.1"
+      },
+      "psutil": {
+        "sha256": "54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7",
+        "url": "https://files.pythonhosted.org/packages/a5/73/35cea01aad1baf901c915dc95ea33a2f271c8ff8cf2f1c73b7f591f1bdf1/psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl",
+        "version": "5.9.4"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "pygments": {
+        "sha256": "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
+        "url": "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl",
+        "version": "2.13.0"
+      },
+      "pyjwt": {
+        "sha256": "d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14",
+        "url": "https://files.pythonhosted.org/packages/40/46/505f0dd53c14096f01922bf93a7abb4e40e29a06f858abbaa791e6954324/PyJWT-2.6.0-py3-none-any.whl",
+        "version": "2.6.0"
+      },
+      "pyrsistent": {
+        "sha256": "20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a",
+        "url": "https://files.pythonhosted.org/packages/ed/7b/7d032130a6838b179b46dff1ee88909c11d518a10ec9bc70c4b72c7c2f80/pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl",
+        "version": "0.19.3"
+      },
+      "python-daemon": {
+        "sha256": "01d26358598f8c3f5fc6de553e2f3080ffc59cf89102d7ee8098f33c72b3c04c",
+        "url": "https://files.pythonhosted.org/packages/89/38/c223036ee8104ae95118d4481b5cacccf4547d7e5b8d1ee1c63d2cd57e5d/python_daemon-2.3.2-py3-none-any.whl",
+        "version": "2.3.2"
+      },
+      "python-dateutil": {
+        "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+        "url": "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl",
+        "version": "2.8.2"
+      },
+      "python-nvd3": {
+        "sha256": "fbd75ff47e0ef255b4aa4f3a8b10dc8b4024aa5a9a7abed5b2406bd3cb817715",
+        "url": "https://files.pythonhosted.org/packages/0b/aa/97165daa6e319409c5c2582e62736a7353bda3c90d90fdcb0b11e116dd2d/python-nvd3-0.15.0.tar.gz",
+        "version": "0.15.0"
+      },
+      "python-slugify": {
+        "sha256": "003aee64f9fd955d111549f96c4b58a3f40b9319383c70fad6277a4974bbf570",
+        "url": "https://files.pythonhosted.org/packages/63/65/d0d7c085964fdf0cb294299663b407c38e2c8e8dd13bafcf5681798c12db/python_slugify-7.0.0-py2.py3-none-any.whl",
+        "version": "7.0.0"
+      },
+      "pytz": {
+        "sha256": "93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd",
+        "url": "https://files.pythonhosted.org/packages/3d/19/4de17f0d5cf5a0d87aa67532d4c2fa75e6e7d8df13c27635ff40fa6f4b76/pytz-2022.7-py2.py3-none-any.whl",
+        "version": "2022.7"
+      },
+      "pytzdata": {
+        "sha256": "e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f",
+        "url": "https://files.pythonhosted.org/packages/e0/4f/4474bda990ee740a020cbc3eb271925ef7daa7c8444240d34ff62c8442a3/pytzdata-2020.1-py2.py3-none-any.whl",
+        "version": "2020.1"
+      },
+      "pyyaml": {
+        "sha256": "d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+        "url": "https://files.pythonhosted.org/packages/44/e5/4fea13230bcebf24b28c0efd774a2dd65a0937a2d39e94a4503438b078ed/PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "6.0"
+      },
+      "requests": {
+        "sha256": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
+        "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl",
+        "version": "2.28.1"
+      },
+      "requests-toolbelt": {
+        "sha256": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+        "url": "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl",
+        "version": "0.10.1"
+      },
+      "rfc3986": {
+        "sha256": "a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97",
+        "url": "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl",
+        "version": "1.5.0"
+      },
+      "rich": {
+        "sha256": "12b1d77ee7edf251b741531323f0d990f5f570a4e7c054d0bfb59fb7981ad977",
+        "url": "https://files.pythonhosted.org/packages/92/37/2732511fdd5c6e037af9e92b87dbb50049c02fd3a8c070bc75eed6c798b3/rich-13.0.0-py3-none-any.whl",
+        "version": "13.0.0"
+      },
+      "setproctitle": {
+        "sha256": "630f6fe5e24a619ccf970c78e084319ee8be5be253ecc9b5b216b0f474f5ef18",
+        "url": "https://files.pythonhosted.org/packages/20/a3/8d19f528ffbb3496040bc0cbef02a8678a102b9c04effd55ac1fcd7d2c07/setproctitle-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "1.3.2"
+      },
+      "setuptools": {
+        "sha256": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+        "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl",
+        "version": "65.6.3"
+      },
+      "setuptools-scm": {
+        "sha256": "73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e",
+        "url": "https://files.pythonhosted.org/packages/1d/66/8f42c941be949ef2b22fe905d850c794e7c170a526023612aad5f3a121ad/setuptools_scm-7.1.0-py3-none-any.whl",
+        "version": "7.1.0"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      },
+      "sniffio": {
+        "sha256": "eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384",
+        "url": "https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl",
+        "version": "1.3.0"
+      },
+      "sqlalchemy": {
+        "sha256": "ca152ffc7f0aa069c95fba46165030267ec5e4bb0107aba45e5e9e86fe4d9363",
+        "url": "https://files.pythonhosted.org/packages/02/6a/04f29a93dce9676a704c815ffa08508ac5b9a3720d6dc559d79df7457942/SQLAlchemy-1.4.45-cp310-cp310-macosx_10_15_x86_64.whl",
+        "version": "1.4.45"
+      },
+      "sqlalchemy-jsonfield": {
+        "sha256": "d6f1e5ee329a3c0d9d164e40d81a2143ac8332e09988fbbaff84179dac5503d4",
+        "url": "https://files.pythonhosted.org/packages/38/1c/283e6216c21827fb1358f2f409432828f9df4e402182cf590a1cc5a8874f/SQLAlchemy_JSONField-1.0.1.post0-py3-none-any.whl",
+        "version": "1.0.1.post0"
+      },
+      "sqlalchemy-utils": {
+        "sha256": "9da26a9b20c6979167772ba5dc2a1d01265648f18c82995f082279a399ea308b",
+        "url": "https://files.pythonhosted.org/packages/12/c2/131e1c6ff887fde1783c1f21e9d132fb799b9c5680abb88c35f40a32a26c/SQLAlchemy_Utils-0.39.0-py3-none-any.whl",
+        "version": "0.39.0"
+      },
+      "sqlparse": {
+        "sha256": "0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
+        "url": "https://files.pythonhosted.org/packages/97/d3/31dd2c3e48fc2060819f4acb0686248250a0f2326356306b38a42e059144/sqlparse-0.4.3-py3-none-any.whl",
+        "version": "0.4.3"
+      },
+      "swagger-ui-bundle": {
+        "sha256": "cea116ed81147c345001027325c1ddc9ca78c1ee7319935c3c75d3669279d575",
+        "url": "https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl",
+        "version": "0.0.9"
+      },
+      "tabulate": {
+        "sha256": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
+        "url": "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl",
+        "version": "0.9.0"
+      },
+      "tenacity": {
+        "sha256": "35525cd47f82830069f0d6b73f7eb83bc5b73ee2fff0437952cedf98b27653ac",
+        "url": "https://files.pythonhosted.org/packages/a5/94/933ce16d18450ccf518a6da5bd51418611e8776b992070b9f40b2f9cedff/tenacity-8.1.0-py3-none-any.whl",
+        "version": "8.1.0"
+      },
+      "termcolor": {
+        "sha256": "fa852e957f97252205e105dd55bbc23b419a70fec0085708fc0515e399f304fd",
+        "url": "https://files.pythonhosted.org/packages/c3/23/16f4cdb09368524cd7cf47c2950663dd197a6c180cd5b6db01dcb65c5135/termcolor-2.1.1-py3-none-any.whl",
+        "version": "2.1.1"
+      },
+      "text-unidecode": {
+        "sha256": "1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+        "url": "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl",
+        "version": "1.3"
+      },
+      "tomli": {
+        "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+        "version": "2.0.1"
+      },
+      "typing-extensions": {
+        "sha256": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
+        "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl",
+        "version": "4.4.0"
+      },
+      "uc-micro-py": {
+        "sha256": "316cfb8b6862a0f1d03540f0ae6e7b033ff1fa0ddbe60c12cbe0d4cec846a69f",
+        "url": "https://files.pythonhosted.org/packages/14/0e/738dbd15b1afe372d0d788e1e2112cfa67c9cf9e1c777360eaf9cd429caf/uc_micro_py-1.0.1-py3-none-any.whl",
+        "version": "1.0.1"
+      },
+      "unicodecsv": {
+        "sha256": "018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc",
+        "url": "https://files.pythonhosted.org/packages/6f/a4/691ab63b17505a26096608cc309960b5a6bdf39e4ba1a793d5f9b1a53270/unicodecsv-0.14.1.tar.gz",
+        "version": "0.14.1"
+      },
+      "urllib3": {
+        "sha256": "47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+        "url": "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl",
+        "version": "1.26.13"
+      },
+      "werkzeug": {
+        "sha256": "f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5",
+        "url": "https://files.pythonhosted.org/packages/c8/27/be6ddbcf60115305205de79c29004a0c6bc53cec814f733467b1bb89386d/Werkzeug-2.2.2-py3-none-any.whl",
+        "version": "2.2.2"
+      },
+      "wrapt": {
+        "sha256": "80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+        "url": "https://files.pythonhosted.org/packages/f7/92/121147bb2f9ed1aa35a8780c636d5da9c167545f97737f0860b4c6c92086/wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "1.14.1"
+      },
+      "wtforms": {
+        "sha256": "837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b",
+        "url": "https://files.pythonhosted.org/packages/eb/2e/199a0edf6577af771a68fbd950d98f0c1a16bb5fa956e45772005318c702/WTForms-3.0.1-py3-none-any.whl",
+        "version": "3.0.1"
+      }
+    },
+    "targets": {
+      "default": {
+        "alembic": [
+          "mako",
+          "sqlalchemy"
+        ],
+        "anyio": [
+          "idna",
+          "sniffio"
+        ],
+        "apache-airflow": [
+          "alembic",
+          "apache-airflow-providers-common-sql",
+          "apache-airflow-providers-ftp",
+          "apache-airflow-providers-http",
+          "apache-airflow-providers-imap",
+          "apache-airflow-providers-sqlite",
+          "argcomplete",
+          "attrs",
+          "blinker",
+          "cattrs",
+          "colorlog",
+          "configupdater",
+          "connexion",
+          "cron-descriptor",
+          "croniter",
+          "cryptography",
+          "deprecated",
+          "dill",
+          "flask",
+          "flask-appbuilder",
+          "flask-caching",
+          "flask-login",
+          "flask-session",
+          "flask-wtf",
+          "graphviz",
+          "gunicorn",
+          "httpx",
+          "itsdangerous",
+          "jinja2",
+          "jsonschema",
+          "lazy-object-proxy",
+          "linkify-it-py",
+          "lockfile",
+          "markdown",
+          "markdown-it-py",
+          "markupsafe",
+          "marshmallow-oneofschema",
+          "mdit-py-plugins",
+          "packaging",
+          "pathspec",
+          "pendulum",
+          "pluggy",
+          "psutil",
+          "pygments",
+          "pyjwt",
+          "python-daemon",
+          "python-dateutil",
+          "python-nvd3",
+          "python-slugify",
+          "rich",
+          "setproctitle",
+          "sqlalchemy",
+          "sqlalchemy-jsonfield",
+          "tabulate",
+          "tenacity",
+          "termcolor",
+          "typing-extensions",
+          "unicodecsv",
+          "werkzeug"
+        ],
+        "apache-airflow-providers-common-sql": [
+          "sqlparse"
+        ],
+        "apache-airflow-providers-ftp": [],
+        "apache-airflow-providers-http": [
+          "requests",
+          "requests-toolbelt"
+        ],
+        "apache-airflow-providers-imap": [],
+        "apache-airflow-providers-sqlite": [
+          "apache-airflow-providers-common-sql"
+        ],
+        "apispec": [
+          "pyyaml"
+        ],
+        "argcomplete": [],
+        "attrs": [],
+        "babel": [
+          "pytz"
+        ],
+        "blinker": [],
+        "cachelib": [],
+        "cattrs": [
+          "attrs",
+          "exceptiongroup"
+        ],
+        "certifi": [],
+        "cffi": [
+          "pycparser"
+        ],
+        "charset-normalizer": [],
+        "click": [],
+        "clickclick": [
+          "click",
+          "pyyaml"
+        ],
+        "colorama": [],
+        "colorlog": [],
+        "commonmark": [],
+        "configupdater": [],
+        "connexion": [
+          "clickclick",
+          "flask",
+          "inflection",
+          "itsdangerous",
+          "jsonschema",
+          "packaging",
+          "pyyaml",
+          "requests",
+          "swagger-ui-bundle",
+          "werkzeug"
+        ],
+        "cron-descriptor": [],
+        "croniter": [
+          "python-dateutil"
+        ],
+        "cryptography": [
+          "cffi"
+        ],
+        "deprecated": [
+          "wrapt"
+        ],
+        "dill": [],
+        "dnspython": [],
+        "docutils": [],
+        "email-validator": [
+          "dnspython",
+          "idna"
+        ],
+        "exceptiongroup": [],
+        "flask": [
+          "click",
+          "itsdangerous",
+          "jinja2",
+          "werkzeug"
+        ],
+        "flask-appbuilder": [
+          "apispec",
+          "click",
+          "colorama",
+          "email-validator",
+          "flask",
+          "flask-babel",
+          "flask-jwt-extended",
+          "flask-login",
+          "flask-sqlalchemy",
+          "flask-wtf",
+          "jsonschema",
+          "marshmallow",
+          "marshmallow-enum",
+          "marshmallow-sqlalchemy",
+          "prison",
+          "pyjwt",
+          "python-dateutil",
+          "sqlalchemy",
+          "sqlalchemy-utils",
+          "wtforms"
+        ],
+        "flask-babel": [
+          "babel",
+          "flask",
+          "jinja2",
+          "pytz"
+        ],
+        "flask-caching": [
+          "cachelib",
+          "flask"
+        ],
+        "flask-jwt-extended": [
+          "flask",
+          "pyjwt",
+          "werkzeug"
+        ],
+        "flask-login": [
+          "flask",
+          "werkzeug"
+        ],
+        "flask-session": [
+          "cachelib",
+          "flask"
+        ],
+        "flask-sqlalchemy": [
+          "flask",
+          "sqlalchemy"
+        ],
+        "flask-wtf": [
+          "flask",
+          "itsdangerous",
+          "wtforms"
+        ],
+        "graphviz": [],
+        "greenlet": [],
+        "gunicorn": [
+          "setuptools"
+        ],
+        "h11": [],
+        "httpcore": [
+          "anyio",
+          "certifi",
+          "h11",
+          "sniffio"
+        ],
+        "httpx": [
+          "certifi",
+          "httpcore",
+          "rfc3986",
+          "sniffio"
+        ],
+        "idna": [],
+        "inflection": [],
+        "itsdangerous": [],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "jsonschema": [
+          "attrs",
+          "pyrsistent"
+        ],
+        "lazy-object-proxy": [],
+        "linkify-it-py": [
+          "uc-micro-py"
+        ],
+        "lockfile": [],
+        "mako": [
+          "markupsafe"
+        ],
+        "markdown": [],
+        "markdown-it-py": [
+          "mdurl"
+        ],
+        "markupsafe": [],
+        "marshmallow": [
+          "packaging"
+        ],
+        "marshmallow-enum": [
+          "marshmallow"
+        ],
+        "marshmallow-oneofschema": [
+          "marshmallow"
+        ],
+        "marshmallow-sqlalchemy": [
+          "marshmallow",
+          "sqlalchemy"
+        ],
+        "mdit-py-plugins": [
+          "markdown-it-py"
+        ],
+        "mdurl": [],
+        "packaging": [],
+        "pathspec": [],
+        "pendulum": [
+          "python-dateutil",
+          "pytzdata"
+        ],
+        "pluggy": [],
+        "prison": [
+          "six"
+        ],
+        "psutil": [],
+        "pycparser": [],
+        "pygments": [],
+        "pyjwt": [],
+        "pyrsistent": [],
+        "python-daemon": [
+          "docutils",
+          "lockfile",
+          "setuptools"
+        ],
+        "python-dateutil": [
+          "six"
+        ],
+        "python-nvd3": [
+          "jinja2",
+          "python-slugify"
+        ],
+        "python-slugify": [
+          "text-unidecode"
+        ],
+        "pytz": [],
+        "pytzdata": [],
+        "pyyaml": [],
+        "requests": [
+          "certifi",
+          "charset-normalizer",
+          "idna",
+          "urllib3"
+        ],
+        "requests-toolbelt": [
+          "requests"
+        ],
+        "rfc3986": [
+          "idna"
+        ],
+        "rich": [
+          "commonmark",
+          "pygments"
+        ],
+        "setproctitle": [],
+        "setuptools": [],
+        "setuptools-scm": [
+          "packaging",
+          "setuptools",
+          "tomli",
+          "typing-extensions"
+        ],
+        "six": [],
+        "sniffio": [],
+        "sqlalchemy": [
+          "greenlet"
+        ],
+        "sqlalchemy-jsonfield": [
+          "sqlalchemy"
+        ],
+        "sqlalchemy-utils": [
+          "sqlalchemy"
+        ],
+        "sqlparse": [],
+        "swagger-ui-bundle": [
+          "jinja2"
+        ],
+        "tabulate": [],
+        "tenacity": [],
+        "termcolor": [],
+        "text-unidecode": [],
+        "tomli": [],
+        "typing-extensions": [],
+        "uc-micro-py": [],
+        "unicodecsv": [],
+        "urllib3": [],
+        "werkzeug": [
+          "markupsafe"
+        ],
+        "wrapt": [],
+        "wtforms": [
+          "markupsafe"
+        ]
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/isso/lock-aarch64-darwin.json
+++ b/v1/nix/modules/drvs/isso/lock-aarch64-darwin.json
@@ -1,0 +1,109 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "bleach": {
+        "sha256": "33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4",
+        "url": "https://files.pythonhosted.org/packages/ac/e2/dfcab68c9b2e7800c8f06b85c76e5f978d05b195a958daa9b1dda54a1db6/bleach-6.0.0-py3-none-any.whl",
+        "version": "6.0.0"
+      },
+      "cffi": {
+        "sha256": "285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+        "url": "https://files.pythonhosted.org/packages/ea/be/c4ad40ad441ac847b67c7a37284ae3c58f39f3e638c6b0f85fb662233825/cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl",
+        "version": "1.15.1"
+      },
+      "html5lib": {
+        "sha256": "0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
+        "url": "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl",
+        "version": "1.1"
+      },
+      "isso": {
+        "sha256": "ab514c5ebddd1af8329b13eeaa6ddf90a9a68303603653e7daffb7b89f092834",
+        "url": "https://files.pythonhosted.org/packages/27/a0/068411a0be2bdf2e5b8d569ac5c71f9199be4223620dc600264c2c69d5a9/isso-0.13.0-py3-none-any.whl",
+        "version": "0.13.0"
+      },
+      "itsdangerous": {
+        "sha256": "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
+        "url": "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl",
+        "version": "2.1.2"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "markupsafe": {
+        "sha256": "665a36ae6f8f20a4676b53224e33d456a6f5a72657d9c83c2aa00765072f31f7",
+        "url": "https://files.pythonhosted.org/packages/37/b2/6f4d5cac75ba6fe9f17671304fe339ea45a73c5609b5f5e652aa79c915c8/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_universal2.whl",
+        "version": "2.1.2"
+      },
+      "misaka": {
+        "sha256": "62f35254550095d899fc2ab8b33e156fc5e674176f074959cbca43cf7912ecd7",
+        "url": "https://files.pythonhosted.org/packages/fa/87/b1020510a00aba1b936477e54180b143df654c565b84936b0b3e85272cf2/misaka-2.1.1.tar.gz",
+        "version": "2.1.1"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "setuptools": {
+        "sha256": "5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f",
+        "url": "https://files.pythonhosted.org/packages/f5/2c/074ab1c5be9c7d523d8d6d69d1f46f450fe7f11713147dc9e779aa4ca4ea/setuptools-67.8.0-py3-none-any.whl",
+        "version": "67.8.0"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      },
+      "webencodings": {
+        "sha256": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+        "url": "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl",
+        "version": "0.5.1"
+      },
+      "werkzeug": {
+        "sha256": "48e5e61472fee0ddee27ebad085614ebedb7af41e88f687aaf881afb723a162f",
+        "url": "https://files.pythonhosted.org/packages/c2/2f/f0dc628295bd23571c962d5a349307d9c8796a05bfca6571659eaded38e2/Werkzeug-2.3.4-py3-none-any.whl",
+        "version": "2.3.4"
+      }
+    },
+    "targets": {
+      "default": {
+        "bleach": [
+          "six",
+          "webencodings"
+        ],
+        "cffi": [
+          "pycparser"
+        ],
+        "html5lib": [
+          "six",
+          "webencodings"
+        ],
+        "isso": [
+          "bleach",
+          "html5lib",
+          "itsdangerous",
+          "jinja2",
+          "misaka",
+          "werkzeug"
+        ],
+        "itsdangerous": [],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "markupsafe": [],
+        "misaka": [
+          "cffi"
+        ],
+        "pycparser": [],
+        "setuptools": [],
+        "six": [],
+        "webencodings": [],
+        "werkzeug": [
+          "markupsafe"
+        ]
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/isso/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/isso/lock-x86_64-darwin.json
@@ -1,0 +1,109 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "bleach": {
+        "sha256": "33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4",
+        "url": "https://files.pythonhosted.org/packages/ac/e2/dfcab68c9b2e7800c8f06b85c76e5f978d05b195a958daa9b1dda54a1db6/bleach-6.0.0-py3-none-any.whl",
+        "version": "6.0.0"
+      },
+      "cffi": {
+        "sha256": "39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+        "url": "https://files.pythonhosted.org/packages/e8/ff/c4b7a358526f231efa46a375c959506c87622fb4a2c5726e827c55e6adf2/cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "1.15.1"
+      },
+      "html5lib": {
+        "sha256": "0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
+        "url": "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl",
+        "version": "1.1"
+      },
+      "isso": {
+        "sha256": "ab514c5ebddd1af8329b13eeaa6ddf90a9a68303603653e7daffb7b89f092834",
+        "url": "https://files.pythonhosted.org/packages/27/a0/068411a0be2bdf2e5b8d569ac5c71f9199be4223620dc600264c2c69d5a9/isso-0.13.0-py3-none-any.whl",
+        "version": "0.13.0"
+      },
+      "itsdangerous": {
+        "sha256": "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
+        "url": "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl",
+        "version": "2.1.2"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "markupsafe": {
+        "sha256": "340bea174e9761308703ae988e982005aedf427de816d1afe98147668cc03036",
+        "url": "https://files.pythonhosted.org/packages/34/19/64b0abc021b22766e86efee32b0e2af684c4b731ce8ac1d519c791800c13/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl",
+        "version": "2.1.2"
+      },
+      "misaka": {
+        "sha256": "62f35254550095d899fc2ab8b33e156fc5e674176f074959cbca43cf7912ecd7",
+        "url": "https://files.pythonhosted.org/packages/fa/87/b1020510a00aba1b936477e54180b143df654c565b84936b0b3e85272cf2/misaka-2.1.1.tar.gz",
+        "version": "2.1.1"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "setuptools": {
+        "sha256": "5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f",
+        "url": "https://files.pythonhosted.org/packages/f5/2c/074ab1c5be9c7d523d8d6d69d1f46f450fe7f11713147dc9e779aa4ca4ea/setuptools-67.8.0-py3-none-any.whl",
+        "version": "67.8.0"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      },
+      "webencodings": {
+        "sha256": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+        "url": "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl",
+        "version": "0.5.1"
+      },
+      "werkzeug": {
+        "sha256": "48e5e61472fee0ddee27ebad085614ebedb7af41e88f687aaf881afb723a162f",
+        "url": "https://files.pythonhosted.org/packages/c2/2f/f0dc628295bd23571c962d5a349307d9c8796a05bfca6571659eaded38e2/Werkzeug-2.3.4-py3-none-any.whl",
+        "version": "2.3.4"
+      }
+    },
+    "targets": {
+      "default": {
+        "bleach": [
+          "six",
+          "webencodings"
+        ],
+        "cffi": [
+          "pycparser"
+        ],
+        "html5lib": [
+          "six",
+          "webencodings"
+        ],
+        "isso": [
+          "bleach",
+          "html5lib",
+          "itsdangerous",
+          "jinja2",
+          "misaka",
+          "werkzeug"
+        ],
+        "itsdangerous": [],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "markupsafe": [],
+        "misaka": [
+          "cffi"
+        ],
+        "pycparser": [],
+        "setuptools": [],
+        "six": [],
+        "webencodings": [],
+        "werkzeug": [
+          "markupsafe"
+        ]
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/nodejs-no-lock/lock-aarch64-darwin.json
+++ b/v1/nix/modules/drvs/nodejs-no-lock/lock-aarch64-darwin.json
@@ -1,0 +1,37 @@
+{
+  "package-lock": {
+    "name": "app",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "name": "app",
+        "dependencies": {
+          "typescript": "^5.1.6"
+        },
+        "bin": {
+          "app": "app.js"
+        }
+      },
+      "node_modules/typescript": {
+        "version": "5.1.6",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+        "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+        "bin": {
+          "tsc": "bin/tsc",
+          "tsserver": "bin/tsserver"
+        },
+        "engines": {
+          "node": ">=14.17"
+        }
+      }
+    },
+    "dependencies": {
+      "typescript": {
+        "version": "5.1.6",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+        "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/nodejs-no-lock/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/nodejs-no-lock/lock-x86_64-darwin.json
@@ -1,0 +1,37 @@
+{
+  "package-lock": {
+    "name": "app",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "name": "app",
+        "dependencies": {
+          "typescript": "^5.1.6"
+        },
+        "bin": {
+          "app": "app.js"
+        }
+      },
+      "node_modules/typescript": {
+        "version": "5.1.6",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+        "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+        "bin": {
+          "tsc": "bin/tsc",
+          "tsserver": "bin/tsserver"
+        },
+        "engines": {
+          "node": ">=14.17"
+        }
+      }
+    },
+    "dependencies": {
+      "typescript": {
+        "version": "5.1.6",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+        "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/odoo/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/odoo/lock-x86_64-darwin.json
@@ -1,0 +1,453 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "attrs": {
+        "sha256": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+        "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl",
+        "version": "22.2.0"
+      },
+      "babel": {
+        "sha256": "b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610",
+        "url": "https://files.pythonhosted.org/packages/df/c4/1088865e0246d7ecf56d819a233ab2b72f7d6ab043965ef327d0731b5434/Babel-2.12.1-py3-none-any.whl",
+        "version": "2.12.1"
+      },
+      "beautifulsoup4": {
+        "sha256": "2130a5ad7f513200fae61a17abb5e338ca980fa28c439c0571014bc0217e9591",
+        "url": "https://files.pythonhosted.org/packages/ee/a7/06b189a2e280e351adcef25df532af3c59442123187e228b960ab3238687/beautifulsoup4-4.12.0-py3-none-any.whl",
+        "version": "4.12.0"
+      },
+      "certifi": {
+        "sha256": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+        "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl",
+        "version": "2022.12.7"
+      },
+      "cffi": {
+        "sha256": "320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+        "url": "https://files.pythonhosted.org/packages/87/4b/64e8bd9d15d6b22b6cb11997094fbe61edf453ea0a97c8675cb7d1c3f06f/cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "1.15.1"
+      },
+      "chardet": {
+        "sha256": "362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9",
+        "url": "https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl",
+        "version": "5.1.0"
+      },
+      "charset-normalizer": {
+        "sha256": "3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+        "url": "https://files.pythonhosted.org/packages/ac/c5/990bc41a98b7fa2677c665737fdf278bb74ad4b199c56b6b564b3d4cbfc5/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "3.1.0"
+      },
+      "cryptography": {
+        "sha256": "9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797",
+        "url": "https://files.pythonhosted.org/packages/a1/e0/4fa9f4d0c15040ea0b0c19f8442c62a5cebc4846db4a745177a85b7a6d82/cryptography-40.0.1-cp36-abi3-macosx_10_12_x86_64.whl",
+        "version": "40.0.1"
+      },
+      "decorator": {
+        "sha256": "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186",
+        "url": "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl",
+        "version": "5.1.1"
+      },
+      "docopt": {
+        "sha256": "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491",
+        "url": "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz",
+        "version": "0.6.2"
+      },
+      "docutils": {
+        "sha256": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc",
+        "url": "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl",
+        "version": "0.19"
+      },
+      "gevent": {
+        "sha256": "2929377c8ebfb6f4d868d161cd8de2ea6b9f6c7a5fcd4f78bcd537319c16190b",
+        "url": "https://files.pythonhosted.org/packages/9c/33/78f417eebde535d9146dde08b7d15d408176a023c9c02921c04fe235ab10/gevent-22.10.2-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "22.10.2"
+      },
+      "greenlet": {
+        "sha256": "b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30",
+        "url": "https://files.pythonhosted.org/packages/50/3d/7e3d95b955722c514f982bdf6bbe92bb76218b0036dd9b093ae0c168d63a/greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl",
+        "version": "2.0.2"
+      },
+      "idna": {
+        "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+        "version": "3.4"
+      },
+      "isodate": {
+        "sha256": "0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+        "url": "https://files.pythonhosted.org/packages/b6/85/7882d311924cbcfc70b1890780763e36ff0b140c7e51c110fc59a532f087/isodate-0.6.1-py2.py3-none-any.whl",
+        "version": "0.6.1"
+      },
+      "jinja2": {
+        "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+        "version": "3.1.2"
+      },
+      "libsass": {
+        "sha256": "081e256ab3c5f3f09c7b8dea3bf3bf5e64a97c6995fd9eea880639b3f93a9f9a",
+        "url": "https://files.pythonhosted.org/packages/92/fd/73b8081c5bc2b11b61596f74b54d45226633313c2a4de53205da948fc01c/libsass-0.22.0-cp37-abi3-macosx_10_15_x86_64.whl",
+        "version": "0.22.0"
+      },
+      "lxml": {
+        "sha256": "da4dd7c9c50c059aba52b3524f84d7de956f7fef88f0bafcf4ad7dde94a064e8",
+        "url": "https://files.pythonhosted.org/packages/ac/21/424f7ffbea6a6022c60e9f4ba542326f813bd9e36582bf01ac9a9eb54a87/lxml-4.9.2-cp38-cp38-macosx_10_15_x86_64.whl",
+        "version": "4.9.2"
+      },
+      "markupsafe": {
+        "sha256": "a4abaec6ca3ad8660690236d11bfe28dfd707778e2442b45addd2f086d6ef094",
+        "url": "https://files.pythonhosted.org/packages/4b/34/dc837e5ad9e14634aac4342eb8b12a9be20a4f74f50cc0d765f7aa2fc1e3/MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "2.1.2"
+      },
+      "num2words": {
+        "sha256": "9eeef488658226ab36818c06d7aeb956d19b530fb62030596b6802fb4659f30e",
+        "url": "https://files.pythonhosted.org/packages/eb/09/b14d798bc02411b1e5a9896d680f8f417cadc53232bbf7ae9d30263dcf45/num2words-0.5.12-py3-none-any.whl",
+        "version": "0.5.12"
+      },
+      "odoo": {
+        "sha256": "6653c7f9169165b5a8a1efa4a6215866dbee5665ed38c1de096f99ef866c7176",
+        "url": "https://github.com/odoo/odoo/archive/2d42fd69cada3b1f2716c3d0a20bec6170f9b226.tar.gz",
+        "version": "16.0"
+      },
+      "ofxparse": {
+        "sha256": "057ab68d31270dece4d1a47662096aa76341968aaee145ffc711cb44cbd5c4a7",
+        "url": "https://files.pythonhosted.org/packages/45/ae/98a2acfd06d15869c4b1be7fb74849c8a67cf15b65181f1fe879547e7494/ofxparse-0.21.tar.gz",
+        "version": "0.21"
+      },
+      "passlib": {
+        "sha256": "aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1",
+        "url": "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl",
+        "version": "1.7.4"
+      },
+      "pillow": {
+        "sha256": "83125753a60cfc8c412de5896d10a0a405e0bd88d0470ad82e0869ddf0cb3848",
+        "url": "https://files.pythonhosted.org/packages/e8/cd/6dbd1286a28a074dd8c47583c2224617c0283e69749a6cea45e084d99c8a/Pillow-9.4.0-2-cp38-cp38-macosx_10_10_x86_64.whl",
+        "version": "9.4.0"
+      },
+      "platformdirs": {
+        "sha256": "ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e",
+        "url": "https://files.pythonhosted.org/packages/b2/f3/4fb5fae710fc9f22a42cd90dc0547da18ec83e2e139294ab94f04c449cf5/platformdirs-3.2.0-py3-none-any.whl",
+        "version": "3.2.0"
+      },
+      "polib": {
+        "sha256": "1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d",
+        "url": "https://files.pythonhosted.org/packages/6b/99/45bb1f9926efe370c6dbe324741c749658e44cb060124f28dad201202274/polib-1.2.0-py2.py3-none-any.whl",
+        "version": "1.2.0"
+      },
+      "psutil": {
+        "sha256": "54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7",
+        "url": "https://files.pythonhosted.org/packages/a5/73/35cea01aad1baf901c915dc95ea33a2f271c8ff8cf2f1c73b7f591f1bdf1/psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl",
+        "version": "5.9.4"
+      },
+      "psycopg2": {
+        "sha256": "a5246d2e683a972e2187a8714b5c2cf8156c064629f9a9b1a873c1730d9e245a",
+        "url": "https://files.pythonhosted.org/packages/89/d6/cd8c46417e0f7a16b4b0fc321f4ab676a59250d08fce5b64921897fb07cc/psycopg2-2.9.5.tar.gz",
+        "version": "2.9.5"
+      },
+      "pycparser": {
+        "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
+        "version": "2.21"
+      },
+      "pydot": {
+        "sha256": "66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451",
+        "url": "https://files.pythonhosted.org/packages/ea/76/75b1bb82e9bad3e3d656556eaa353d8cd17c4254393b08ec9786ac8ed273/pydot-1.4.2-py2.py3-none-any.whl",
+        "version": "1.4.2"
+      },
+      "pyopenssl": {
+        "sha256": "9e0c526404a210df9d2b18cd33364beadb0dc858a739b885677bc65e105d4a4c",
+        "url": "https://files.pythonhosted.org/packages/b7/6d/d7377332703ffd8821878794aca4fb54637da654bf3e467ffb32109c2147/pyOpenSSL-23.1.1-py3-none-any.whl",
+        "version": "23.1.1"
+      },
+      "pyparsing": {
+        "sha256": "5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
+        "url": "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl",
+        "version": "3.0.9"
+      },
+      "pypdf2": {
+        "sha256": "d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928",
+        "url": "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl",
+        "version": "3.0.1"
+      },
+      "pypng": {
+        "sha256": "4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c",
+        "url": "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl",
+        "version": "0.20220715.0"
+      },
+      "pyserial": {
+        "sha256": "c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0",
+        "url": "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl",
+        "version": "3.5"
+      },
+      "python-dateutil": {
+        "sha256": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+        "url": "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl",
+        "version": "2.8.2"
+      },
+      "python-stdnum": {
+        "sha256": "d7f2a3c7ef4635c957b9cbdd9b1993d1f6ee3a2959f03e172c45440d99f296eb",
+        "url": "https://files.pythonhosted.org/packages/2e/fe/ab24ee186f710cf6a6d654b272db07915da4f93c7bd9c037747718c03c28/python_stdnum-1.18-py2.py3-none-any.whl",
+        "version": "1.18"
+      },
+      "pytz": {
+        "sha256": "a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb",
+        "url": "https://files.pythonhosted.org/packages/7f/99/ad6bd37e748257dd70d6f85d916cafe79c0b0f5e2e95b11f7fbc82bf3110/pytz-2023.3-py2.py3-none-any.whl",
+        "version": "2023.3"
+      },
+      "pyusb": {
+        "sha256": "2b4c7cb86dbadf044dfb9d3a4ff69fd217013dbe78a792177a3feb172449ea36",
+        "url": "https://files.pythonhosted.org/packages/15/a8/4982498b2ab44d1fcd5c49f07ea3795eab01601dc143b009d333fcace3b9/pyusb-1.2.1-py3-none-any.whl",
+        "version": "1.2.1"
+      },
+      "qrcode": {
+        "sha256": "581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a",
+        "url": "https://files.pythonhosted.org/packages/24/79/aaf0c1c7214f2632badb2771d770b1500d3d7cbdf2590ae62e721ec50584/qrcode-7.4.2-py3-none-any.whl",
+        "version": "7.4.2"
+      },
+      "reportlab": {
+        "sha256": "b6a1b685da0b9a8000bb980e02d9d5be202d0cc539af113b661c76c051fca6f1",
+        "url": "https://files.pythonhosted.org/packages/d7/d2/ab55ac7918e8bdbb2977a1d114fa77aff5f0c72b1dcb9d4409f56f740ec0/reportlab-3.6.12-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "3.6.12"
+      },
+      "requests": {
+        "sha256": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+        "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl",
+        "version": "2.28.2"
+      },
+      "requests-file": {
+        "sha256": "dfe5dae75c12481f68ba353183c53a65e6044c923e64c24b2209f6c7570ca953",
+        "url": "https://files.pythonhosted.org/packages/77/86/cdb5e8eaed90796aa83a6d9f75cfbd37af553c47a291cd47bc410ef9bdb2/requests_file-1.5.1-py2.py3-none-any.whl",
+        "version": "1.5.1"
+      },
+      "requests-toolbelt": {
+        "sha256": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+        "url": "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl",
+        "version": "0.10.1"
+      },
+      "setuptools": {
+        "sha256": "e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078",
+        "url": "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl",
+        "version": "67.6.1"
+      },
+      "six": {
+        "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+        "version": "1.16.0"
+      },
+      "soupsieve": {
+        "sha256": "49e5368c2cda80ee7e84da9dbe3e110b70a4575f196efb74e51b94549d921955",
+        "url": "https://files.pythonhosted.org/packages/d2/70/2c92d7bc961ba43b7b21032b7622144de5f97dec14b62226533f6940798e/soupsieve-2.4-py3-none-any.whl",
+        "version": "2.4"
+      },
+      "typing-extensions": {
+        "sha256": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+        "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl",
+        "version": "4.5.0"
+      },
+      "urllib3": {
+        "sha256": "aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42",
+        "url": "https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl",
+        "version": "1.26.15"
+      },
+      "vobject": {
+        "sha256": "96512aec74b90abb71f6b53898dd7fe47300cc940104c4f79148f0671f790101",
+        "url": "https://files.pythonhosted.org/packages/da/ce/27c48c0e39cc69ffe7f6e3751734f6073539bf18a0cfe564e973a3709a52/vobject-0.9.6.1.tar.gz",
+        "version": "0.9.6.1"
+      },
+      "werkzeug": {
+        "sha256": "56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612",
+        "url": "https://files.pythonhosted.org/packages/f6/f8/9da63c1617ae2a1dec2fbf6412f3a0cfe9d4ce029eccbda6e1e4258ca45f/Werkzeug-2.2.3-py3-none-any.whl",
+        "version": "2.2.3"
+      },
+      "xlrd": {
+        "sha256": "6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd",
+        "url": "https://files.pythonhosted.org/packages/a6/0c/c2a72d51fe56e08a08acc85d13013558a2d793028ae7385448a6ccdfae64/xlrd-2.0.1-py2.py3-none-any.whl",
+        "version": "2.0.1"
+      },
+      "xlsxwriter": {
+        "sha256": "5eaaf3c6f791cba1dd1c3065147c35982180f693436093aabe5b7d6c16148e95",
+        "url": "https://files.pythonhosted.org/packages/87/b9/bc9e4fe0c6a2656d0baa40aa324f9c11e07e5bcec51be9e90ee4deebb309/XlsxWriter-3.0.9-py3-none-any.whl",
+        "version": "3.0.9"
+      },
+      "xlwt": {
+        "sha256": "a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e",
+        "url": "https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl",
+        "version": "1.3.0"
+      },
+      "zeep": {
+        "sha256": "6754feb4c34a4b6d65fbc359252bf6654dcce3937bf1d95aae4402a60a8f5939",
+        "url": "https://files.pythonhosted.org/packages/57/49/1091bd708f8892dc2ed5155bdf71ff51fcde75df137d65ac53f5d7f4fa25/zeep-4.2.1-py3-none-any.whl",
+        "version": "4.2.1"
+      },
+      "zope-event": {
+        "sha256": "73d9e3ef750cca14816a9c322c7250b0d7c9dbc337df5d1b807ff8d3d0b9e97c",
+        "url": "https://files.pythonhosted.org/packages/8b/a8/3ab9648dc08d2ab7543145ec174a2d982d08fb996d50d9a4d3e057da7132/zope.event-4.6-py2.py3-none-any.whl",
+        "version": "4.6"
+      },
+      "zope-interface": {
+        "sha256": "dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f",
+        "url": "https://files.pythonhosted.org/packages/c1/21/0d3fee6837ef00673a606cdf16d9c17f801edacd95729b7154e819cedd07/zope.interface-6.0-cp38-cp38-macosx_10_9_x86_64.whl",
+        "version": "6.0"
+      }
+    },
+    "targets": {
+      "default": {
+        "attrs": [],
+        "babel": [
+          "pytz"
+        ],
+        "beautifulsoup4": [
+          "soupsieve"
+        ],
+        "certifi": [],
+        "cffi": [
+          "pycparser"
+        ],
+        "chardet": [],
+        "charset-normalizer": [],
+        "cryptography": [
+          "cffi"
+        ],
+        "decorator": [],
+        "docopt": [],
+        "docutils": [],
+        "gevent": [
+          "greenlet",
+          "setuptools",
+          "zope-event",
+          "zope-interface"
+        ],
+        "greenlet": [],
+        "idna": [],
+        "isodate": [
+          "six"
+        ],
+        "jinja2": [
+          "markupsafe"
+        ],
+        "libsass": [],
+        "lxml": [],
+        "markupsafe": [],
+        "num2words": [
+          "docopt"
+        ],
+        "odoo": [
+          "babel",
+          "chardet",
+          "cryptography",
+          "decorator",
+          "docutils",
+          "gevent",
+          "greenlet",
+          "idna",
+          "jinja2",
+          "libsass",
+          "lxml",
+          "markupsafe",
+          "num2words",
+          "ofxparse",
+          "passlib",
+          "pillow",
+          "polib",
+          "psutil",
+          "psycopg2",
+          "pydot",
+          "pyopenssl",
+          "pypdf2",
+          "pyserial",
+          "python-dateutil",
+          "python-stdnum",
+          "pytz",
+          "pyusb",
+          "qrcode",
+          "reportlab",
+          "requests",
+          "urllib3",
+          "vobject",
+          "werkzeug",
+          "xlrd",
+          "xlsxwriter",
+          "xlwt",
+          "zeep"
+        ],
+        "ofxparse": [
+          "beautifulsoup4",
+          "lxml",
+          "six"
+        ],
+        "passlib": [],
+        "pillow": [],
+        "platformdirs": [],
+        "polib": [],
+        "psutil": [],
+        "psycopg2": [],
+        "pycparser": [],
+        "pydot": [
+          "pyparsing"
+        ],
+        "pyopenssl": [
+          "cryptography"
+        ],
+        "pyparsing": [],
+        "pypdf2": [
+          "typing-extensions"
+        ],
+        "pypng": [],
+        "pyserial": [],
+        "python-dateutil": [
+          "six"
+        ],
+        "python-stdnum": [],
+        "pytz": [],
+        "pyusb": [],
+        "qrcode": [
+          "pypng",
+          "typing-extensions"
+        ],
+        "reportlab": [
+          "pillow"
+        ],
+        "requests": [
+          "certifi",
+          "charset-normalizer",
+          "idna",
+          "urllib3"
+        ],
+        "requests-file": [
+          "requests",
+          "six"
+        ],
+        "requests-toolbelt": [
+          "requests"
+        ],
+        "setuptools": [],
+        "six": [],
+        "soupsieve": [],
+        "typing-extensions": [],
+        "urllib3": [],
+        "vobject": [
+          "python-dateutil"
+        ],
+        "werkzeug": [
+          "markupsafe"
+        ],
+        "xlrd": [],
+        "xlsxwriter": [],
+        "xlwt": [],
+        "zeep": [
+          "attrs",
+          "isodate",
+          "lxml",
+          "platformdirs",
+          "pytz",
+          "requests",
+          "requests-file",
+          "requests-toolbelt"
+        ],
+        "zope-event": [
+          "setuptools"
+        ],
+        "zope-interface": [
+          "setuptools"
+        ]
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/pillow/lock-aarch64-darwin.json
+++ b/v1/nix/modules/drvs/pillow/lock-aarch64-darwin.json
@@ -1,0 +1,16 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "pillow": {
+        "sha256": "bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1",
+        "url": "https://files.pythonhosted.org/packages/00/d5/4903f310765e0ff2b8e91ffe55031ac6af77d982f0156061e20a4d1a8b2d/Pillow-9.5.0.tar.gz",
+        "version": "9.5.0"
+      }
+    },
+    "targets": {
+      "default": {
+        "pillow": []
+      }
+    }
+  }
+}

--- a/v1/nix/modules/drvs/pillow/lock-x86_64-darwin.json
+++ b/v1/nix/modules/drvs/pillow/lock-x86_64-darwin.json
@@ -1,0 +1,16 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "pillow": {
+        "sha256": "bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1",
+        "url": "https://files.pythonhosted.org/packages/00/d5/4903f310765e0ff2b8e91ffe55031ac6af77d982f0156061e20a4d1a8b2d/Pillow-9.5.0.tar.gz",
+        "version": "9.5.0"
+      }
+    },
+    "targets": {
+      "default": {
+        "pillow": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since we [switched to hercules ci](https://github.com/nix-community/dream2nix/commit/27468aef5a466f625db3a3edcac003b5f8bd35ca) on monday, we can build checks and other packages in CI on the following architectures:

* aarch64-linux
* aarch64-darwin
* x86_64-darwin

This is a draft as I'd like to take a day or two trying to fix the still-failing builds or disabling them and linking a specific github issue for each.

## Questions

* [ ] Could we refresh lock files in CI?
  Need to check whether that's better implemented via hercules effects or impure derivations?
  It would already be very useful to at least verify that lock-files are reproducible - and the  
  copies in the repo are up to date.
  Maybe there could even be an optional job to refresh lock files on other platform, so that contributors could i.e. commit their x86_86-linux lock file and CI builds aarch64-linux et al?
* Should we run this on each and every commit?
  I think with the current state of things and the fact that most contributors won't have access to each supported systems.
  But you need that to keep lock files up to date, we can't expect all platforms to work on each commit to `main`.
  Additionally, we are effectively doing ~4 times the work every time, while platform-specific breakage will be much more likely for some commits (i.e. drvs changes, compared to refactoring of functions).
  -> We could only run x86_64-linux on commits to main and only test the rest for releases or upon request (not sure how to implement that in hercules yet)

