### PR TITLE
feat(ui): add .drvPath top-level attribute

### DIFF
--- a/modules/dream2nix/core/ui/default.nix
+++ b/modules/dream2nix/core/ui/default.nix
@@ -11,4 +11,6 @@
     else null
   } =
     config.lock.refresh;
+  config.type = "derivation";
+  config.drvPath = config.public.drvPath;
 }

--- a/modules/dream2nix/core/ui/interface.nix
+++ b/modules/dream2nix/core/ui/interface.nix
@@ -9,14 +9,14 @@
       the `public` attrs, allowing users to reference name and version elsewhere
       via `${config.name}` instead of `${config.public.name}`.
     This is not only more convenient but currently also circumvents issues with
-      infinite recusions that can be triggered by referencing
+      infinite recursions that can be triggered by referencing
       `${config.public.name}`.
     The top-level of `public` contains an entry for each output, and is
       therefore dynamic. This makes `public` non-lazy as it requires evaluating
       `outputs` before it can be constructed.
     If `outputs` depend on the name and version of the package, which it might
       in IFD scenarios, then name and version itself cannot be read from
-      `public` without triggering an infinite recusion.
+      `public` without triggering an infinite recursion.
     This problem could be circumvented by removing the top-level output attrs
       from `public` as proposed in
       https://github.com/NixOS/nix/issues/6507#issuecomment-1474664755 .
@@ -31,6 +31,16 @@
     version = lib.mkOption {
       type = lib.types.str;
       description = "The version of the package";
+    };
+    drvPath = lib.mkOption {
+      type = lib.types.path;
+      internal = true;
+      description = "The path to the derivation of the package";
+    };
+    type = lib.mkOption {
+      type = lib.types.str;
+      internal = true;
+      description = "The type attribute required by nix to identify derivations";
     };
   };
 }


### PR DESCRIPTION
This allows building evaluated dream2nix modules directly via the nix CLI without having to reference `.public`
