### PR TITLE
fix(pdm): Make package dependencies lowercase to be consistent with pdm lock

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/lib.nix
+++ b/modules/dream2nix/WIP-python-pdm/lib.nix
@@ -215,7 +215,8 @@
   # and dependencies as names.
   # getDepsRecursively :: Attrset -> String -> Attrset
   getDepsRecursively = parseLockData: name: let
-    getDeps = name: let
+    getDeps = unstandardizedName: let
+      name = lib.strings.toLower unstandardizedName;
       dep = parseLockData.${name};
     in
       [{"${name}" = dep;}] ++ lib.flatten (map getDeps dep.dependencies);


### PR DESCRIPTION
Package dependencies in the lock file can have uppercase letters, while all pdm.lock entries are lowercase. The package that I found this in was flask. 
This PR fixes this by making all package names lowercase it `getDepsRecursively`.