### PR TITLE
python/pdm: hide groups as implementation detail

### DIFF
--- a/modules/dream2nix/WIP-groups/groups-option.nix
+++ b/modules/dream2nix/WIP-groups/groups-option.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  specialArgs,
+  ...
+}: let
+  t = lib.types;
+  groupType = t.submoduleWith {
+    modules = [
+      (import ./group.nix {
+        inherit (config) overrideAll;
+        overrides = config.overrides;
+      })
+    ];
+    inherit specialArgs;
+  };
+in
+  lib.mkOption {
+    type = t.lazyAttrsOf groupType;
+    description = ''
+      Holds multiple package sets (eg. groups).
+      Holds shared config (overrideAll) and overrides on a global and on a per group basis.
+    '';
+  }

--- a/modules/dream2nix/WIP-groups/interface.nix
+++ b/modules/dream2nix/WIP-groups/interface.nix
@@ -1,28 +1,10 @@
 {
   config,
   lib,
-  dream2nix,
   specialArgs,
   ...
-}: let
-  t = lib.types;
-  groupType = t.submoduleWith {
-    modules = [
-      (import ./group.nix {
-        inherit (config) overrideAll;
-        overrides = config.overrides;
-      })
-    ];
-    inherit specialArgs;
-  };
-in {
-  options = {
-    groups = lib.mkOption {
-      type = t.lazyAttrsOf groupType;
-      description = ''
-        Holds multiple package sets (eg. groups).
-        Holds shared config (overrideAll) and overrides on a global and on a per group basis.
-      '';
-    };
+}: {
+  options.groups = import ./groups-option.nix {
+    inherit config lib specialArgs;
   };
 }

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -56,9 +56,9 @@
   };
 in {
   imports = [
-    dream2nix.modules.dream2nix.WIP-groups
     dream2nix.modules.dream2nix.buildPythonPackage
     ../core/deps
+    ../overrides
     ./interface.nix
     ./lock.nix
     commonModule
@@ -86,8 +86,10 @@ in {
       ;
     python = lib.mkDefault config.deps.python3;
   };
-  overrideAll = {
+  overrideType = {
     imports = [commonModule];
+  };
+  overrideAll = {
     deps = {nixpkgs, ...}: {
       python = lib.mkDefault config.deps.python;
     };

--- a/modules/dream2nix/WIP-python-pdm/interface.nix
+++ b/modules/dream2nix/WIP-python-pdm/interface.nix
@@ -1,7 +1,7 @@
 {
   config,
   lib,
-  dream2nix,
+  specialArgs,
   ...
 }: let
   l = lib // builtins;
@@ -17,4 +17,10 @@ in {
 
     sourceSelector = import ./sourceSelectorOption.nix {inherit lib;};
   };
+  options.groups =
+    (import ../WIP-groups/groups-option.nix {inherit config lib specialArgs;})
+    // {
+      internal = true;
+      visible = "shallow";
+    };
 }


### PR DESCRIPTION
The most important feature of the groups module was the overriding which is a separate module now. Therefore removing the fact that groups are used from the docs to decrease the API surface to maintain.

Instead render the override and overrideAll options in the manual of pdm correctly by setting `overrideType`.
