### PR TITLE
examples: remove use of `l = builtins // lib`

### DIFF
--- a/examples/packages/multi-language/python-nodejs/default.nix
+++ b/examples/packages/multi-language/python-nodejs/default.nix
@@ -22,8 +22,8 @@ in {
   version = "0.13.0";
 
   deps = {nixpkgs, ...}: {
-    stdenv = l.mkForce nixpkgs.stdenv;
-    jq = l.mkForce nixpkgs.jq;
+    stdenv = lib.mkForce nixpkgs.stdenv;
+    jq = lib.mkForce nixpkgs.jq;
     fetchFromGitHub = nixpkgs.fetchFromGitHub;
   };
 
@@ -43,8 +43,8 @@ in {
   };
 
   nodejs-granular = {
-    installMethod = l.mkForce "copy";
-    buildScript = l.mkForce "npm run build-prod";
+    installMethod = lib.mkForce "copy";
+    buildScript = lib.mkForce "npm run build-prod";
     # runBuild = true;
     # TODO: create a better interface for overrides
     deps.delayed-stream."1.0.0" = {

--- a/examples/packages/single-language/nodejs-no-lock/default.nix
+++ b/examples/packages/single-language/nodejs-no-lock/default.nix
@@ -4,7 +4,6 @@
   dream2nix,
   ...
 }: let
-  l = lib // builtins;
   system = config.deps.stdenv.system;
 in {
   imports = [
@@ -39,9 +38,9 @@ in {
       ;
   };
 
-  name = l.mkForce "app";
-  version = l.mkForce "0.0.0";
+  name = lib.mkForce "app";
+  version = lib.mkForce "0.0.0";
 
   lock.lockFileRel =
-    l.mkForce "/locks/example-package-nodejs-no-lock/lock-${system}.json";
+    lib.mkForce "/locks/example-package-nodejs-no-lock/lock-${system}.json";
 }

--- a/examples/packages/single-language/nodejs-prettier-devshell/default.nix
+++ b/examples/packages/single-language/nodejs-prettier-devshell/default.nix
@@ -3,9 +3,7 @@
   config,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.nodejs-devshell
   ];
@@ -31,6 +29,6 @@ in {
       ;
   };
 
-  name = l.mkForce "prettier";
-  version = l.mkForce "2.8.7";
+  name = lib.mkForce "prettier";
+  version = lib.mkForce "2.8.7";
 }

--- a/examples/packages/single-language/nodejs-prettier-node-modules/default.nix
+++ b/examples/packages/single-language/nodejs-prettier-node-modules/default.nix
@@ -3,9 +3,7 @@
   config,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.nodejs-node-modules
   ];
@@ -28,6 +26,6 @@ in {
       ;
   };
 
-  name = l.mkForce "prettier";
-  version = l.mkForce "2.8.7";
+  name = lib.mkForce "prettier";
+  version = lib.mkForce "2.8.7";
 }

--- a/examples/packages/single-language/nodejs-prettier/default.nix
+++ b/examples/packages/single-language/nodejs-prettier/default.nix
@@ -3,9 +3,7 @@
   config,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.nodejs-package-lock
     dream2nix.modules.dream2nix.nodejs-granular
@@ -28,6 +26,6 @@ in {
       ;
   };
 
-  name = l.mkForce "prettier";
-  version = l.mkForce "2.8.7";
+  name = lib.mkForce "prettier";
+  version = lib.mkForce "2.8.7";
 }

--- a/examples/packages/single-language/python-ansible/default.nix
+++ b/examples/packages/single-language/python-ansible/default.nix
@@ -3,9 +3,7 @@
   lib,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.pip
   ];

--- a/examples/packages/single-language/python-apache-airflow/default.nix
+++ b/examples/packages/single-language/python-apache-airflow/default.nix
@@ -4,7 +4,6 @@
   dream2nix,
   ...
 }: let
-  l = lib // builtins;
   python = config.deps.python;
 in {
   imports = [

--- a/examples/packages/single-language/python-odoo/default.nix
+++ b/examples/packages/single-language/python-odoo/default.nix
@@ -4,7 +4,6 @@
   dream2nix,
   ...
 }: let
-  l = lib // builtins;
   python = config.deps.python;
   src = config.deps.fetchFromGitHub {
     owner = "odoo";
@@ -65,11 +64,11 @@ in {
       };
       libsass.mkDerivation = {
         doCheck = false;
-        doInstallCheck = l.mkForce false;
+        doInstallCheck = lib.mkForce false;
       };
       pypdf2.mkDerivation = {
         doCheck = false;
-        doInstallCheck = l.mkForce false;
+        doInstallCheck = lib.mkForce false;
       };
     };
   };

--- a/examples/packages/single-language/python-pillow/default.nix
+++ b/examples/packages/single-language/python-pillow/default.nix
@@ -5,9 +5,7 @@
   lib,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.pip
   ];

--- a/examples/packages/single-language/python-pyproject-dependencies/default.nix
+++ b/examples/packages/single-language/python-pyproject-dependencies/default.nix
@@ -5,7 +5,6 @@
   dream2nix,
   ...
 }: let
-  l = lib // builtins;
   pyproject = lib.pipe (config.mkDerivation.src + /pyproject.toml) [
     builtins.readFile
     builtins.fromTOML

--- a/examples/packages/single-language/rust-ripgrep/default.nix
+++ b/examples/packages/single-language/rust-ripgrep/default.nix
@@ -3,9 +3,7 @@
   config,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.rust-cargo-lock
     dream2nix.modules.dream2nix.rust-crane
@@ -15,8 +13,8 @@ in {
     inherit (nixpkgs) fetchFromGitHub;
   };
 
-  name = l.mkForce "ripgrep";
-  version = l.mkForce "13.0.0";
+  name = lib.mkForce "ripgrep";
+  version = lib.mkForce "13.0.0";
 
   mkDerivation = {
     # define the source root that contains the package we want to build.

--- a/examples/packages/single-language/rust-workspace-version-inheritance/default.nix
+++ b/examples/packages/single-language/rust-workspace-version-inheritance/default.nix
@@ -3,9 +3,7 @@
   config,
   dream2nix,
   ...
-}: let
-  l = lib // builtins;
-in {
+}: {
   imports = [
     dream2nix.modules.dream2nix.rust-cargo-lock
     dream2nix.modules.dream2nix.rust-crane


### PR DESCRIPTION
Having this in the examples might confuse people
