### PR TITLE
feat: allow specifying env for fetchPipMetadata

### DIFF
--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -117,12 +117,11 @@ in {
     l.mapAttrs (_: l.mkOverride 1002) {
       # This is imported directly instead of depending on dream2nix.packages
       # with the intention to keep modules independent.
-      fetchPipMetadataScript = import ../../../pkgs/fetchPipMetadata/script.nix {
-        inherit lib;
-        inherit (cfg) pypiSnapshotDate pipFlags pipVersion requirementsList requirementsFiles nativeBuildInputs;
-        inherit (config.deps) writePureShellScript nix;
+      fetchPipMetadataFunction = nixpkgs.callPackage ../../../pkgs/fetchPipMetadata/script.nix;
+      fetchPipMetadataArgs = {
+        inherit (cfg) env pypiSnapshotDate pipFlags pipVersion requirementsList requirementsFiles nativeBuildInputs;
+        inherit (config.deps) writePureShellScript;
         inherit (config.paths) findRoot;
-        inherit (nixpkgs) gitMinimal nix-prefetch-scripts python3 writeText;
         pythonInterpreter = "${python}/bin/python";
       };
       setuptools = config.deps.python.pkgs.setuptools;
@@ -132,7 +131,7 @@ in {
 
   # Keep package metadata fetched by Pip in our lockfile
   lock.fields.fetchPipMetadata = {
-    script = config.deps.fetchPipMetadataScript;
+    script = config.deps.fetchPipMetadataFunction config.deps.fetchPipMetadataArgs;
   };
 
   # if any of the invalidationData changes, the lock file will be invalidated
@@ -141,6 +140,7 @@ in {
     pip = {
       inherit
         (config.pip)
+        env
         pypiSnapshotDate
         pipFlags
         pipVersion

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -22,6 +22,18 @@ in {
     };
 
     # user interface
+    env = l.mkOption {
+      type = t.attrsOf t.str;
+      default = {};
+      description = ''
+        environment variables exported while locking
+      '';
+      example = lib.literalExpression ''
+        {
+          PIP_FIND_LINKS = "${config.deps.setuptools.dist}";
+        }
+      '';
+    };
     pypiSnapshotDate = l.mkOption {
       type = t.nullOr t.str;
       description = ''

--- a/pkgs/fetchPipMetadata/script.nix
+++ b/pkgs/fetchPipMetadata/script.nix
@@ -26,6 +26,7 @@
   requirementsFiles ? [],
   pipFlags ? [],
   pipVersion ? "23.1",
+  env ? {},
   wheelVersion ? "0.40.0",
   nativeBuildInputs ? [],
   # maximum release date for packages
@@ -86,6 +87,12 @@
     writePureShellScript
     path
     ''
+      ${
+        lib.foldlAttrs
+        (acc: name: value: acc + "\nexport " + lib.toShellVar name value)
+        ""
+        env
+      }
       ${package}/bin/fetch_pip_metadata \
         --json-args-file ${args} \
         --project-root $(${findRoot})


### PR DESCRIPTION
This helps for configuring pip with environment variables. See https://github.com/nix-community/dream2nix/discussions/697 for more context.