### PR TITLE
feat: allow pip drvs to access config from their parent drv

### DIFF
--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -106,6 +106,8 @@
           deps = defaultDeps ++ (l.concatLists (l.map depsByExtra cfg.buildExtras));
         in
           l.map (name: cfg.drvs.${name}.public.out) deps;
+
+        passthru.topConfig = config;
       };
     };
   };


### PR DESCRIPTION
I'm doing custom builds from editable installs in a meta-repo.

To get the dirty editable path of a dependency drv, I'd need this patch, to be able to do something like:

```nix
{config, ...}:
let
  inherit (config.mkDerivation.passthru) topConfig;
  fullRelPath = topConfig.lock.content.fetchPipMetadata.sources.${config.name}.path;
in ...
```

@moduon MT-1075