### PR TITLE
Python: fixes and improvements

### DIFF
--- a/examples/dream2nix-packages-python/pyproject-dependencies/default.nix
+++ b/examples/dream2nix-packages-python/pyproject-dependencies/default.nix
@@ -1,0 +1,37 @@
+# An example package with dependencies defined via pyproject.toml
+{
+  config,
+  lib,
+  dream2nix,
+  ...
+}: let
+  l = lib // builtins;
+  pyproject = lib.pipe (config.mkDerivation.src + /pyproject.toml) [
+    builtins.readFile
+    builtins.fromTOML
+  ];
+in {
+  imports = [
+    dream2nix.modules.drv-parts.pip
+  ];
+
+  name = "pyproject-dependencies";
+  version = pyproject.project.version;
+
+  mkDerivation = {
+    src = ./.;
+  };
+
+  buildPythonPackage = {
+    format = lib.mkForce "pyproject";
+    pythonImportsCheck = [
+      "my_tool"
+    ];
+  };
+
+  pip = {
+    pypiSnapshotDate = "2023-08-27";
+    requirementsList = ["setuptools"] ++ pyproject.project.dependencies;
+    flattenDependencies = true;
+  };
+}

--- a/examples/dream2nix-packages-python/pyproject-dependencies/my_tool/__init__.py
+++ b/examples/dream2nix-packages-python/pyproject-dependencies/my_tool/__init__.py
@@ -1,0 +1,4 @@
+import requests
+
+
+print("Hello World!")

