### PR TITLE
WIP-haskell-cabal: fetch correct cabal revisions

### DIFF
--- a/modules/dream2nix/WIP-haskell-cabal/lock.py
+++ b/modules/dream2nix/WIP-haskell-cabal/lock.py
@@ -46,10 +46,10 @@ for i, pkg in enumerate(pkgs):
     id = pkg["id"]
     version = pkg["pkg-version"]
 
-    print(f"[{i+1}/{pkg_len}] Resolving revision for {name}")
+    print(f"[{i+1}/{pkg_len}] Resolving revision for {name}-{version}")
 
     revisions = requests.get(
-        f"https://hackage.haskell.org/package/{name}/revisions/",
+        f"https://hackage.haskell.org/package/{name}-{version}/revisions/",
         headers={"Accept": "application/json"},
     ).json()
 


### PR DESCRIPTION
Fetch cabal revisions from `https://hackage.haskell.org/package/{name}-{version}/revisions/`, rather than `https://hackage.haskell.org/package/{name}/revisions/`, which fetches revisions for the latest package version, not the version pinned in `./dist-newstyle/cache/plan.json`.

Before

```bash
$ nix run github:lbodor/gamgee?ref=dream2nix#gamgee.lock
Downloading the latest package list from hackage.haskell.org
Package list of hackage.haskell.org is up to date.
The index-state is set to 2024-03-27T00:32:46Z.
Resolving dependencies...
Wrote freeze file: /tmp/tmp.7Waiw8oj27/cabal.project.freeze
[1/48] Resolving revision for Hclip
[2/48] Resolving revision for OneTuple
[3/48] Resolving revision for QuickCheck
[4/48] Resolving revision for aeson
Could not find revision for aeson-1.5.6.0
...
```

After

```bash
$ nix run github:lbodor/gamgee?ref=dream2nix#gamgee.lock --override-input dream2nix github:lbodor/dream2nix?ref=fetch-correct-cabal-revisions
Downloading the latest package list from hackage.haskell.org
Package list of hackage.haskell.org is up to date.
The index-state is set to 2024-03-27T00:32:46Z.
Resolving dependencies...
Wrote freeze file: /tmp/tmp.bJf1wGVwJ2/cabal.project.freeze
[1/48] Resolving revision for Hclip-3.0.0.4
[2/48] Resolving revision for OneTuple-0.4.1.1
[3/48] Resolving revision for QuickCheck-2.14.3
[4/48] Resolving revision for aeson-1.5.6.0
[5/48] Resolving revision for ansi-terminal-1.0.2
...
```