### PR TITLE
fetching: set shallow=true for all fetchGit calls

### DIFF
--- a/dev-flake/flake-compat.nix
+++ b/dev-flake/flake-compat.nix
@@ -43,15 +43,14 @@
           outPath =
             builtins.fetchGit
             (
-              {url = info.url;}
+              {
+                url = info.url;
+                shallow = true;
+                allRefs = true;
+              }
               // (
                 if info ? rev
                 then {inherit (info) rev;}
-                else {}
-              )
-              // (
-                if info ? ref
-                then {inherit (info) ref;}
                 else {}
               )
               // (

--- a/lib/internal/fetchers/git/default.nix
+++ b/lib/internal/fetchers/git/default.nix
@@ -57,10 +57,10 @@ in {
         (b.fetchGit
           (refAndRev
             // {
-              inherit url;
+              inherit url submodules;
               # disable fetching all refs if the source specifies a ref
+              shallow = true;
               allRefs = ! hasGitRef;
-              inherit submodules;
             }));
 
       # git can either be verified via revision or hash.
@@ -74,9 +74,8 @@ in {
             b.fetchGit
             (refAndRev
               // {
-                inherit url;
-                allRefs = true;
-                inherit submodules;
+                inherit url submodules;
+                shallow = true;
               })
         else
           fetchgit

--- a/modules/dream2nix/WIP-spago/default.nix
+++ b/modules/dream2nix/WIP-spago/default.nix
@@ -68,6 +68,8 @@ in {
     builtins.fetchGit {
       inherit (dep) rev;
       url = dep.repo;
+      shallow = true;
+      allRefs = true;
     })
   config.lock.content.spago-lock;
 

--- a/modules/dream2nix/nodejs-package-lock-v3/default.nix
+++ b/modules/dream2nix/nodejs-package-lock-v3/default.nix
@@ -24,6 +24,7 @@
     in
       fetchGit {
         url = l.removePrefix "git+" (builtins.head split);
+        shallow = true;
         allRefs = true;
         rev = builtins.head (builtins.tail split);
       }


### PR DESCRIPTION
This should lead to better performance
Also set allRefs=true in some places, as this reduces the risk of running into issues with older nix versions
