### PR TITLE
python: remove catchConflicts = false overrides

### DIFF
--- a/examples/packages/languages/python-local-development-machine-learning/default.nix
+++ b/examples/packages/languages/python-local-development-machine-learning/default.nix
@@ -16,9 +16,6 @@
     src = ./.;
   };
 
-  # workaround because the setuptools hook propagates its inputs resulting in conflicts
-  buildPythonPackage.catchConflicts = false;
-
   # This is not strictly required, but setting it will keep most dependencies
   #   locked, even when new dependencies are added via pyproject.toml
   pip.pypiSnapshotDate = "2023-09-12";

--- a/examples/packages/languages/python-packaging-apache-airflow/default.nix
+++ b/examples/packages/languages/python-packaging-apache-airflow/default.nix
@@ -43,9 +43,6 @@ in {
     ];
   };
 
-  # workaround because the setuptools hook propagates its inputs resulting in conflicts
-  buildPythonPackage.catchConflicts = false;
-
   pip = {
     pypiSnapshotDate = "2023-01-01";
     requirementsList = [
@@ -71,8 +68,6 @@ in {
         # transitive dependencies (i.e. typing-extensions) are
         # compatible with the rest of our lock file.
         mkDerivation.buildInputs = [config.pip.drvs.setuptools-scm.public];
-        # workaround because the setuptools hook propagates its inputs resulting in conflicts
-        buildPythonPackage.catchConflicts = false;
       };
     };
   };

--- a/overrides/python/pillow/default.nix
+++ b/overrides/python/pillow/default.nix
@@ -10,6 +10,4 @@ in {
   imports = [dream2nix.modules.dream2nix.nixpkgs-overrides];
   nixpkgs-overrides.enable = isSdist;
   nixpkgs-overrides.exclude = ["propagatedBuildInputs"];
-  # TODO: upstream: fix setuptools collision (build-hook propagates setuptools)
-  buildPythonPackage.catchConflicts = ! isSdist;
 }

--- a/overrides/python/psycopg2/default.nix
+++ b/overrides/python/psycopg2/default.nix
@@ -16,7 +16,4 @@ in {
 
   # add postgresql to nativeBuildInputs
   mkDerivation.nativeBuildInputs = lib.mkIf isSdist [config.deps.postgresql];
-
-  # TODO: upstream: fix setuptools collision (build-hook propagates setuptools)
-  buildPythonPackage.catchConflicts = ! isSdist;
 }


### PR DESCRIPTION
Those are not needed anymore since the hook has been improved in nixpkgs
