### PR TITLE
python/pdm: Changes deps.python3 refs to deps.python

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/lock.nix
+++ b/modules/dream2nix/WIP-python-pdm/lock.nix
@@ -27,7 +27,7 @@
 
     pushd "$(${config.paths.findRoot})/${config.paths.package}"
 
-    echo ${config.deps.python3}/bin/python3 > .pdm-python
+    echo ${config.deps.python}/bin/python > .pdm-python
     pdm -c ${pdmConfig} lock
 
     popd


### PR DESCRIPTION
Changes config.deps.python3 reference in lock.nix to config.deps.python. 
Fixes https://github.com/nix-community/dream2nix/issues/885 and https://github.com/nix-community/dream2nix/issues/911
