### PR TITLE
fix: make python3 dep just a default

### DIFF
--- a/modules/dream2nix/core/paths/default.nix
+++ b/modules/dream2nix/core/paths/default.nix
@@ -8,7 +8,7 @@
     ../deps
   ];
   deps = {nixpkgs, ...}: {
-    python3 = nixpkgs.python3;
+    python3 = lib.mkDefault nixpkgs.python3;
     substituteAll = nixpkgs.substituteAll;
   };
   paths = {


### PR DESCRIPTION
When trying to build a package that had `python3 = nixpkgs.python311`, I got an error similar to:

```
       Definition values:
       - In `/nix/store/...-source/nix/modules/dream2nix/default': <derivation python3-3.11.4>
       - In `/nix/store/...-source/modules/dream2nix/core/paths': <derivation python3-3.10.12>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.»; }
```

This seems like a sane usage, so I'm expressing here that what dream2nix adds is just a default.