### PR TITLE
nixpkgs-overrides: map env field correctly

### DIFF
--- a/modules/dream2nix/nixpkgs-overrides/default.nix
+++ b/modules/dream2nix/nixpkgs-overrides/default.nix
@@ -38,16 +38,18 @@
     extracted;
 
   extractedEnv =
-    l.filterAttrs
-    (
-      name: _:
-        ! (
-          extractedMkDerivation
-          ? ${name}
-          || extractedBuildPythonPackage ? ${name}
-        )
-    )
-    extracted;
+    (l.filterAttrs
+      (
+        name: _:
+          ! (
+            extractedMkDerivation
+            ? ${name}
+            || extractedBuildPythonPackage ? ${name}
+          )
+          && name != "env"
+      )
+      extracted)
+    // extracted.env or {};
 in {
   imports = [
     ./interface.nix


### PR DESCRIPTION
Now that mkDerivation also has an `env` flag, we need to make sure to not forward this to mkDerivation, as we have our own env option.
