### PR TITLE
feat/group pkgs versions

### DIFF
--- a/examples/dream2nix-repo-flake-pdm/flake.nix
+++ b/examples/dream2nix-repo-flake-pdm/flake.nix
@@ -33,6 +33,6 @@
       specialArgs.packageSets.nixpkgs = nixpkgs.legacyPackages.x86_64-linux;
     };
   in {
-    packages.${system} = evaled.config.groups.default.public.packages;
+    packages.${system}.requests = evaled.config.groups.default.public.packages.requests."2.31.0";
   };
 }

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -52,32 +52,34 @@ in {
       };
 
       packages = lib.flip lib.mapAttrs deps' (name: pkg: {
-        inherit name;
-        version = pkg.version;
-        imports = [
-          dream2nix.modules.dream2nix.buildPythonPackage
-          dream2nix.modules.dream2nix.mkDerivation
-          dream2nix.modules.dream2nix.package-func
-        ];
-        buildPythonPackage = {
-          format =
-            if lib.hasSuffix ".whl" pkg.source.file
-            then "wheel"
-            else "pyproject";
-        };
-        mkDerivation = {
-          # required: { pname, file, version, hash, kind, curlOpts ? "" }:
-          src = fetchFromPypi {
-            pname = name;
-            file = pkg.source.file;
-            version = pkg.version;
-            hash = pkg.source.hash;
-            kind = "";
+        ${pkg.version} = {
+          inherit name;
+          version = pkg.version;
+          imports = [
+            dream2nix.modules.dream2nix.buildPythonPackage
+            dream2nix.modules.dream2nix.mkDerivation
+            dream2nix.modules.dream2nix.package-func
+          ];
+          buildPythonPackage = {
+            format =
+              if lib.hasSuffix ".whl" pkg.source.file
+              then "wheel"
+              else "pyproject";
           };
-          propagatedBuildInputs =
-            lib.forEach
-            parsed_lock_data.${name}.dependencies
-            (depName: config.groups.${groupname}.public.packages.${depName});
+          mkDerivation = {
+            # required: { pname, file, version, hash, kind, curlOpts ? "" }:
+            src = fetchFromPypi {
+              pname = name;
+              file = pkg.source.file;
+              version = pkg.version;
+              hash = pkg.source.hash;
+              kind = "";
+            };
+            propagatedBuildInputs =
+              lib.forEach
+              parsed_lock_data.${name}.dependencies
+              (depName: lib.head (lib.attrValues (config.groups.${groupname}.public.packages.${depName})));
+          };
         };
       });
     in {inherit packages;};

--- a/modules/dream2nix/groups/group.nix
+++ b/modules/dream2nix/groups/group.nix
@@ -22,20 +22,20 @@ in {
       '';
     };
     packages = lib.mkOption {
-      type = t.lazyAttrsOf packageType;
+      type = t.lazyAttrsOf (t.lazyAttrsOf packageType);
       description = ''
         The package configurations to evaluate
       '';
     };
     packagesEval = lib.mkOption {
-      type = t.lazyAttrsOf (t.submoduleWith {modules = [];});
+      type = t.lazyAttrsOf (t.lazyAttrsOf (t.submoduleWith {modules = [];}));
       description = ''
         The evaluated dream2nix package modules
       '';
       internal = true;
     };
     public.packages = lib.mkOption {
-      type = t.lazyAttrsOf t.package;
+      type = t.lazyAttrsOf (t.lazyAttrsOf t.package);
       description = ''
         The evaluated packages ready to consume
       '';
@@ -44,6 +44,9 @@ in {
   };
   config = {
     packagesEval = config.packages;
-    public.packages = lib.mapAttrs (name: pkg: pkg.public) config.packagesEval;
+    public.packages =
+      lib.mapAttrs
+      (name: versions: lib.mapAttrs (version: pkg: pkg.public) versions)
+      config.packagesEval;
   };
 }

