### PR TITLE
docs: don't strip foreign module options

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -46,7 +46,10 @@
       then (lib.head (lib.attrValues config.groups.default.packages.setuptools)).public
       else config.deps.python.pkgs.setuptools;
   in {
-    mkDerivation.buildInputs =
+    imports = [
+      dream2nix.modules.dream2nix.mkDerivation
+    ];
+    config.mkDerivation.buildInputs =
       lib.optionals
       (! lib.hasSuffix ".whl" cfg.mkDerivation.src)
       [setuptools];
@@ -88,7 +91,6 @@ in {
     deps = {nixpkgs, ...}: {
       python = lib.mkDefault config.deps.python;
     };
-    sourceSelector = lib.mkOptionDefault config.pdm.sourceSelector;
   };
   pdm.sourceSelector = lib.mkDefault libpdm.preferWheelSelector;
   buildPythonPackage = {
@@ -146,6 +148,7 @@ in {
           ];
           inherit name;
           version = lib.mkDefault pkg.version;
+          sourceSelector = lib.mkOptionDefault config.pdm.sourceSelector;
           buildPythonPackage = {
             format = lib.mkDefault (
               if lib.hasSuffix ".whl" source.file

--- a/modules/flake-parts/website/default.nix
+++ b/modules/flake-parts/website/default.nix
@@ -21,6 +21,7 @@
       "ui"
       "docs"
       "assertions"
+      "nixpkgs-overrides"
 
       # doesn't need to be rendered
       "_template"
@@ -43,12 +44,8 @@
           ! (lib.elem name excludes))
         (self.modules.dream2nix))
       (name: module: {
+        inherit module;
         title = name;
-        # module = self.modules.dream2nix.${name};
-        module =
-          if lib.pathExists (self.modules.dream2nix.${name} + /interface.nix)
-          then (self.modules.dream2nix.${name} + /interface.nix)
-          else module;
         sourcePath = self;
         attributePath = [
           "dream2nix"

--- a/modules/flake-parts/website/render/default.nix
+++ b/modules/flake-parts/website/render/default.nix
@@ -155,11 +155,7 @@ in {
           )
           opt.declarations;
       in
-        if
-          ((lib.head opt.loc) == sourceName)
-          || (topLevelOptions ? "${(lib.head opt.loc)}")
-        then opt // {inherit declarations;}
-        else opt // {visible = false;};
+        opt // {inherit declarations;};
 
     inputModule = {
       config,


### PR DESCRIPTION
previously the options of other imported modules were not shown which gave an incomplete picture. For example the docs page for the `pip` module did not show the options prefixed with `mkDerivation` which are accepted and needed by the pip module.
It's better to have everything on one page for each module.
