### PR TITLE
pdm: only default to given python3 in overrideAll.

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -82,8 +82,8 @@ in {
   overrideAll = {
     imports = [commonModule];
     deps = {nixpkgs, ...}: {
-      python3 = config.deps.python3;
-      python = config.deps.python3;
+      python3 = lib.mkDefault config.deps.python3;
+      python = lib.mkDefault config.deps.python3;
     };
     sourceSelector = lib.mkOptionDefault config.pdm.sourceSelector;
   };


### PR DESCRIPTION
Without this, one easily runs into conflicts when creating overrides in downstream packages.

```
      error: The option `groups.dev.packages.lxml."4.9.2".evaluated.deps.python' is defined multiple times while it's expected to be unique.
       Definition values:
       - In `/nix/store/37qh8mqrk809zmqcyfn86snqmf1p9j2d-source/modules/dream2nix/WIP-python-pdm, via option overrideAll': <derivation python3-3.11.6>
       - In `/nix/store/xhpcrfk2h8wvy5jpvxi4rqhj9ffc9mfs-source/nix/drvs/my-package, via option overrideAll': <derivation python3-3.10.13>
```