--- a/tests/nix-unit/test_groups/default.nix
+++ b/tests/nix-unit/test_groups/default.nix
@@ -19,20 +19,20 @@
 in {
   test_groups_simple = let
     config = eval {
-      groups.my-group.packages.hello = {...}: fixtures.basic-derivation;
+      groups.my-group.packages.hello."1.0.0" = {...}: fixtures.basic-derivation;
     };
   in {
-    expr = config.groups.my-group.public.packages.hello ? drvPath;
+    expr = config.groups.my-group.public.packages.hello."1.0.0" ? drvPath;
     expected = true;
   };
 
   test_groups_commonModule = let
     config = eval {
-      groups.my-group.packages.hello = {...}: fixtures.basic-derivation;
+      groups.my-group.packages.hello."1.0.0" = {...}: fixtures.basic-derivation;
       commonModule = {name = lib.mkForce "hello-mod";};
     };
   in {
-    expr = "${config.groups.my-group.public.packages.hello.name}";
+    expr = "${config.groups.my-group.public.packages.hello."1.0.0".name}";
     expected = "hello-mod";
   };
 }

--- a/tests/nix-unit/test_python-pdm/default.nix
+++ b/tests/nix-unit/test_python-pdm/default.nix
@@ -24,7 +24,7 @@ in {
       pdm.pyproject = ./../../../examples/dream2nix-repo-flake-pdm/pyproject.toml;
     };
   in {
-    expr = config.groups.default.public.packages.certifi ? drvPath;
+    expr = lib.head (lib.attrValues config.groups.default.public.packages.certifi) ? drvPath;
     expected = true;
   };
 }


