### PR TITLE
Fix spago lock script

### DIFF
--- a/modules/dream2nix/WIP-spago/default.nix
+++ b/modules/dream2nix/WIP-spago/default.nix
@@ -113,9 +113,11 @@ in {
     ]
     ''
       set -euo pipefail
-      mkdir $TMPDIR/package-sets
+      git clone https://github.com/purescript/package-sets.git $TMPDIR/package-sets
       cd $TMPDIR/package-sets
-      curl -fL https://github.com/purescript/package-sets/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
+      REGISTRY="$(yq ".workspace.package_set.registry" ${config.spago.spagoYamlFile})"
+      REV="$(git log --grep "$REGISTRY" --pretty=format:"%H")"
+      git checkout $REV
       yq -o=json < ${config.spago.spagoYamlFile} > spago.json
       python3 ${./lock.py}
     '';


### PR DESCRIPTION
@DavHau I picked this up again and realized that recreating the lockfile then the build failed because now [package-set](https://github.com/purescript/package-sets/) is too new (we were always fetching `master`).
Unfortunately that repo doesn't have tags that includes package set versions (like `42.1.0`) so now the entire repo is fetched instead of the tarball and then I checkout the correct branch which is discovered checking commit messages.

There could be better ways but I believe it's enough for the lock script.