### PR TITLE
branching policy

### DIFF
--- a/docs/src/v1-api/branches.md
+++ b/docs/src/v1-api/branches.md
@@ -1,0 +1,23 @@
+# Branches
+
+## `main` - this is where development happens; it can **break**!
+
+As we strive for trunk-based development and smaller commits, testing each
+subsystem on each supported system for each commit is expensive in terms of
+computing resources, so we only run CI checks on `x86_64-linux` here.
+
+Another reason is that, as of time of writing, you need shell access
+to a target, i.e. `aarch64-darwin` machine, to update platform-specific lock
+files. We hope to allow at least remote builders here soon.
+
+## `stable` - still no warranties, but some best-effort promises ;)
+
+Each commit here should include a changelog since the last commit, and pass all CI jobs
+on all platforms, before being tagged. Tagging it will then publish a GitHub release.
+
+A staging branch may be used to prepare the changelog and fixes for non `x86_64-linux`
+when needed, but it should be merged into `main` before tagging and cherry-picking
+that commit into `stable`.
+
+The changelog contains a list of breaking changes since the last release.
+


### PR DESCRIPTION
We've seen quite a few regressions on `main` in the history of this project, and I don't think it will be feasible to test all platforms and subsystem for each commit anytime soon.

So the following snippet is a draft, which can be improved in many ways, but I'd like to propose it for discussion here. It's a PR so you can comment inline, feel free to use the suggestion feature or just leave a comment.

One thing that's missing here right now is a version scheme.
At least medium term i would try to circa match nixos releases, so do dream2nix-23.11 or so. We could do more regular releases, i.e. monthly as long as changes are more likely and we don't have to many v1-subsystems to test? Would that work?

