### PR TITLE
Fix type error in default value provided for option lock.extraScripts

### DIFF
--- a/modules/dream2nix/core/lock/interface.nix
+++ b/modules/dream2nix/core/lock/interface.nix
@@ -26,7 +26,7 @@ in {
 
     extraScripts = l.mkOption {
       type = t.listOf t.path;
-      default = "";
+      default = [];
       description = ''
         Extra shell scripts to execute when `nix run .#{package}.lock` is called.
 


### PR DESCRIPTION
**Problem**: The default is an empty string but this violates the type constraint for the value which expects a list.

**Fix**: change empty string to empty array.

This bug is mentioned by @yukkop in this issue https://github.com/nix-community/dream2nix/issues/829