### PR TITLE
Add git to the npm lock fetch script path

### DIFF
--- a/modules/dream2nix/nodejs-package-json-v3/default.nix
+++ b/modules/dream2nix/nodejs-package-json-v3/default.nix
@@ -33,6 +33,7 @@ in {
           bash
           coreutils
           gawk
+          git
           path
           writeScript
           writeScriptBin
@@ -45,6 +46,7 @@ in {
       [
         config.deps.coreutils
         config.deps.npm
+        config.deps.git
       ]
       ''
         source=${cfg.source}

--- a/modules/dream2nix/nodejs-package-json/default.nix
+++ b/modules/dream2nix/nodejs-package-json/default.nix
@@ -38,6 +38,7 @@ in {
           bash
           coreutils
           gawk
+          git
           path
           writeScript
           writeScriptBin
@@ -48,6 +49,7 @@ in {
       writers.writePureShellScript
       [
         config.deps.coreutils
+        config.deps.git
         npm
       ]
       ''

--- a/modules/dream2nix/nodejs-package-lock-v3/default.nix
+++ b/modules/dream2nix/nodejs-package-lock-v3/default.nix
@@ -7,7 +7,7 @@
   l = lib // builtins;
   cfg = config.nodejs-package-lock-v3;
 
-  inherit (config.deps) fetchurl;
+  inherit (config.deps) fetchurl fetchGit;
 
   nodejsLockUtils = import ../../../lib/internal/nodejsLockUtils.nix {inherit lib;};
 
@@ -18,6 +18,15 @@
     then
       # entry is local file
       (builtins.dirOf config.nodejs-package-lock-v3.packageLockFile) + "/${plent.resolved}"
+    else if (l.hasPrefix "git+" plent.resolved)
+    then let
+      split = l.splitString "#" plent.resolved;
+    in
+      fetchGit {
+        url = l.removePrefix "git+" (builtins.head split);
+        allRefs = true;
+        rev = builtins.head (builtins.tail split);
+      }
     else
       fetchurl {
         url = plent.resolved;
@@ -93,6 +102,10 @@ in {
     inherit
       (nixpkgs)
       fetchurl
+      ;
+    inherit
+      (builtins)
+      fetchGit
       ;
   };
 


### PR DESCRIPTION
Testing with pisignage-server, I found that it failed to create `lock.json` when I ran `flake run .#pisignage-server.lock`, presumably because https://github.com/colloqi/pisignage-server/blob/59d9fb6b238c00a2ba6d166cd58c444f738416bf/package-lock.json#L3108C4-L3108C4 requires git to fetch.

With this change, it now creates a `lock.json` - however without an `integrity` section:

```
      "node_modules/919.socket.io": {
        "version": "0.9.19",
        "resolved": "git+ssh://git@github.com/colloqi/socket.io.git#7534db0e49b8310047527cc46e3c3342d3986be3",
        "dependencies": {
          "base64id": "0.1.0",
          "policyfile": "0.0.4",
          "socket.io-client": "0.9.16"
        },
        "engines": {
          "node": ">= 0.4.0"
        },
        "optionalDependencies": {
          "redis": "0.7.3"
        }
      },
```

... and even if it would have an `integrity` field, it fails to download:

```
trying git+ssh://git@github.com/colloqi/socket.io.git#7534db0e49b8310047527cc46e3c3342d3986be3
curl: (1) Protocol "git+ssh" not supported or disabled in libcurl
error: cannot download socket.io.git-7534db0e49b8310047527cc46e3c3342d3986be3 from any mirror
```

... so it seems further explicit support for fetching would be needed?

Interestingly the 'upstream' package-lock.json doesn't have an `integrity` field for this package either