### PR TITLE
fix: improve handling of local python dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 result
 interpreter
 __pycache__
+*.egg-info

--- a/examples/packages/single-language/python-local-dependencies/default.nix
+++ b/examples/packages/single-language/python-local-dependencies/default.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  dream2nix,
+  ...
+}: let
+  pyproject = lib.importTOML ./subpkg1/pyproject.toml;
+  buildWithSetuptools = {
+    buildPythonPackage.format = "pyproject";
+    mkDerivation.buildInputs = [config.deps.python.pkgs.setuptools];
+  };
+in rec {
+  imports = [
+    dream2nix.modules.dream2nix.pip
+    buildWithSetuptools
+  ];
+
+  inherit (pyproject.project) name version;
+
+  mkDerivation.src = lib.concatStringsSep "/" [
+    config.paths.projectRoot
+    config.paths.package
+    "subpkg1"
+  ];
+
+  buildPythonPackage.pythonImportsCheck = [
+    "subpkg1"
+    "subpkg2"
+  ];
+
+  pip = {
+    pypiSnapshotDate = "2023-09-19";
+    requirementsList = [
+      "${config.paths.package}/subpkg1"
+      "${config.paths.package}/subpkg2"
+    ];
+    drvs.subpkg2 = buildWithSetuptools;
+  };
+}

--- a/examples/packages/single-language/python-local-dependencies/lock.json
+++ b/examples/packages/single-language/python-local-dependencies/lock.json
@@ -1,0 +1,25 @@
+{
+  "fetchPipMetadata": {
+    "sources": {
+      "subpkg1": {
+        "path": "examples/packages/single-language/python-local-dependencies/subpkg1",
+        "type": "local",
+        "version": "0.0.1"
+      },
+      "subpkg2": {
+        "path": "examples/packages/single-language/python-local-dependencies/subpkg2",
+        "type": "local",
+        "version": "0.0.2"
+      }
+    },
+    "targets": {
+      "default": {
+        "subpkg1": [
+          "subpkg2"
+        ],
+        "subpkg2": []
+      }
+    }
+  },
+  "invalidationHash": "226b1267f23fd3705dd88929c9eb630aececd273204130ad42f13a4f7b8e35ca"
+}

--- a/examples/packages/single-language/python-local-dependencies/subpkg1/pyproject.toml
+++ b/examples/packages/single-language/python-local-dependencies/subpkg1/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [ "setuptools" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "subpkg1"
+version = "0.0.1"
+dependencies = [
+  "subpkg2"
+]

--- a/examples/packages/single-language/python-local-dependencies/subpkg1/subpkg1.py
+++ b/examples/packages/single-language/python-local-dependencies/subpkg1/subpkg1.py
@@ -1,0 +1,1 @@
+from subpkg2 import where

--- a/examples/packages/single-language/python-local-dependencies/subpkg2/pyproject.toml
+++ b/examples/packages/single-language/python-local-dependencies/subpkg2/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [ "setuptools" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "subpkg2"
+version = "0.0.2"

--- a/examples/packages/single-language/python-local-dependencies/subpkg2/subpkg2.py
+++ b/examples/packages/single-language/python-local-dependencies/subpkg2/subpkg2.py
@@ -1,0 +1,2 @@
+def where():
+    print(__name__)

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -56,6 +56,7 @@
   fetchers = {
     url = info: l.fetchurl {inherit (info) url sha256;};
     git = info: config.deps.fetchgit {inherit (info) url sha256 rev;};
+    local = info: "${config.paths.projectRoot}/${info.path}";
   };
 
   commonModule = {config, ...}: {
@@ -95,7 +96,7 @@
         # This is required for autoPatchelfHook to find .so files from other
         # python dependencies, like for example libcublas.so.11 from nvidia-cublas-cu11.
         preFixup = lib.optionalString config.deps.stdenv.isLinux ''
-          addAutoPatchelfSearchPath ${toString (config.mkDerivation.propagatedBuildInputs)}
+          addAutoPatchelfSearchPath $propagatedBuildInputs
         '';
         propagatedBuildInputs = let
           depsByExtra = extra: targets.${extra}.${config.name} or [];

--- a/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -67,9 +67,8 @@ def lock_info_from_path(full_path, project_root: Path):
     # See whether the path is relative to our local repo
     if project_root in full_path.parents or project_root == full_path:
         return {
-            "type": "url",
-            "url": str(full_path.relative_to(project_root)),
-            "sha256": None,
+            "type": "local",
+            "path": str(full_path.relative_to(project_root)),
         }
 
     # Otherwise, we require it is in /nix/store and just the "top-level"

--- a/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
+++ b/pkgs/fetchPipMetadata/src/tests/test_lock_info_from_path.py
@@ -6,9 +6,8 @@ import lock_file_from_report as l
 
 def test_path_in_repo_root(git_repo_path):
     assert l.lock_info_from_path(git_repo_path / "foo", git_repo_path) == {
-        "type": "url",
-        "url": "foo",
-        "sha256": None,
+        "type": "local",
+        "path": "foo",
     }
 
 


### PR DESCRIPTION
The pip locker [sometimes created a URL without hash][1] to reflect that there was a local source.

This produced the following error when trying to evaluate that derivation:

       … from call site

         at /nix/store/qdzdi6qvrqxfqxhi3j70d5dsl9f5jpby-source/modules/dream2nix/pip/default.nix:86:28:

           85|       mkDerivation = {
           86|         src = l.mkDefault (fetchers.${metadata.sources.${config.name}.type} metadata.sources.${config.name});
             |                            ^
           87|         doCheck = l.mkDefault false;

       … while calling 'url'

         at /nix/store/qdzdi6qvrqxfqxhi3j70d5dsl9f5jpby-source/modules/dream2nix/pip/default.nix:57:11:

           56|   fetchers = {
           57|     url = info: l.fetchurl {inherit (info) url sha256;};
             |           ^
           58|     git = info: config.deps.fetchgit {inherit (info) url sha256 rev;};

       error: value is null while a string was expected

Of course, one cannot call `builtins.fetchurl` without a `sha256` argument.

Now, local dependencies are specified exactly like that in the lock file. Now, we'll fetch nothing when dealing with local dependencies.

Also, their evaluation when generating `preFixup` attribute is delayed until build time. This was a bigger problem due to the previous bug, but in any case it should still help to reduce evaluation overhead.

FWIW, sometimes local sources might not really exit in the derivation source tree until build time. For example, when building aggregated sources with meta-repo management tools such as Mr. Chef.

[1]: https://github.com/nix-community/dream2nix/blob/40b65e4598e249af6cc285259c1c0afefbb0f420/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py#L72C28-L72C28