### PR TITLE
mkDerivation: fix typo in checkFlags

### DIFF
--- a/modules/dream2nix/mkDerivation/interface.nix
+++ b/modules/dream2nix/mkDerivation/interface.nix
@@ -171,7 +171,7 @@
 
     # check phase
     checkTarget = optNullOrStr;
-    checkFLags = optList;
+    checkFlags = optList;
 
     # install phase
     installTargets = optNullOrStr;


### PR DESCRIPTION
:wave: 

This fixes a typo I've encountered through https://github.com/yusdacra/nix-cargo-integration, which uses dream2nix.