### PR DESCRIPTION
- docs: fix typo on fetchers
- feat(github): add dependabot
- fix(github): fix dependabot file location
- chore(deps): bump actions/checkout from 2.4.0 to 3.5.3
- chore(deps): bump cachix/cachix-action from 10 to 12
- chore(deps): bump cachix/install-nix-action from 17 to 22
- feat(lock): don't write empty lock file
- examples(nodejs): add example nodejs-no-lock
- examples(nodejs): remove example prettier-no-lock
- fix(nodejs): lower prio for buildScript default
- chore(v1): update all lock files
- ci: don't run .#update-locks
- examples(nodejs): allow prettier-devshell derivation to be built
- refactor(fetchPipMetadata): split package and script
- chore(fetchPipMetadata): add devShell + .envrc
- devshell: include black into python
- tests(pip): initialize unit tests via pytest
- refactor(fetchPipMetadata): raise Exception instead of sys.exit(1)
- test(fetchPipMetadata): add more tests
- ci: expose fetchPipMetadata package and build it
- refactor(fetchPipRequirements): refactor git_repo_root
- test(fetchPipRequirements) monkeypatch nix_show_derivation
- test(fetchPipMetadata): refactor test_path_in_nix_store
- fix(v1/pip): bug in fetchPipMetadata when multiple roots are requested
- chore: update lock files
- refactor(fetchPipMetadata): minor refactoring after code review
- test(fetchPipMatadata): fix mistake in test
- ci: enable hercules
- ci: remove tests irrelevant for v1
- feat(nodejs-devshell): expose node_modules drv submodule
- packages: allow all systems...
- ci: remove nix flake check run...
- v1/lock: fix nix deprecation warning
- v1/drvs/isso: add setuptools and comment
- v1/drvs: add nixpkgs-overrides for odoos psycopg2
- readme: cleanup, improve, remove legacy stuff
- docs: remove legacy docs
- remove legacy examples + example tests
- remove legacy tests
- remove legacy notes + templates
- remove legacy overrides
- cleanup flake.nix
- chore: remove nixpkgsV1
- chore: reformat files
- chore: fix treefmt pre-commit check
- remove legacy ./src
- move v1/nix to top-level
- docs: improve readme
- WIP (#598)
- readme: fix typo
- feat: add dream2nix.modules.drv-parts.core
- examples: add dream2nix-repo
- Add module docs for writers
- chore: format
- chore: reformat docs for writers
- packages.nix: fix typo
- refactor: move drv-parts into dream2nix
- drv-parts: migrate some examples from drv-parts repo
- chore(modules): move core modules to ./modules/core
- docs: migrate docs from drv-parts
- examples: move to /examples from /modules/drvs
- examples: improve dream2nix-repo example
- docs: link examples from the docs
- fix internal links after v1 restructuring (#612)
- fetchPipMetadata: compute hash for non-FOD paths
- docs: remove v1 draft API docs from index
- notes: add notes/module-system-problems.md
- benchmarks: pkg-funcs vs. modules
- all-modules: ignore files in module directory
- modules: add standalone flake
- benchmarks: configure number of env variables via $2
- pip: fix devshell
- lib.evalModules: fix reference to modules
- pip: don't crash on cycles, fix them instead
- pip: fix bug with parsing requirements
- feat(pip): add option flattenedDependencies for requirements specifications without root
- feat(pip): add option ignoredDependencies, to ignore dependencies like wheel
- refactor(pip): move flattenDependencies and ignoredDependencies to separate module pip-hotfixes
- example: add pyproject example package
- pip: add internal option pip.rootDependencies
- tests: add nix unit tests for pip module
- chore(v1): get rid of dreamLockUtils.nix
- feat(v1): port cargo-lock translator to drv-parts
- port buildRustPackage to drv-parts
- rust: backport #525: add support for workspace-inherited crate versions
- feat(rust): move v1/nix/modules to modules
- docs(rust): update some comments
- feat(rust): port crane builder
- feat(rust): add some options to crane builder, move rust drvs to examples dir
- refactor: remove devshell code from buildRustPackage
- feat(rust): pass mkDerivation options to crane options, add options to specify arguments for main and deps derivations
- refactor(rust-crane): move crane dependency out of config.deps
- feat(rust-crane): use mkDerivation instead of mainDrvOptions
- feat(rust-crane): get rid of depsDrvOptions and use mkDerivation as a submodule instead
- Port php to dream2nix modules (#623)
- chore(deps): bump actions/checkout from 3.5.3 to 3.6.0
- refactor(examples): re-categorize
- refactor: rename modules.drv-parts => modules.dream2nix
- deps: simplify example
- feat(paths): init new core module 'paths'
- chore: update all lock files and move to new location
- cleanup: remove commented code
- Add hash for git based packages
- Support install git dependencies
- Fixup fetchPipMetadata shell.nix
- Add test for pip with git dependency
- Revert "Add test for pip with git dependency"
- Revert "Fixup fetchPipMetadata shell.nix"
- Revert "Support install git dependencies"
- Revert "Add hash for git based packages"
- example-repo: use dream2nix.lib.evalModules
- examples: add dream2nix-repo-flake
- fix(examples): use settings.nix
- fix(paths): fix computation of lock and cache file paths
- fix(pip): remove default for `format`
- feat(pip): add .devShell attribute to package
- fix(pip): conflicting override  priority
- examples: add .project-root
- refactor(fetchPipMetadata)
- fix(pip): missing writeText dependency
- examples: remove use of `l = builtins // lib`
- fetchPipMetadata: fix devShell
- refactor(examples): more meaningful names
- .github: remove format test (already executed by hercules)
- examples: pick cheaper packages for nodejs
- Support git repositories in fetchPipMetadata; take 2 (#637)
- .github: update dependencies
- typo (#640)
- init: package-lock.json V3 parser
- checks.nix-unit: fix nix-unit call
- fix(nodejs-package-lock-v3): handle multiple versions & auto load packageLock
- nodejs-granular-v3: init (copy from nodejs-granular)
- nodejs-granular-v3: use new nodejs-package-lock-v3 module
- docs(readme): fix example links and add one for flake repo
- examples: templates for all example packages and repos
- feat(lib): add helper lib.importPackages
- feat(rust-crane): add devshell to packages
- fix(buildRustPackage): add patch workspace deps to build rust package
- fix(rust-crane): add cargo to the devshell
- fix(examples): fix rust-package example
- fix(rust-crane): pull stdenv from correct option, pass drvs separately in devshell
- fix(pip): change nixpkgs-overrides & remove default for top-level source
- feat(lib/internal): add findCycles.nix
- fix: allow locking git dependencies with pip
- examples: simplify repo examples
- modules.drv-parts: add deprecation error
- fix(pip): ensure autoPatchelfHook finds python binary dependencies
- feat(pip): allow pypiSnapshotDate to be null
- fix(pip): fix namespace packages collision error
- feat(python): add module WIP-python-pyproject
- fix(python-pyproject): remove default for pythonImportsCheck
- feat: community overrides
- feat(ui): add .lock attribute
- feat(ui): add .drvPath top-level attribute
- fix(pip): set dontStrip for all dependencies
- feat(overlays/torch): add /run/opengl-driver/lib to RPATH
- fix(overlays/torch): use autoAddOpenGLRunpathHook
- feat(lock): lock file invalidation via lock.invalidationData
- chore: update lock files
- fix(lock): remove flakes command from error
- refactor(lock): introduce mkLazy
- fix(pip): don't set addAutoPatchelfSearchPath on darwin
- docs: simplify python project example
- refactor: update rust-package example to latest changes (#685)
- templates: remove v1-python template
- fix(rust-crane): actually pull craneSource from config.deps (#688)
- fix(rust-crane): use crane functions from config.deps.crane options (#689)
- update nixpkgs input
- fix(pip): don't invalidate lock file on python minor version updates
- chore: re-generate all lock files
- fix(php): exclude xml extension
- fix: forward incoming modules when using `importPackages` interface
- feat(paths): allow paths.package to be an absolute path
- ci: remove ./ci.nix
- fix(paths): don't force projectRoot to be in store
- feat: output pyEnv for pip derivations
- feat: allow to split buildInputs in python derivations
- fix: improve handling of local python dependencies
- chore(deps): bump actions/checkout from 4.0.0 to 4.1.0
- wip pdm init
- chore(python-pdm): rename python-pdm -> WIP-python-pdm
- feat(python-pdm): initialize wheel filtering
- feat(python-pdm): iterate
- chore(pdm): update example lock file
- fix(pdm/parseLockData): filter deps properly
- pdm lib: add several type annotations
- fix(python-pdm): fix tests
- fix(modules): pass modules inputs correctly
- fix(examples): fix shadowed dream2nix arg
- pdm: no need tos split filename from url with new format
- pdm lib: recurse into dependencies
- WIP
- fix(spago): fix flake inputs
- feat(pdm): build default group
- fix(rust-crane): don't forget to pass mkDerivation.meta to main derivation
- pdm: add non-default groups as well
- pdm: re-activate nix-unit test for pdm
- fix: nixpkgs follows d2n
- modules: export also core modules
- flake: update nixpkgs
- checks: add all packages to checks
- fetch-pip-metadata: fix build
- mergify: init
- examples/pdm: pin nixpkgs to dream2nix nixpkgs
- fix(groups): fix type on override parameter
- feat: allow specifying env for fetchPipMetadata
- findCycles: add some unit tests
- init flake parts docs modules
- WIP: adopt flake-parts docs modules for dream2nix
- docs: add missing descriptions for core module
- docs: render first module via `site` module
- docs: improve module reference rendering
- modules: various fixups for rendering docs
- modules: fixups for documentation rendering
- modules: fixups nodejs modules to render docs
- modules: fixup more nodejs modules for docs rendering
- modules: fixup core modules for docs rendering
- docs: add reference documentation to website
- linkchecker: disable because of performance issues
- buildRustPackage: add example package
- checks: add system attribute
- add new node builder mono-module (#748)
- fix(spago): lock script uses correct `package-set` rev
- fix(pdm): Make parsed_deps lowercase
- mergify: add auto-merge label
- add more graph utilities
- format
- add more graph utilities
- format
- format
- findCycles: revert to original file
- add versions to group packages
