### PR TITLE
fix(pip): set dontStrip for all dependencies

### DIFF
--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -85,6 +85,7 @@
       mkDerivation = {
         src = l.mkDefault (fetchers.${metadata.sources.${config.name}.type} metadata.sources.${config.name});
         doCheck = l.mkDefault false;
+        dontStrip = l.mkDefault true;
 
         nativeBuildInputs =
           [config.deps.unzip]
@@ -142,7 +143,6 @@ in {
     };
 
     mkDerivation = {
-      dontStrip = l.mkDefault true;
       propagatedBuildInputs = let
         rootDeps = lib.filterAttrs (_: x: x == true) cfg.rootDependencies;
       in


### PR DESCRIPTION
Stripping is slow on large binary wheels and doesn't provide much benefit as it seems
It also prevents some breakages that can occur after stripping.
