### PR TITLE
fix(pip): change nixpkgs-overrides & remove default for top-level source

### DIFF
--- a/examples/packages/single-language/python-package-apache-airflow/default.nix
+++ b/examples/packages/single-language/python-package-apache-airflow/default.nix
@@ -53,9 +53,13 @@ in {
     drvs = {
       # We include fixes from nixpkgs for pendulum, but keep
       # our dependencies to avoid version conflicts
-      pendulum.nixpkgs-overrides = {
-        enable = true;
-        exclude = ["propagatedBuildInputs"];
+      pendulum = {
+        imports = [
+          dream2nix.modules.dream2nix.nixpkgs-overrides
+        ];
+        nixpkgs-overrides = {
+          exclude = ["propagatedBuildInputs"];
+        };
       };
       lazy-object-proxy.mkDerivation = {
         # setuptools-scm is required by lazy-object-proxy,

--- a/examples/packages/single-language/python-package-odoo/default.nix
+++ b/examples/packages/single-language/python-package-odoo/default.nix
@@ -48,12 +48,14 @@ in {
     # fix some builds via package-specific overrides
     drvs = {
       psycopg2 = {
+        imports = [
+          dream2nix.modules.dream2nix.nixpkgs-overrides
+        ];
         # We can bulk-inherit overrides from nixpkgs, to which often helps to
         # get something working quickly. In this case it's needed for psycopg2
         # to build on aarch64-darwin. We exclude propagatedBuildInputs to keep
         # python deps from our lock file and avoid version conflicts
         nixpkgs-overrides = {
-          enable = true;
           exclude = ["propagatedBuildInputs"];
         };
         # packages-specific build inputs that are used for this

--- a/modules/dream2nix/nixpkgs-overrides/interface.nix
+++ b/modules/dream2nix/nixpkgs-overrides/interface.nix
@@ -7,7 +7,11 @@
   t = l.types;
 in {
   options.nixpkgs-overrides = {
-    enable = l.mkEnableOption "Whether to copy attributes, except those in `excluded` from nixpkgs";
+    enable =
+      (l.mkEnableOption "Whether to copy attributes, except those in `excluded` from nixpkgs")
+      // {
+        default = true;
+      };
 
     exclude = l.mkOption {
       type = t.listOf t.str;

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -31,7 +31,6 @@
         imports = [
           commonModule
           dependencyModule
-          ../nixpkgs-overrides
         ];
         config = {
           inherit name;


### PR DESCRIPTION
- nixpkgs-overrides are not lazy enough. They can lead to eval failures thrown in nixpkgs despite not being enabled. Therefore we better use the `import` as an enable mechanism instead of the `enable` option.
We keep the enable option to allow for users to disable the override module via mkForce
