### PR TITLE
fix: forward incoming modules when using `importPackages` interface

### DIFF
--- a/modules/flake-parts/lib.nix
+++ b/modules/flake-parts/lib.nix
@@ -28,14 +28,17 @@
       module: type:
         self.lib.evalModules (forwardedArgs
           // {
-            modules = [
-              (packagesDirPath + "/${module}")
-              {
-                paths.projectRoot = projectRoot;
-                paths.projectRootFile = projectRootFile;
-                paths.package = "/${packagesDir}/${module}";
-              }
-            ];
+            modules =
+              args.modules
+              or []
+              ++ [
+                (packagesDirPath + "/${module}")
+                {
+                  paths.projectRoot = projectRoot;
+                  paths.projectRootFile = projectRootFile;
+                  paths.package = "/${packagesDir}/${module}";
+                }
+              ];
           })
     )
     (builtins.readDir packagesDirPath);


### PR DESCRIPTION
Before this patch, if a user calls `importPackages` and includes custom modules in the call, those would be lost.

@moduon MT-1075