### PR TITLE
docs: remove v1 draft API docs from index

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,18 +6,6 @@
 # Concepts
 - [dream2nix modules](./modules.md)
 
-# Drafts
-- [DRAFT (outdated): modules based API](./v1-api/summary.md)
-  - [problems of the legacy dream2nix](./v1-api/problems.md)
-  - [users of dream2nix](./v1-api/users.md)
-  - [v1 packaging: project initialization](./v1-api/packaging/nodejs-init-project.md)
-  - [v1 packaging: workspaces](./v1-api/packaging/nodejs-workspaces.md)
-  - [v1 packaging: multiple repos](./v1-api/packaging/nodejs-multiple-repos.md)
-  - [v1 packaging: monorepo](./v1-api/packaging/monorepo.md)
-  - [v1 consuming: inspect package options](./v1-api/consuming/inspect-options.md)
-  - [v1 consuming: override packages](./v1-api/consuming/override.md)
-  - [v1 integrating: lang2nix tool (pure)](./v1-api/integrating/integrate-lang2nix-pure.md)
-  - [v1 integrating: lang2nix tool (code-gen/impure)](./v1-api/integrating/integrate-lang2nix-impure.md)
 # Development Roundups
 - [April - June 2022](./development-roundups/2022-april-june.md)
 - [July - September 2022](./development-roundups/2022-july-september.md)


### PR DESCRIPTION
... but keep the md files. There are still valuable drafts which are not yet implemented
