### PR TITLE
`WIP-python-pdm`: add `public.pyEnv`; reuse `public.pyEnv` in `public.devShell`

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -104,18 +104,23 @@ in {
       # all packages attrs prefixed with version
       (lib.attrValues config.groups.default.packages);
   };
-  public.devShell = let
-    interpreter = config.deps.python.withPackages (
-      ps:
-        config.mkDerivation.propagatedBuildInputs
-    );
+
+  public.pyEnv = let
+    pyEnv' = config.deps.python.withPackages (ps: config.mkDerivation.propagatedBuildInputs);
   in
-    config.deps.mkShell {
-      packages = [
-        interpreter
-        config.deps.pdm
-      ];
-    };
+    pyEnv'.override (old: {
+      # namespaced packages are triggering a collision error, but this can be
+      # safely ignored. They are still set up correctly and can be imported.
+      ignoreCollisions = true;
+    });
+
+  public.devShell = config.deps.mkShell {
+    packages = [
+      config.public.pyEnv
+      config.deps.pdm
+    ];
+  };
+
   groups = let
     groupNames = lib.attrNames groups_with_deps;
     populateGroup = groupname: let


### PR DESCRIPTION
`public.pyEnv` can be used as `runtimeInputs` in other applications. You can find one such example [here](https://github.com/shivaraj-bh/ollama-flake/blob/7b6375cc4849c6b3a91be5543043d3c820d312f6/nix/ollama.nix#L52).
