### PR TITLE
fix(nodejs-package-json-v3): remove duplicate dependency

### DIFF
--- a/modules/dream2nix/nodejs-package-json-v3/default.nix
+++ b/modules/dream2nix/nodejs-package-json-v3/default.nix
@@ -36,7 +36,6 @@ in {
           git
           path
           writeScript
-          writeScriptBin
           ;
         npm = nixpkgs.nodejs.pkgs.npm;
       };


### PR DESCRIPTION
Fixes this bug:

```shell
➤ nix run gitlab:moduon/precommix/87d94a95c17d0aa3ac61d6e9d190221c0634c972#eslint.lock -L
error:
       … while calling the 'head' builtin

         at /nix/store/0zqp13i2jys5amxmyfxjr6kj62m7ncya-source/lib/attrsets.nix:922:11:

          921|         || pred here (elemAt values 1) (head values) then
          922|           head values
             |           ^
          923|         else

       … while evaluating the attribute 'optionalValue.value'

         at /nix/store/0zqp13i2jys5amxmyfxjr6kj62m7ncya-source/lib/modules.nix:854:5:

          853|
          854|     optionalValue =
             |     ^
          855|       if isDefined then { value = mergedValue; }

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The option `deps.writeScriptBin' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `/nix/store/kqgmg47i6zs3im5zalsg5zzb0ihx5p2x-source/modules/dream2nix/nodejs-package-json-v3': <function>
       - In `/nix/store/kqgmg47i6zs3im5zalsg5zzb0ihx5p2x-source/modules/dream2nix/core/lock': <function>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

For future reference, it's building [this revision](https://gitlab.com/moduon/precommix/-/merge_requests/9/diffs?diff_id=902027728).