### PR TITLE
build(direnv): explicitly allow IFD for devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake ./dev-flake
+use flake ./dev-flake --allow-import-from-derivation


### PR DESCRIPTION
Otherwise, if your Nix is configured to block IFDs, direnv will fail always.