### PR TITLE
cleanup core options

### DIFF
--- a/examples/packages/basics/htop-with-flags/default.nix
+++ b/examples/packages/basics/htop-with-flags/default.nix
@@ -10,6 +10,7 @@ in {
   # select mkDerivation as a backend for this package
   imports = [
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.flags
   ];
 
   config = {

--- a/examples/packages/basics/mkDerivation/default.nix
+++ b/examples/packages/basics/mkDerivation/default.nix
@@ -7,6 +7,7 @@
   # select mkDerivation as a backend for this package
   imports = [
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.flags
   ];
 
   deps = {nixpkgs, ...}: {

--- a/modules/dream2nix/core/default.nix
+++ b/modules/dream2nix/core/default.nix
@@ -4,8 +4,6 @@
     ./docs
     ./deps
     ./env
-    ./eval-cache
-    ./flags
     ./lock
     ./paths
     ./public

--- a/modules/dream2nix/core/eval-cache/interface.nix
+++ b/modules/dream2nix/core/eval-cache/interface.nix
@@ -14,6 +14,7 @@ in {
       type = t.submodule {
         freeformType = t.anything;
       };
+      internal = true;
       description = ''
         The content of the cached fields.
         For example if fields.pname is set to true, then content.pname will exist.
@@ -22,6 +23,7 @@ in {
 
     invalidationFields = l.mkOption {
       type = t.attrsOf t.anything;
+      internal = true;
       description = "Fields, when changed, require refreshing the cache";
       default = {};
       example = {
@@ -31,6 +33,7 @@ in {
 
     fields = l.mkOption {
       type = t.attrsOf t.anything;
+      internal = true;
       description = "Fields for which to cache evaluation";
       default = {};
       example = {
@@ -49,6 +52,7 @@ in {
 
     refresh = l.mkOption {
       type = t.path;
+      internal = true;
       description = "Script to refresh the eval cache file";
       readOnly = true;
     };

--- a/modules/dream2nix/package-func/interface.nix
+++ b/modules/dream2nix/package-func/interface.nix
@@ -11,21 +11,25 @@ in {
   options = {
     package-func.outputs = l.mkOption {
       type = t.listOf t.str;
+      internal = true;
       description = "Outputs of the derivation this package function produces";
     };
 
     package-func.args = l.mkOption {
       type = t.lazyAttrsOf (t.either (t.listOf t.raw) t.anything);
+      internal = true;
       description = "The arguments which will be passed to `package-func.func`";
     };
 
     package-func.func = l.mkOption {
       type = t.raw;
+      internal = true;
       description = "Will be called with `package-func.args` in order to derive `package-func.result`";
     };
 
     package-func.result = l.mkOption {
       type = t.raw;
+      internal = true;
       description = ''
         The result of calling the final derivation function.
         This is not necessarily the same as `final.package`. The function output might not be compatible to the interface of `final.package` and additional logic might be needed to create `final.package`.

--- a/modules/flake-parts/apps.update-locks.nix
+++ b/modules/flake-parts/apps.update-locks.nix
@@ -1,4 +1,4 @@
-# custom app to update the eval-cache of each exported package.
+# custom app to update the lock file of each exported package.
 {
   self,
   lib,


### PR DESCRIPTION
- don't import eval-cache and flags modules by default (those have never been used so far)
- mark options of package-func as internal. Those are for maintainers only and don't need to be rendered by default
