### PR TITLE
feat(pip): allow direct reuse of upstream derivations

### DIFF
--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -134,6 +134,18 @@ in {
         '';
       };
 
+      preferredDrvs = l.mkOption {
+        type = t.lazyAttrsOf t.package;
+        default = {};
+        description = ''
+          disable dream2nix machinery and use the specified drv directly if
+          it can be found in this attribute set
+        '';
+        example = lib.literalExpression ''
+          config.deps.python.pkgs
+        '';
+      };
+
       drvs = l.mkOption {
         internal = true;
         # hack because internal=true doesn't propagate to the submodule options


### PR DESCRIPTION
Sometimes I'm just interested in the `targets` part of pip locking system. However, if a derivation can be found directly in nixpkgs, I prefer to use that one instead of building it downstream with dream2nix.

This is because I can then benefit from upstream maintenance, patching and caching done by nixpkgs directly.

Thus, I'm here adding a `preferredDrvs` option to pip module. You can add the derivations that you want to search by name. If found and requested by the resulting python closure, the derivation will be used directly instead of being auto-generated.

Usually you can just pass `config.deps.python.pkgs` here and avoid rebuilding a lot of stuff automatically. It should help on avoiding duplicate dependencies too.

I have not added any tests because I'd like to get some feedback over this prototype before testing.

@moduon MT-1075