### PR TITLE
refactor(rust-crane): separate main derivation config into mainDrv option

### DIFF
--- a/examples/packages/single-language/rust-package/default.nix
+++ b/examples/packages/single-language/rust-package/default.nix
@@ -16,21 +16,26 @@
   name = lib.mkForce "ripgrep";
   version = lib.mkForce "13.0.0";
 
-  mkDerivation = {
+  rust-crane = {
     # define the source root that contains the package we want to build.
-    src = config.deps.fetchFromGitHub {
+    source = config.deps.fetchFromGitHub {
       owner = "BurntSushi";
       repo = "ripgrep";
       rev = config.version;
       sha256 = "sha256-udEh+Re2PeO3DnX4fQThsaT1Y3MBHFfrX5Q5EN2XrF0=";
     };
-    # note: any more options defined here will be applied to both
-    # `config.mkDerivation` and `config.depsDrv.mkDerivation`.
-  };
-
-  rust-crane = {
+    # define additional options, such as build profile and flags
+    # these can modify both derivations (main and dependencies)
     buildProfile = "dev";
     buildFlags = ["--verbose"];
     runTests = false;
+    # options defined here will only apply to the resulting (`config.public`) derivation (main derivation).
+    mainDrv = {
+      env.CARGO_TERM_VERBOSE = "true";
+    };
+    # options defined here will only apply to the dependencies derivation.
+    depsDrv = {
+      env.CARGO_TERM_VERBOSE = "true";
+    };
   };
 }

--- a/examples/packages/single-language/rust-workspace/default.nix
+++ b/examples/packages/single-language/rust-workspace/default.nix
@@ -9,10 +9,6 @@
     dream2nix.modules.dream2nix.rust-crane
   ];
 
-  mkDerivation = {
-    src = ./.;
-  };
-
   deps = {nixpkgs, ...}: {
     inherit
       (nixpkgs)
@@ -22,4 +18,8 @@
 
   name = "app";
   version = "0.1.0";
+
+  rust-crane = {
+    source = ./.;
+  };
 }

--- a/modules/dream2nix/rust-cargo-lock/interface.nix
+++ b/modules/dream2nix/rust-cargo-lock/interface.nix
@@ -15,7 +15,8 @@ in {
     source = {
       type = t.either t.path t.package;
       description = "Source of the package";
-      default = config.mkDerivation.src;
+      # pull default either from rust-crane source or mkDerivation source (mkDerivation is what buildRustPackage uses)
+      default = config.rust-crane.source or config.mkDerivation.src;
     };
   };
 }

--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -10,7 +10,7 @@
 
   dreamLock = config.rust-cargo-lock.dreamLock;
 
-  sourceRoot = config.mkDerivation.src;
+  sourceRoot = cfg.source;
 
   fetchDreamLockSources =
     import ../../../lib/internal/fetchDreamLockSources.nix
