### PR TITLE
expose writers as drv-parts module...

### DIFF
--- a/modules/drv-parts/nodejs-package-json/default.nix
+++ b/modules/drv-parts/nodejs-package-json/default.nix
@@ -11,42 +11,17 @@
     then config.deps.npm
     else throw "The version of config.deps.npm must be < 9";
 
-  writers = import ../../../pkgs/writers {
-    inherit lib;
-    inherit
-      (config.deps)
-      bash
-      coreutils
-      gawk
-      path
-      writeScript
-      writeScriptBin
-      ;
-  };
-
   npmArgs = l.concatStringsSep " " (map (arg: "'${arg}'") cfg.npmArgs);
 in {
   imports = [
     ./interface.nix
     ../nodejs-package-lock
     ../lock
+    ../writers
   ];
   config = {
-    deps = {nixpkgs, ...}:
-      l.mapAttrs (_: l.mkDefault) {
-        inherit
-          (nixpkgs)
-          bash
-          coreutils
-          gawk
-          path
-          writeScript
-          writeScriptBin
-          ;
-      };
-
     lock.fields.package-lock.script =
-      writers.writePureShellScript
+      config.writers.writePureShellScript
       [
         config.deps.coreutils
         npm

--- a/modules/drv-parts/pip/default.nix
+++ b/modules/drv-parts/pip/default.nix
@@ -9,19 +9,6 @@
   python = config.deps.python;
   metadata = config.lock.content.fetchPipMetadata;
 
-  writers = import ../../../pkgs/writers {
-    inherit lib;
-    inherit
-      (config.deps)
-      bash
-      coreutils
-      gawk
-      path
-      writeScript
-      writeScriptBin
-      ;
-  };
-
   drvs =
     l.mapAttrs (
       name: info:
@@ -59,13 +46,7 @@
           inherit
             (nixpkgs)
             autoPatchelfHook
-            bash
-            coreutils
-            gawk
-            path
             stdenv
-            writeScript
-            writeScriptBin
             ;
           inherit (nixpkgs.pythonManylinuxPackages) manylinux1;
         };
@@ -98,6 +79,7 @@ in {
     commonModule
     ./interface.nix
     ../lock
+    ../writers
   ];
 
   config = {
@@ -105,11 +87,11 @@ in {
       l.mapAttrs (_: l.mkDefault) {
         fetchPipMetadataScript = nixpkgs.callPackage ../../../pkgs/fetchPipMetadata {
           inherit (cfg) pypiSnapshotDate pipFlags pipVersion requirementsList requirementsFiles nativeBuildInputs;
-          inherit (config.deps) writePureShellScript python nix git;
+          inherit (config.deps) python nix git;
+          inherit (config.writers) writePureShellScript;
         };
         setuptools = config.deps.python.pkgs.setuptools;
         inherit (nixpkgs) git;
-        inherit (writers) writePureShellScript;
       };
 
     # Keep package metadata fetched by Pip in our lockfile

--- a/modules/drv-parts/writers/default.nix
+++ b/modules/drv-parts/writers/default.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  writers = config.deps.callPackage ../../../pkgs/writers {};
+in {
+  imports = [
+    ./interface.nix
+  ];
+
+  config.deps = {nixpkgs, ...}:
+    lib.mapAttrs (_: lib.mkOverride 1001) {
+      inherit
+        (nixpkgs)
+        callPackage
+        bash
+        coreutils
+        gawk
+        path
+        stdenv
+        writeScript
+        writeScriptBin
+        ;
+    };
+
+  config.writers = {
+    inherit
+      (writers)
+      writePureShellScript
+      writePureShellScriptBin
+      ;
+  };
+}

--- a/modules/drv-parts/writers/interface.nix
+++ b/modules/drv-parts/writers/interface.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  lib,
+  ...
+}: {
+  options.writers = {
+    writePureShellScript = lib.mkOption {
+      type = lib.types.functionTo (lib.types.functionTo lib.types.package);
+      description = ''
+        Create a script that runs in a `pure` environment, in the sense that:
+          - the behavior is similar to `nix-shell --pure`
+          - `PATH` only contains exactly the packages passed via the `PATH` arg
+          - `NIX_PATH` is set to the path of the current `pkgs`
+          - `TMPDIR` is set up and cleaned up even if the script fails
+          - out, if set, is kept as-is
+          - all environment variables are unset, except:
+            - the ones listed in `keepVars` below
+            - ones listed via the `KEEP_VARS` variable
+      '';
+    };
+    writePureShellScriptBin = lib.mkOption {
+      type = lib.types.functionTo (lib.types.functionTo (lib.types.functionTo lib.types.package));
+      description = ''
+        Creates a script in a `bin/` directory in the output; suitable for use with `lib.makeBinPath`, etc.
+        See {option}`writers.writePureShellScript`
+      '';
+    };
+  };
+}


### PR DESCRIPTION
...and don't manually include it per module where it's used (pip and nodejs-package-json).

I think that's useful as we add more modules, to keep `deps` in consuming modules clean.

Might be a good idea to also de-duplicate the options with the flake-parts module? the callPackage invocation is the only difference between the flake-parts and drv-parts module