### PR TITLE
feat: add dream2nix.modules.drv-parts.core

### DIFF
--- a/modules/flake-parts/modules.drv-parts.core.nix
+++ b/modules/flake-parts/modules.drv-parts.core.nix
@@ -1,0 +1,13 @@
+{
+  self,
+  lib,
+  ...
+}: {
+  flake.modules.drv-parts.core = lib.mkForce {
+    imports = [
+      self.inputs.drv-parts.modules.drv-parts.core
+      self.modules.drv-parts.lock
+      self.modules.drv-parts.eval-cache
+    ];
+  };
+}

--- a/modules/flake-parts/packages.nix
+++ b/modules/flake-parts/packages.nix
@@ -31,11 +31,8 @@
     makeDrv = module: let
       evaled = lib.evalModules {
         modules = [
-          inputs.drv-parts.modules.drv-parts.core
-          inputs.drv-parts.modules.drv-parts.docs
+          self.modules.drv-parts.core
           module
-          ../drv-parts/eval-cache
-          ../drv-parts/lock
           setup
         ];
         specialArgs.packageSets = {


### PR DESCRIPTION
This already includes the `lock` module and makes it easier to call dream2nix via evalModules