@@ -189,7 +189,6 @@
 in {
   imports = [
     ./interface.nix
-    dream2nix.modules.dream2nix.mkDerivation
   ];
 
   rust-crane.depsDrv = {
@@ -202,20 +201,25 @@ in {
     ];
   };
 
-  package-func.func = crane.buildPackage;
-  package-func.args = l.mkMerge [common buildArgs];
-
-  public = {
-    devShell = import ./devshell.nix {
-      name = "${pname}-devshell";
-      depsDrv = cfg.depsDrv.public;
-      mainDrv = config.public;
-      inherit lib;
-      inherit (config.deps) libiconv mkShell cargo;
+  rust-crane.mainDrv = {
+    inherit version;
+    name = pname;
+    package-func.func = crane.buildPackage;
+    package-func.args = l.mkMerge [common buildArgs];
+    public = {
+      devShell = import ./devshell.nix {
+        name = "${pname}-devshell";
+        depsDrv = cfg.depsDrv.public;
+        mainDrv = cfg.mainDrv.public;
+        inherit lib;
+        inherit (config.deps) libiconv mkShell cargo;
+      };
+      dependencies = cfg.depsDrv.public;
+      meta = utils.getMeta pname version;
     };
-    dependencies = cfg.depsDrv.public;
-    meta = utils.getMeta pname version;
   };
+
+  public = cfg.mainDrv.public;
 
   deps = {nixpkgs, ...}:
     (l.mapAttrs (_: l.mkDefault) {

--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -197,10 +197,7 @@ in {
     inherit version;
     name = pname + depsNameSuffix;
     package-func.func = crane.buildDepsOnly;
-    package-func.args = l.mkMerge [
-      common
-      depsArgs
-    ];
+    package-func.args = l.mkMerge [common depsArgs];
   };
 
   rust-crane.mainDrv = {

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -60,10 +60,7 @@ in {
     };
     mainDrv = {
       type = t.submoduleWith {
-        modules = [
-          dream2nix.modules.dream2nix.core
-          dream2nix.modules.dream2nix.mkDerivation
-        ];
+        modules = [dream2nix.modules.dream2nix.mkDerivation];
         inherit specialArgs;
       };
       description = "The main derivation config that builds the package";
@@ -71,10 +68,7 @@ in {
     };
     depsDrv = {
       type = t.submoduleWith {
-        modules = [
-          dream2nix.modules.dream2nix.core
-          dream2nix.modules.dream2nix.mkDerivation
-        ];
+        modules = [dream2nix.modules.dream2nix.mkDerivation];
         inherit specialArgs;
       };
       description = "A single derivation with all dependencies of the package";

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -7,6 +7,17 @@
   l = lib // builtins;
   t = l.types;
 in {
+  options.public = {
+    devShell = l.mkOption {
+      type = t.package;
+      description = "Development shell for this package";
+    };
+    dependencies = l.mkOption {
+      type = t.package;
+      description = "The dependencies derivation for this package";
+    };
+  };
+
   options.deps = {
     cargo = l.mkOption {
       type = t.package;

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -60,7 +60,10 @@ in {
     };
     mainDrv = {
       type = t.submoduleWith {
-        modules = [dream2nix.modules.dream2nix.mkDerivation];
+        modules = [
+          dream2nix.modules.dream2nix.core
+          dream2nix.modules.dream2nix.mkDerivation
+        ];
         inherit specialArgs;
       };
       description = "The main derivation config that builds the package";
@@ -68,7 +71,10 @@ in {
     };
     depsDrv = {
       type = t.submoduleWith {
-        modules = [dream2nix.modules.dream2nix.mkDerivation];
+        modules = [
+          dream2nix.modules.dream2nix.core
+          dream2nix.modules.dream2nix.mkDerivation
+        ];
         inherit specialArgs;
       };
       description = "A single derivation with all dependencies of the package";

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -29,6 +29,10 @@ in {
   };
 
   options.rust-crane = l.mapAttrs (_: l.mkOption) {
+    source = {
+      type = t.path;
+      description = "The source of a Cargo package or workspace to use when building";
+    };
     runTests = {
       type = t.bool;
       description = "Whether to run tests via `cargo test`";
@@ -53,6 +57,14 @@ in {
       type = t.listOf t.str;
       description = "Flags to add when running `cargo test`";
       default = [];
+    };
+    mainDrv = {
+      type = t.submoduleWith {
+        modules = [dream2nix.modules.dream2nix.mkDerivation];
+        inherit specialArgs;
+      };
+      description = "The main derivation config that builds the package";
+      default = {};
     };
     depsDrv = {
       type = t.submoduleWith {


### PR DESCRIPTION
- separates main derivation config to `config.rust-crane.mainDrv` option
- remove `mkDerivation` options from top level
- introduce `config.rust-crane.source` for setting the source root (this also helps differentiate `mkDerivation.src` since this can also hold workspace source)