### PR TITLE
overrides/python: Adds qt support for opencv

### DIFF
--- a/overrides/python/opencv-python/default.nix
+++ b/overrides/python/opencv-python/default.nix
@@ -5,16 +5,23 @@
 }: {
   # TODO: supply more of the dependencies instead of ignoring them
   env.autoPatchelfIgnoreMissingDeps = true;
-  mkDerivation.buildInputs = [
-    config.deps.libglvnd
-    config.deps.glib
-  ];
+  mkDerivation = {
+    buildInputs = [
+      config.deps.libglvnd
+      config.deps.glib
+      config.deps.qt6Packages.qtbase
+    ];
+    nativeBuildInputs = [
+      config.deps.qt6Packages.wrapQtAppsHook
+    ];
+  };
   deps = {nixpkgs, ...}:
     lib.mapAttrs (_: lib.mkDefault) {
       inherit
         (nixpkgs)
         libglvnd
         glib
+        qt6Packages
         ;
     };
 }


### PR DESCRIPTION
Adds qt support for opencv-python
(Currently fails with the classic QPA Plugin Error).