### PR TITLE
feat(ui): add .lock attribute

### DIFF
--- a/modules/dream2nix/core/ui/default.nix
+++ b/modules/dream2nix/core/ui/default.nix
@@ -5,4 +5,10 @@
 
   config.public.name = config.name;
   config.public.version = config.version;
+  config.public.${
+    if config ? lock
+    then "lock"
+    else null
+  } =
+    config.lock.refresh;
 }


### PR DESCRIPTION
This allows updating the lock file via `nix run .#{package}.lock` instead of ` nix run .#{package}.config.lock.refresh`

This is better as it's shorter, and the keyword `lock` is widely understood to lock dependencies.
