### PR TITLE
Racket: Add binaries to $out/bin.

### DIFF
--- a/src/subsystems/racket/builders/simple-racket/default.nix
+++ b/src/subsystems/racket/builders/simple-racket/default.nix
@@ -96,7 +96,7 @@
           export PLTADDONDIR=$PLTCONFIGDIR;
 
           mkdir -p $out/bin
-          for EXE in $racket/bin/* $out/etc/bin/*;
+          for EXE in $racket/bin/* $out/etc/bin/* $out/etc/*/bin/*;
           do
             NAME=$(basename "$EXE")
             makeWrapper "$EXE" "$out/bin/$NAME" --set PLTCONFIGDIR "$PLTCONFIGDIR" --set PLTADDONDIR "$PLTADDONDIR"


### PR DESCRIPTION
Fixes https://github.com/nix-community/dream2nix/issues/527. 

I'm still figuring out how to move this change over to the new API.