### PR TITLE
feat(pip): allow pypiSnapshotDate to be null

### DIFF
--- a/examples/packages/single-language/python-package-pillow/default.nix
+++ b/examples/packages/single-language/python-package-pillow/default.nix
@@ -40,7 +40,6 @@
   };
 
   pip = {
-    pypiSnapshotDate = "2023-04-02";
     requirementsList = ["${config.name}==${config.version}"];
     pipFlags = [
       "--no-binary"

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -23,12 +23,13 @@ in {
 
     # user interface
     pypiSnapshotDate = l.mkOption {
-      type = t.str;
+      type = t.nullOr t.str;
       description = ''
         maximum release date for packages
         Choose any date from the past.
       '';
       example = "2023-01-01";
+      default = null;
     };
     pipFlags = l.mkOption {
       type = t.listOf t.str;

--- a/pkgs/fetchPipMetadata/script.nix
+++ b/pkgs/fetchPipMetadata/script.nix
@@ -65,7 +65,11 @@
     mitmProxy = "${pythonWithMitmproxy}/bin/mitmdump";
 
     # convert pypiSnapshotDate to string and integrate into finalAttrs
-    pypiSnapshotDate = builtins.toString pypiSnapshotDate;
+    pypiSnapshotDate =
+      if pypiSnapshotDate == null
+      # when the snapshot date is disabled, put it far into the future
+      then "9999-01-01"
+      else builtins.toString pypiSnapshotDate;
 
     # add some variables to the derivation to integrate them into finalAttrs
     inherit


### PR DESCRIPTION
For many users not having a snapshot date is a valid use case.
Also many users will expect their lock file to be updated to the latest dependency versions via a nix run .#package.config.lock.refresh. so it can be the default behavior.
