### PR TITLE
pdm: fix various bugs

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -42,7 +42,9 @@
     setuptools =
       if cfg.name == "setuptools"
       then config.deps.python.pkgs.setuptools
-      else config.pip.drvs.setuptools.public or config.deps.python.pkgs.setuptools;
+      else if config.groups.default.packages ? setuptools
+      then (lib.head (lib.attrValues config.groups.default.packages.setuptools)).public
+      else config.deps.python.pkgs.setuptools;
   in {
     mkDerivation.buildInputs =
       lib.optionals

--- a/modules/dream2nix/core/paths/default.nix
+++ b/modules/dream2nix/core/paths/default.nix
@@ -8,7 +8,7 @@
     ../deps
   ];
   deps = {nixpkgs, ...}:
-    lib.mapAttrs (_: opt: lib.mkOverride 49 opt) {
+    lib.mapAttrs (_: opt: lib.mkOverride 1003 opt) {
       python3 = nixpkgs.python3;
       substituteAll = nixpkgs.substituteAll;
     };


### PR DESCRIPTION
- default to correct version of setuptools from lock file
- better default for python3 set in dream2nix.core.paths
