### PR TITLE
mkDerivation: stop depending on all core modules

### DIFF
--- a/modules/dream2nix/WIP-groups/group.nix
+++ b/modules/dream2nix/WIP-groups/group.nix
@@ -32,9 +32,12 @@ in {
       default = {};
     };
     overrides = lib.mkOption {
+      # TODO: This version of deferredModuleWith might lead to an infinite
+      #   recursion because it doesn't support specialArgs
+      #   (see custom deferredModuleWith in ../overrides/default.nix)
       type = t.lazyAttrsOf (t.deferredModuleWith {
         staticModules = [
-          {_module.args = specialArgs;}
+          {_module.args = specialArgs // {inherit specialArgs;};}
         ];
       });
       description = ''

--- a/modules/dream2nix/WIP-nodejs-builder-v3/default.nix
+++ b/modules/dream2nix/WIP-nodejs-builder-v3/default.nix
@@ -289,6 +289,7 @@ in {
 
   imports = [
     ./interface.nix
+    dream2nix.modules.dream2nix.core
     dream2nix.modules.dream2nix.mkDerivation
     dream2nix.modules.dream2nix.WIP-groups
   ];

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -47,7 +47,7 @@
       else config.deps.python.pkgs.setuptools;
   in {
     imports = [
-      dream2nix.modules.dream2nix.mkDerivation
+      dream2nix.modules.dream2nix.buildPythonPackage
     ];
     config.mkDerivation.buildInputs =
       lib.optionals
@@ -56,8 +56,6 @@
   };
 in {
   imports = [
-    dream2nix.modules.dream2nix.buildPythonPackage
-    ../core/deps
     ../overrides
     ./interface.nix
     ./lock.nix

--- a/modules/dream2nix/WIP-python-pdm/lock.nix
+++ b/modules/dream2nix/WIP-python-pdm/lock.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  dream2nix,
   ...
 }: let
   pdmConfig = config.deps.writeText "pdm-config.toml" ''
@@ -32,6 +33,9 @@
     popd
   '';
 in {
+  imports = [
+    dream2nix.modules.dream2nix.lock
+  ];
   lock.extraScripts = [script];
   deps = {nixpkgs, ...}:
     lib.mapAttrs (_: lib.mkDefault) {

--- a/modules/dream2nix/buildPythonPackage/default.nix
+++ b/modules/dream2nix/buildPythonPackage/default.nix
@@ -8,7 +8,8 @@
 in {
   imports = [
     ./interface.nix
-    ../mkDerivation
+    dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.deps
   ];
   config = {
     package-func.func = config.deps.python.pkgs.buildPythonPackage;

--- a/modules/dream2nix/buildRustPackage/default.nix
+++ b/modules/dream2nix/buildRustPackage/default.nix
@@ -146,6 +146,7 @@
 in {
   imports = [
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.core
     ./interface.nix
   ];
 

--- a/modules/dream2nix/mkDerivation/default.nix
+++ b/modules/dream2nix/mkDerivation/default.nix
@@ -1,10 +1,10 @@
 {
   config,
   lib,
+  dream2nix,
   ...
 }: let
   l = lib // builtins;
-  t = l.types;
 
   cfg = config.mkDerivation;
 
@@ -42,8 +42,10 @@
 in {
   imports = [
     ./interface.nix
-    ../core
     ../package-func
+    dream2nix.modules.dream2nix.deps
+    dream2nix.modules.dream2nix.env
+    dream2nix.modules.dream2nix.ui
   ];
 
   config.package-func.outputs = cfg.outputs;

--- a/modules/dream2nix/nodejs-granular-v3/default.nix
+++ b/modules/dream2nix/nodejs-granular-v3/default.nix
@@ -291,6 +291,7 @@ in {
   imports = [
     ./interface.nix
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.core
     (commonModule defaultPackageName defaultPackageVersion)
   ];
   deps = {nixpkgs, ...}:

--- a/modules/dream2nix/nodejs-granular-v3/interface.nix
+++ b/modules/dream2nix/nodejs-granular-v3/interface.nix
@@ -18,6 +18,7 @@ in {
     config.overrideType = {
       imports = [
         dream2nix.modules.dream2nix.mkDerivation
+        dream2nix.modules.dream2nix.core
       ];
     };
     options = l.mapAttrs (_: l.mkOption) {
@@ -49,10 +50,11 @@ in {
         internal = true;
         # hack because internal doesn't propagate to submodule options
         visible = "shallow";
-        type = t.attrsOf (t.attrsOf (t.submodule {
-          imports = [
+        type = t.attrsOf (t.attrsOf (t.submoduleWith {
+          modules = [
             cfg.overrideType
           ];
+          inherit specialArgs;
         }));
       };
     };

--- a/modules/dream2nix/nodejs-granular/default.nix
+++ b/modules/dream2nix/nodejs-granular/default.nix
@@ -281,6 +281,7 @@ in {
   imports = [
     ./interface.nix
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.core
     (commonModule defaultPackageName defaultPackageVersion)
   ];
   deps = {nixpkgs, ...}:

--- a/modules/dream2nix/nodejs-granular/interface.nix
+++ b/modules/dream2nix/nodejs-granular/interface.nix
@@ -2,7 +2,7 @@
   config,
   lib,
   dream2nix,
-  packageSets,
+  specialArgs,
   ...
 }: let
   l = lib // builtins;
@@ -34,12 +34,12 @@ in {
       '';
     };
     deps = {
-      type = t.lazyAttrsOf (t.lazyAttrsOf (t.submodule {
-        imports = [
+      type = t.lazyAttrsOf (t.lazyAttrsOf (t.submoduleWith {
+        modules = [
           dream2nix.modules.dream2nix.core
           dream2nix.modules.dream2nix.mkDerivation
         ];
-        _module.args = {inherit dream2nix packageSets;};
+        inherit specialArgs;
       }));
     };
   };

--- a/modules/dream2nix/nodejs-package-lock/default.nix
+++ b/modules/dream2nix/nodejs-package-lock/default.nix
@@ -30,6 +30,7 @@
 in {
   imports = [
     ./interface.nix
+    dream2nix.modules.dream2nix.core
     dream2nix.modules.dream2nix.mkDerivation
   ];
 

--- a/modules/dream2nix/php-composer-lock/default.nix
+++ b/modules/dream2nix/php-composer-lock/default.nix
@@ -30,6 +30,7 @@ in {
   imports = [
     ./interface.nix
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.core
   ];
 
   # declare external dependencies

--- a/modules/dream2nix/php-granular/default.nix
+++ b/modules/dream2nix/php-granular/default.nix
@@ -169,6 +169,7 @@
     {config, ...}: {
       imports = [
         dream2nix.modules.dream2nix.mkDerivation
+        dream2nix.modules.dream2nix.core
       ];
       deps = {nixpkgs, ...}:
         l.mapAttrs (_: l.mkDefault) {

--- a/modules/dream2nix/php-granular/interface.nix
+++ b/modules/dream2nix/php-granular/interface.nix
@@ -24,11 +24,12 @@ in {
       deps = {
         internal = true;
         visible = "shallow";
-        type = t.lazyAttrsOf (t.lazyAttrsOf (t.submodule {
-          imports = [
+        type = t.lazyAttrsOf (t.lazyAttrsOf (t.submoduleWith {
+          modules = [
             dream2nix.modules.dream2nix.core
             cfg.overrideType
           ];
+          inherit specialArgs;
         }));
       };
       composerInstallFlags = {

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -76,6 +76,7 @@
   commonModule = {config, ...}: {
     imports = [
       dream2nix.modules.dream2nix.mkDerivation
+      dream2nix.modules.dream2nix.core
       ../buildPythonPackage
     ];
     config = {

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -139,8 +139,8 @@ in {
         # hack because internal=true doesn't propagate to the submodule options
         visible = "shallow";
         type = t.lazyAttrsOf (t.submoduleWith {
+          inherit specialArgs;
           modules = [dream2nix.modules.dream2nix.core];
-          specialArgs = {inherit packageSets dream2nix;};
         });
         description = "drv-parts modules that define python dependencies";
       };

--- a/modules/dream2nix/pip/tests/packages/python-nodejs/default.nix
+++ b/modules/dream2nix/pip/tests/packages/python-nodejs/default.nix
@@ -22,7 +22,6 @@ in {
   version = "0.13.0";
 
   deps = {nixpkgs, ...}: {
-    stdenv = lib.mkForce nixpkgs.stdenv;
     jq = lib.mkForce nixpkgs.jq;
     fetchFromGitHub = nixpkgs.fetchFromGitHub;
     python = nixpkgs.python310;

--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -185,6 +185,7 @@ in {
   imports = [
     ./interface.nix
     dream2nix.modules.dream2nix.mkDerivation
+    dream2nix.modules.dream2nix.core
   ];
 
   rust-crane.depsDrv = {

--- a/modules/flake-parts/website/render/default.nix
+++ b/modules/flake-parts/website/render/default.nix
@@ -83,7 +83,10 @@ in {
             #   version = "dummy-version";
             # }
           ];
-        specialArgs.dream2nix = self;
+        specialArgs.dream2nix =
+          # trace website modules
+          # lib.trace modules
+          self;
         specialArgs.packageSets.nixpkgs = pkgs;
       };
     # inputs.flake-parts.lib.evalFlakeModule


### PR DESCRIPTION
mkDerivation should be minimal, but currently it always pulls in modules like `lock` and `paths` etc. despite those not being needed for many instances, like when mkDerivation is imported by a dependency.

Modules like pip which do need some of these core modules, now need to directly depend on them.

This will remove a bunch of unneeded options which currently pollute the manual.

The remaining core dependencies of mkDerivation are now: deps, env, ui
