### PR TITLE
docs: simplify python project example

### DIFF
--- a/examples/packages/single-language/python-project/default.nix
+++ b/examples/packages/single-language/python-project/default.nix
@@ -5,17 +5,13 @@
   dream2nix,
   ...
 }: let
-  pyproject = lib.pipe (config.mkDerivation.src + /pyproject.toml) [
-    builtins.readFile
-    builtins.fromTOML
-  ];
+  pyproject = lib.importTOML (config.mkDerivation.src + /pyproject.toml);
 in {
   imports = [
     dream2nix.modules.dream2nix.pip
   ];
 
-  name = "pyproject-dependencies";
-  version = pyproject.project.version;
+  inherit (pyproject.project) name version;
 
   mkDerivation = {
     src = ./.;
@@ -30,7 +26,10 @@ in {
 
   pip = {
     pypiSnapshotDate = "2023-08-27";
-    requirementsList = ["setuptools"] ++ pyproject.project.dependencies;
+    requirementsList =
+      pyproject.build-system.requires
+      or []
+      ++ pyproject.project.dependencies;
     flattenDependencies = true;
   };
 }


### PR DESCRIPTION
Use `lib.importTOML`, clearer than the previous implementation.

Reuse more information from `pyproject`.