### PR TITLE
docs: refine public/experimental

### DIFF
--- a/modules/flake-parts/website/default.nix
+++ b/modules/flake-parts/website/default.nix
@@ -27,9 +27,6 @@
       "_template"
     ];
     public = lib.genAttrs [
-      "nodejs-devshell-v3"
-      "nodejs-node-modules-v3"
-      "nodejs-package-json-v3"
       "nodejs-package-lock-v3"
       "php-composer-lock"
       "pip"


### PR DESCRIPTION
Move some barely used modules to the experimental section to reduce surface.
Instead of the separate dev-shell module the nodejs package should have a devShell subattribute.
