### PR TITLE
fix: allow locking git dependencies with pip

### DIFF
--- a/pkgs/fetchPipMetadata/package.nix
+++ b/pkgs/fetchPipMetadata/package.nix
@@ -12,11 +12,11 @@
     nativeBuildInputs = [
       gitMinimal
       python3.pkgs.pytestCheckHook
-      nix-prefetch-scripts
     ];
     propagatedBuildInputs = with python3.pkgs; [
       packaging
       certifi
+      nix-prefetch-scripts
       python-dateutil
       pip
     ];


### PR DESCRIPTION
When you had a pip git requirement such as `git+https://github.com/OCA/maintainer-tools`, `fetch_pip_metadata` was failing with:

```
Traceback (most recent call last):
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/bin/.fetch_pip_metadata-wrapped", line 9, in <module>
    sys.exit(fetch_pip_metadata())
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/lib/python3.10/site-packages/fetch_pip_metadata/__init__.py", line 126, in fetch_pip_metadata
    lock = lock_file_from_report(report, project_root=args.project_root)
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/lib/python3.10/site-packages/fetch_pip_metadata/lock_file_from_report.py", line 240, in lock_file_from_report
    name, package = lock_entry_from_report_entry(install, project_root)
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/lib/python3.10/site-packages/fetch_pip_metadata/lock_file_from_report.py", line 154, in lock_entry_from_report_entry
    info = lock_info(download_info)
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/lib/python3.10/site-packages/fetch_pip_metadata/lock_file_from_report.py", line 132, in lock_info_from_vcs
    sha256 = nix_prefetch_git(url, rev)
  File "/nix/store/v28wx7mr5m9wasbnmsij4dqfrgl0d28q-python3.10-fetch_pip_metadata/lib/python3.10/site-packages/fetch_pip_metadata/lock_file_from_report.py", line 29, in nix_prefetch_git
    subprocess.run(
  File "/nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'nix-prefetch-git'
Traceback (most recent call last):
  File "/nix/store/0715rzxpxka6b12x7nl6i25gbxp9m80g-refresh/bin/refresh", line 37, in <module>
    lock_data = run_refresh_scripts(refresh_scripts)
  File "/nix/store/0715rzxpxka6b12x7nl6i25gbxp9m80g-refresh/bin/refresh", line 33, in run_refresh_scripts
    refresh_scripts[name] = run_refresh_script(value["script"])
  File "/nix/store/0715rzxpxka6b12x7nl6i25gbxp9m80g-refresh/bin/refresh", line 19, in run_refresh_script
    subprocess.run(
  File "/nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/nix/store/2qfpia31lh9dajnf9s6dm0rp5dw109d3-script.sh']' returned non-zero exit status 1.
```

@moduon MT-1075