### PR TITLE
test: add per module testing infra

### DIFF
--- a/modules/dream2nix/nodejs-devshell/tests/packages/basic/default.nix
+++ b/modules/dream2nix/nodejs-devshell/tests/packages/basic/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  dream2nix,
+  ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-devshell
+    dream2nix.modules.dream2nix.nodejs-package-lock
+  ];
+
+  nodejs-package-lock = {
+    source = ./.;
+  };
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      mkShell
+      rsync
+      stdenv
+      ;
+  };
+
+  name = "app";
+  version = "1.0.0";
+
+  mkDerivation = {
+    src = config.nodejs-package-lock.source;
+    # allow devshell to be built -> CI pipeline happy
+    buildPhase = "mkdir $out";
+  };
+}

--- a/modules/dream2nix/nodejs-devshell/tests/packages/basic/package-lock.json
+++ b/modules/dream2nix/nodejs-devshell/tests/packages/basic/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0",
+      "dependencies": {
+        "typescript": "^5.1.6"
+      },
+      "bin": {
+        "app": "app.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+    }
+  }
+}

--- a/modules/dream2nix/nodejs-devshell/tests/packages/basic/package.json
+++ b/modules/dream2nix/nodejs-devshell/tests/packages/basic/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "dependencies": {
+    "typescript": "^5.1.6"
+  },
+  "bin": "app.js"
+}

--- a/modules/dream2nix/nodejs-node-modules/tests/packages/basic/default.nix
+++ b/modules/dream2nix/nodejs-node-modules/tests/packages/basic/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  dream2nix,
+  ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-node-modules
+    dream2nix.modules.dream2nix.nodejs-package-lock
+  ];
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      mkShell
+      stdenv
+      ;
+  };
+
+  nodejs-package-lock = {
+    source = ./.;
+  };
+
+  name = "app";
+  version = "1.0.0";
+  mkDerivation = {
+    src = config.nodejs-package-lock.source;
+  };
+}

--- a/modules/dream2nix/nodejs-node-modules/tests/packages/basic/package-lock.json
+++ b/modules/dream2nix/nodejs-node-modules/tests/packages/basic/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0",
+      "dependencies": {
+        "typescript": "^5.1.6"
+      },
+      "bin": {
+        "app": "app.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+    }
+  }
+}

--- a/modules/dream2nix/nodejs-node-modules/tests/packages/basic/package.json
+++ b/modules/dream2nix/nodejs-node-modules/tests/packages/basic/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "dependencies": {
+    "typescript": "^5.1.6"
+  },
+  "bin": "app.js"
+}

--- a/modules/dream2nix/nodejs-package-json/tests/packages/basic/app.ts
+++ b/modules/dream2nix/nodejs-package-json/tests/packages/basic/app.ts
@@ -1,0 +1,2 @@
+let message: string = 'Hello, World!';
+console.log(message);

--- a/modules/dream2nix/nodejs-package-json/tests/packages/basic/default.nix
+++ b/modules/dream2nix/nodejs-package-json/tests/packages/basic/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  config,
+  dream2nix,
+  ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-package-json
+    dream2nix.modules.dream2nix.nodejs-granular
+  ];
+
+  nodejs-package-lock = {
+    source = ./.;
+  };
+
+  paths.projectRootFile = "package.json";
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      stdenv
+      ;
+    npm = nixpkgs.nodejs.pkgs.npm.override rec {
+      version = "8.19.4";
+      src = nixpkgs.fetchurl {
+        url = "https://registry.npmjs.org/npm/-/npm-${version}.tgz";
+        hash = "sha256-JmehuDAPMV0iPkPDB/vpRuuLl3kq85lCTvZ+qcsKcvY=";
+      };
+    };
+  };
+
+  name = lib.mkForce "app";
+  version = lib.mkForce "1.0.0";
+
+  nodejs-granular = {
+    buildScript = ''
+      tsc ./app.ts
+      mv app.js app.js.tmp
+      echo "#!${config.deps.nodejs}/bin/node" > app.js
+      cat app.js.tmp >> app.js
+      chmod +x ./app.js
+      patchShebangs .
+    '';
+  };
+
+  mkDerivation = {
+    src = ./.;
+    checkPhase = ''
+      [[ "Hello, World!" =~ "$(./app.js)" ]]
+    '';
+    doCheck = true;
+  };
+}

--- a/modules/dream2nix/nodejs-package-json/tests/packages/basic/lock.json
+++ b/modules/dream2nix/nodejs-package-json/tests/packages/basic/lock.json
@@ -1,0 +1,40 @@
+{
+  "package-lock": {
+    "name": "app",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": {
+          "typescript": "^5.1.6"
+        },
+        "bin": {
+          "app": "app.js"
+        }
+      },
+      "node_modules/typescript": {
+        "version": "5.2.2",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+        "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+        "bin": {
+          "tsc": "bin/tsc",
+          "tsserver": "bin/tsserver"
+        },
+        "engines": {
+          "node": ">=14.17"
+        }
+      }
+    },
+    "dependencies": {
+      "typescript": {
+        "version": "5.2.2",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+        "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+      }
+    }
+  },
+  "invalidationHash": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+}

--- a/modules/dream2nix/nodejs-package-json/tests/packages/basic/package.json
+++ b/modules/dream2nix/nodejs-package-json/tests/packages/basic/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "dependencies": {
+    "typescript": "^5.1.6"
+  },
+  "bin": "app.js"
+}

--- a/modules/flake-parts/checks.nix
+++ b/modules/flake-parts/checks.nix
@@ -1,5 +1,44 @@
 {
-  perSystem = {self', ...}: {
-    checks = self'.packages;
+  self,
+  lib,
+  ...
+}: {
+  perSystem = {
+    self',
+    pkgs,
+    ...
+  }: let
+    modules = self.modules.dream2nix;
+    modulesWithTests =
+      lib.filterAttrs
+      (_: module: lib.pathExists (module + /tests/packages))
+      modules;
+    getPackagePaths = moduleName: modulePath:
+      lib.concatMapAttrs
+      (packageDir: _: {
+        "module-${moduleName}-${packageDir}" = "${modulePath}/tests/packages/${packageDir}";
+      })
+      (builtins.readDir (modulePath + /tests/packages));
+    makePackage = testModulePath: let
+      evaled = lib.evalModules {
+        specialArgs = {
+          dream2nix.modules = self.modules;
+          packageSets.nixpkgs = pkgs;
+        };
+        modules = [
+          testModulePath
+          {
+            paths.projectRoot = testModulePath;
+            paths.package = testModulePath;
+          }
+        ];
+      };
+    in
+      evaled.config.public;
+    packagesToBuild =
+      lib.concatMapAttrs getPackagePaths modulesWithTests;
+    packagesBuilt = lib.mapAttrs (_: makePackage) packagesToBuild;
+  in {
+    checks = self'.packages // packagesBuilt;
   };
 }


### PR DESCRIPTION
So far, /examples was the only place with packages that are built in the CI pipeline.
This change allows us to add package build tests to individual modules at the location where the module is defined. This has several benefits:

- We are not forced to add unnecessary examples in order to maintain test coverage
- When modules get removed, their tests will be removed alongside
- It allows us to keep old modules around and assure they keep working without having to keep outdated examples in /examples