--- a/examples/dream2nix-packages-python/pyproject-dependencies/pyproject.toml
+++ b/examples/dream2nix-packages-python/pyproject-dependencies/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [ "setuptools" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "my-tool"
+description = "my tool"
+version = "1.0.0"
+dependencies = [
+  "requests"
+]

--- a/flake.lock
+++ b/flake.lock
@@ -70,6 +70,52 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-unit": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1690289081,
+        "narHash": "sha256-PCXQAQt8+i2pkUym9P1JY4JGoeZJLzzxWBhprHDdItM=",
+        "owner": "adisbladis",
+        "repo": "nix-unit",
+        "rev": "a9d6f33e50d4dcd9cfc0c92253340437bbae282b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "nix-unit",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1686501370,
@@ -111,6 +157,7 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
+        "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       }
@@ -127,6 +174,27 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689620039,
+        "narHash": "sha256-BtNwghr05z7k5YMdq+6nbue+nEalvDepuA7qdQMAKoQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "719c2977f958c41fa60a928e2fbc50af14844114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
+    nix-unit.url = "github:adisbladis/nix-unit";
+    nix-unit.inputs.nixpkgs.follows = "nixpkgs";
+    nix-unit.inputs.flake-parts.follows = "flake-parts";
+
     devshell = {
       url = "github:numtide/devshell";
       flake = false;
@@ -40,6 +44,7 @@
       config,
       pkgs,
       system,
+      inputs',
       ...
     }: {
       apps = {
@@ -78,6 +83,7 @@
           packages = [
             pkgs.alejandra
             pkgs.mdbook
+            inputs'.nix-unit.packages.nix-unit
             (pkgs.python3.withPackages (ps: [
               pkgs.python3.pkgs.black
             ]))

--- a/locks/example-package-python-pyproject-dependencies/lock-x86_64-linux.json
+++ b/locks/example-package-python-pyproject-dependencies/lock-x86_64-linux.json
@@ -1,0 +1,51 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "certifi": {
+        "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
+        "url": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
+        "version": "2023.7.22"
+      },
+      "charset-normalizer": {
+        "sha256": "193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad",
+        "url": "https://files.pythonhosted.org/packages/a4/65/057bf29660aae6ade0816457f8db4e749e5c0bfa2366eb5f67db9912fa4c/charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "version": "3.2.0"
+      },
+      "idna": {
+        "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+        "version": "3.4"
+      },
+      "requests": {
+        "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+        "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+        "version": "2.31.0"
+      },
+      "setuptools": {
+        "sha256": "3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b",
+        "url": "https://files.pythonhosted.org/packages/4f/ab/0bcfebdfc3bfa8554b2b2c97a555569c4c1ebc74ea288741ea8326c51906/setuptools-68.1.2-py3-none-any.whl",
+        "version": "68.1.2"
+      },
+      "urllib3": {
+        "sha256": "de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4",
+        "url": "https://files.pythonhosted.org/packages/9b/81/62fd61001fa4b9d0df6e31d47ff49cfa9de4af03adecf339c7bc30656b37/urllib3-2.0.4-py3-none-any.whl",
+        "version": "2.0.4"
+      }
+    },
+    "targets": {
+      "default": {
+        "certifi": [],
+        "charset-normalizer": [],
+        "idna": [],
+        "requests": [
+          "certifi",
+          "charset-normalizer",
+          "idna",
+          "urllib3"
+        ],
+        "setuptools": [],
+        "urllib3": []
+      }
+    }
+  }
+}

--- a/modules/drv-parts/pip-hotfixes/default.nix
+++ b/modules/drv-parts/pip-hotfixes/default.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  l = lib // builtins;
+  cfg = config.pip;
+  metadata = config.lock.content.fetchPipMetadata;
+
+  ignored = l.genAttrs cfg.ignoredDependencies (name: true);
+
+  filterTarget = target:
+    l.filterAttrs (name: target: ! ignored ? ${name}) target;
+
+  # filter out ignored dependencies
+  targets = l.flip l.mapAttrs metadata.targets (
+    targetName: target:
+      l.flip l.mapAttrs (filterTarget target) (
+        packageName: deps:
+          l.filter (dep: ! ignored ? ${dep}) deps
+      )
+  );
+in {
+  imports = [
+    ./interface.nix
+  ];
+  pip.targets = targets;
+  mkDerivation.propagatedBuildInputs =
+    if cfg.flattenDependencies
+    then
+      if targets.default ? ${config.name}
+      then
+        throw ''
+          Top-level package ${config.name} is listed in the lockfile.
+          Set `pip.flattenDependencies` to false to use only the top-level dependencies.
+        ''
+      else let
+        topLevelDepNames = l.attrNames (targets.default);
+      in
+        l.map (name: cfg.drvs.${name}.public.out) topLevelDepNames
+    else if ! targets.default ? ${config.name}
+    then
+      throw ''
+        Top-level package ${config.name} is not listed in the lockfile.
+        Set `pip.flattenDependencies` to true to use all dependencies for the top-level package.
+      ''
+    else [];
+}

--- a/modules/drv-parts/pip-hotfixes/interface.nix
+++ b/modules/drv-parts/pip-hotfixes/interface.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  l = lib // builtins;
+  t = l.types;
+in {
+  options.pip = {
+    flattenDependencies = l.mkOption {
+      type = t.bool;
+      description = ''
+        Use all dependencies as top-level dependencies
+      '';
+      default = false;
+    };
+    ignoredDependencies = l.mkOption {
+      type = t.listOf t.str;
+      description = ''
+        list of dependencies to ignore
+      '';
+      default = ["wheel"];
+    };
+  };
+}

--- a/modules/drv-parts/pip/default.nix
+++ b/modules/drv-parts/pip/default.nix
@@ -9,19 +9,8 @@
   python = config.deps.python;
   metadata = config.lock.content.fetchPipMetadata;
 
-  ignored = l.genAttrs cfg.ignoredDependencies (name: true);
-
-  filterTarget = target:
-    l.filterAttrs (name: target: ! ignored ? ${name}) target;
-
   # filter out ignored dependencies
-  targets = l.flip l.mapAttrs metadata.targets (
-    targetName: target:
-      l.flip l.mapAttrs (filterTarget target) (
-        packageName: deps:
-          l.filter (dep: ! ignored ? ${dep}) deps
-      )
-  );
+  targets = cfg.targets;
 
   writers = import ../../../pkgs/writers {
     inherit lib;
@@ -113,6 +102,7 @@ in {
   imports = [
     commonModule
     ./interface.nix
+    ../pip-hotfixes
   ];
 
   config = {
@@ -138,26 +128,6 @@ in {
 
     mkDerivation = {
       dontStrip = l.mkDefault true;
-      propagatedBuildInputs =
-        if cfg.flattenDependencies
-        then
-          if targets.default ? ${config.name}
-          then
-            throw ''
-              Top-level package ${config.name} is listed in the lockfile.
-              Set `pip.flattenDependencies` to false to use only the top-level dependencies.
-            ''
-          else let
-            topLevelDepNames = l.attrNames (targets.default);
-          in
-            l.map (name: cfg.drvs.${name}.public.out) topLevelDepNames
-        else if ! targets.default ? ${config.name}
-        then
-          throw ''
-            Top-level package ${config.name} is not listed in the lockfile.
-            Set `pip.flattenDependencies` to true to use all dependencies for the top-level package.
-          ''
-        else [];
     };
   };
 }

--- a/modules/drv-parts/pip/default.nix
+++ b/modules/drv-parts/pip/default.nix
@@ -124,10 +124,16 @@ in {
 
     pip = {
       drvs = drvs;
+      rootDependencies =
+        l.genAttrs (targets.default.${config.name} or []) (_: true);
     };
 
     mkDerivation = {
       dontStrip = l.mkDefault true;
+      propagatedBuildInputs = let
+        rootDeps = lib.filterAttrs (_: x: x == true) cfg.rootDependencies;
+      in
+        l.attrValues (l.mapAttrs (name: _: cfg.drvs.${name}.public.out) rootDeps);
     };
   };
 }

--- a/modules/drv-parts/pip/interface.nix
+++ b/modules/drv-parts/pip/interface.nix
@@ -16,6 +16,13 @@ in {
       '';
       default = false;
     };
+    ignoredDependencies = l.mkOption {
+      type = t.listOf t.str;
+      description = ''
+        list of dependencies to ignore
+      '';
+      default = ["wheel"];
+    };
     pypiSnapshotDate = l.mkOption {
       type = t.str;
       description = ''

--- a/modules/drv-parts/pip/interface.nix
+++ b/modules/drv-parts/pip/interface.nix
@@ -9,6 +9,13 @@
   t = l.types;
 in {
   options.pip = {
+    flattenDependencies = l.mkOption {
+      type = t.bool;
+      description = ''
+        Use all dependencies as top-level dependencies
+      '';
+      default = false;
+    };
     pypiSnapshotDate = l.mkOption {
       type = t.str;
       description = ''

--- a/modules/drv-parts/pip/interface.nix
+++ b/modules/drv-parts/pip/interface.nix
@@ -15,6 +15,13 @@ in {
       internal = true;
       description = "the targets of the lock file to build";
     };
+    rootDependencies = l.mkOption {
+      type = t.attrsOf t.bool;
+      internal = true;
+      description = "the names of the selected top-level dependencies";
+    };
+
+    # user interface
     pypiSnapshotDate = l.mkOption {
       type = t.str;
       description = ''

--- a/modules/drv-parts/pip/interface.nix
+++ b/modules/drv-parts/pip/interface.nix
@@ -9,19 +9,11 @@
   t = l.types;
 in {
   options.pip = {
-    flattenDependencies = l.mkOption {
-      type = t.bool;
-      description = ''
-        Use all dependencies as top-level dependencies
-      '';
-      default = false;
-    };
-    ignoredDependencies = l.mkOption {
-      type = t.listOf t.str;
-      description = ''
-        list of dependencies to ignore
-      '';
-      default = ["wheel"];
+    # internal options to pass data between pip-hotfixes and pip
+    targets = l.mkOption {
+      type = t.raw;
+      internal = true;
+      description = "the targets of the lock file to build";
     };
     pypiSnapshotDate = l.mkOption {
       type = t.str;

--- a/modules/flake-parts/checks.nix-unit.nix
+++ b/modules/flake-parts/checks.nix-unit.nix
@@ -1,0 +1,17 @@
+# evaluate packages from `/**/modules/drvs` and export them via `flake.packages`
+{self, ...}: {
+  perSystem = {
+    pkgs,
+    inputs',
+    ...
+  }: {
+    # map all modules in /examples to a package output in the flake.
+    checks.nix-unit = pkgs.runCommand "nix-unit-tests" {} ''
+      export NIX_PATH=nixpkgs=${pkgs.path}
+      ${inputs'.nix-unit.packages.nix-unit}/bin/nix-unit \
+        ${self}/tests/nix-unit/* \
+        --eval-store $(realpath .)
+      touch $out
+    '';
+  };
+}

--- a/modules/flake-parts/lib.evalModules.nix
+++ b/modules/flake-parts/lib.evalModules.nix
@@ -28,7 +28,7 @@
           modules =
             args.modules
             ++ [
-              inputs.drv-parts.modules.drv-parts.core
+              self.modules.drv-parts.core
             ];
           specialArgs =
             args.specialArgs

--- a/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -1,10 +1,8 @@
-import os
-import sys
 import subprocess
 import json
 from pathlib import Path
 
-from packaging.requirements import Requirement
+from pip._vendor.packaging.requirements import Requirement
 from packaging.utils import (
     canonicalize_name,
 )

--- a/pkgs/fetchPipMetadata/src/shell.nix
+++ b/pkgs/fetchPipMetadata/src/shell.nix
@@ -1,5 +1,5 @@
 {
-  nixpkgs ? (import ../../../../..).inputs.nixpkgs,
+  nixpkgs ? (import ../../..).inputs.nixpkgs,
   system ? builtins.currentSystem,
 }: let
   lib = nixpkgs.lib;

--- a/pkgs/fetchPipMetadata/src/tests/test_evaluate_requirements.py
+++ b/pkgs/fetchPipMetadata/src/tests/test_evaluate_requirements.py
@@ -68,3 +68,23 @@ def test_platform_mismatch():
         seen=[],
     )
     assert result == dict(root_package=set())
+
+
+def test_cycle():
+    result = l.evaluate_requirements(
+        env={},
+        reqs=dict(
+            root_package={Requirement("foo")},
+            foo={Requirement("bar")},
+            bar={Requirement("foo")},
+        ),
+        dependencies=dict(),
+        root_name="root_package",
+        extras=None,
+        seen=[],
+    )
+    assert result == dict(
+        root_package={"foo"},
+        foo={"bar"},
+        bar=set(),
+    )

--- a/tests/nix-unit/test_pip_pyproject/default.nix
+++ b/tests/nix-unit/test_pip_pyproject/default.nix
@@ -1,0 +1,75 @@
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? import <nixpkgs/lib>,
+  dream2nix ? (import (../../../modules + "/flake.nix")).outputs {},
+}: let
+  eval = module:
+    lib.evalModules {
+      modules = [module];
+      specialArgs = {
+        inherit dream2nix;
+        packageSets.nixpkgs = pkgs;
+      };
+    };
+in {
+  # test if dependencies are flattened
+  test_pip_flattened_dependencies = let
+    evaled = eval {
+      imports = [
+        dream2nix.modules.drv-parts.pip
+      ];
+      name = "test";
+      lock.content = lib.mkForce {
+        fetchPipMetadata.targets.default.flask = [];
+        fetchPipMetadata.targets.default.requests = [];
+      };
+      pip.flattenDependencies = true;
+    };
+    config = evaled.config;
+  in {
+    expr = config.pip.rootDependencies;
+    expected = {
+      flask = true;
+      requests = true;
+    };
+  };
+
+  # test if dependencies are ignored successfully in pip.rootDependencies
+  test_pip_ignore_dependencies = let
+    evaled = eval {
+      imports = [
+        dream2nix.modules.drv-parts.pip
+      ];
+      name = "test";
+      pip.ignoredDependencies = ["requests"];
+      lock.content = lib.mkForce {
+        fetchPipMetadata.targets.default.test = ["requests"];
+        fetchPipMetadata.targets.default.requests = [];
+      };
+    };
+    config = evaled.config;
+  in {
+    expr = config.pip.targets.default ? requests;
+    expected = false;
+  };
+
+  # test if root dependency is picked correctly
+  test_pip_root_dependency = let
+    evaled = eval {
+      imports = [
+        dream2nix.modules.drv-parts.pip
+      ];
+      name = "test";
+      lock.content = lib.mkForce {
+        fetchPipMetadata.targets.default.test = ["requests"];
+        fetchPipMetadata.targets.default.requests = [];
+      };
+    };
+    config = evaled.config;
+  in {
+    expr = config.pip.rootDependencies;
+    expected = {
+      requests = true;
+    };
+  };
+}


### PR DESCRIPTION
- adds new option flattenDependnecies (bool), to allow for dependency specifications without root (like a requirements.txt file).
- raise an informative error if flattenedDependencies is used the wrong way (like when it's set but a root with the current package name actually exists)
- adds new option ignoredDependencies to ignore dependencies. It cotains `wheel` by default, as building wheel using buildPythonPackage usually crashes due to conflicts
- pins the packaging library used to parse pip's report to the exact version that pip uses by refering to `pip._internal`
- prevents crashes when there is a cycle in the report -> instead remove the cycle

Other stuff:
- fix lib.evalModules
- fix devshell for the pip module python stuff 