### PR TITLE
feat: output pyEnv for pip derivations

### DIFF
--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -164,13 +164,14 @@ in {
       l.attrValues (l.mapAttrs (name: _: cfg.drvs.${name}.public.out) rootDeps);
   };
 
-  public.devShell = let
+  public.pyEnv = let
     pyEnv' = config.deps.python.withPackages (ps: config.mkDerivation.propagatedBuildInputs);
-    pyEnv = pyEnv'.override (old: {
+  in
+    pyEnv'.override (old: {
       # namespaced packages are triggering a collision error, but this can be
       # safely ignored. They are still set up correctly and can be imported.
       ignoreCollisions = true;
     });
-  in
-    pyEnv.env;
+
+  public.devShell = config.public.pyEnv.env;
 }


### PR DESCRIPTION
In case you're building a python environment instead of a package, this output is very handy.