### PR TITLE
Python DevShells (for pip)

### DIFF
--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -42,7 +42,7 @@ in {
     # to .dream2nix/editables to make them writeable.
     # Alternatively you can point it to an existing checkout via an absolute path, i.e.:
     #   editables.charset-normalizer = "/home/my-user/src/charset-normalizer";
-    editables.charset-normalizer = true;
+    editables.charset-normalizer = ".editables/charset_normalizer";
 
     requirementsList =
       pyproject.build-system.requires

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -43,7 +43,6 @@ in {
     # Alternatively you can point it to an existing checkout via an absolute path, i.e.:
     #   editables.charset-normalizer = "/home/my-user/src/charset-normalizer";
     editables.charset-normalizer = true;
-    editables.my-tool = true;
 
     requirementsList =
       pyproject.build-system.requires

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -12,7 +12,7 @@ in {
   ];
 
   deps = {nixpkgs, ...}: {
-    python = nixpkgs.python310;
+    python = nixpkgs.python3;
   };
 
   inherit (pyproject.project) name version;
@@ -29,11 +29,12 @@ in {
   };
 
   pip = {
-    pypiSnapshotDate = "2023-08-27";
     requirementsList =
       pyproject.build-system.requires
       or []
       ++ pyproject.project.dependencies;
     flattenDependencies = true;
+
+    overrides.click.mkDerivation.nativeBuildInputs = [config.deps.python.pkgs.flit-core];
   };
 }

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -18,7 +18,15 @@ in {
   inherit (pyproject.project) name version;
 
   mkDerivation = {
-    src = ./.;
+    src = lib.cleanSourceWith {
+      src = lib.cleanSource ./.;
+      filter = name: type:
+        !(builtins.any (x: x) [
+          (lib.hasSuffix ".nix" name)
+          (lib.hasPrefix "." (builtins.baseNameOf name))
+          (lib.hasSuffix "flake.lock" name)
+        ]);
+    };
   };
 
   buildPythonPackage = {

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -41,8 +41,9 @@ in {
     # for the root package (my-tool here), or otherwise copy the contents of mkDerivation.src
     # to .dream2nix/editables to make them writeable.
     # Alternatively you can point it to an existing checkout via an absolute path, i.e.:
-    editables.charset-normalizer = null; # "/home/my-user/src/charset-normalizer";
-    editables.my-tool = null;
+    #   editables.charset-normalizer = "/home/my-user/src/charset-normalizer";
+    editables.charset-normalizer = true;
+    editables.my-tool = true;
 
     requirementsList =
       pyproject.build-system.requires

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -29,6 +29,13 @@ in {
   };
 
   pip = {
+    # Setting editables.$pkg.null will link the current project root as an editable
+    # for the root package (my-tool here), or otherwise copy the contents of mkDerivation.src
+    # to .dream2nix/editables to make them writeable.
+    # Alternatively you can point it to an existing checkout via an absolute path, i.e.:
+    editables.charset-normalizer = null; # "/home/my-user/src/charset-normalizer";
+    editables.my-tool = null;
+
     requirementsList =
       pyproject.build-system.requires
       or []

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -26,10 +26,7 @@
           paths.package = ./.;
         }
         {
-          # TODO rewrite interface to name -> bool or path
-          pip.editables.my_tool = {
-            path = "/home/phaer/src/dream2nix/examples/packages/languages/python-local-development";
-          };
+          pip.editables.my_tool = "/home/phaer/src/dream2nix/examples/packages/languages/python-local-development";
         }
       ];
     };

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -13,11 +13,10 @@
     ...
   }: let
     system = "x86_64-linux";
+    pkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
     packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
+      packageSets.nixpkgs = pkgs;
       modules = [
         ./default.nix
         {
@@ -26,7 +25,18 @@
           paths.projectRootFile = "flake.nix";
           paths.package = ./.;
         }
+        {
+          # TODO rewrite interface to name -> bool or path
+          pip.editables.my_tool = {
+            path = "/home/phaer/src/dream2nix/examples/packages/languages/python-local-development";
+          };
+        }
       ];
+    };
+    devShells.${system}.default = pkgs.mkShell {
+      shellHook = ''
+        ${self.packages.${system}.default.config.pip.editablesShellHook}
+      '';
     };
   };
 }

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -27,10 +27,6 @@
         }
       ];
     };
-    devShells.${system}.default = pkgs.mkShell {
-      shellHook = ''
-        ${self.packages.${system}.default.config.pip.editablesShellHook}
-      '';
-    };
+    devShells.${system}.default = self.packages.${system}.default.devShell;
   };
 }

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -13,7 +13,7 @@
     ...
   }: let
     system = "x86_64-linux";
-    pkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
+    pkgs = nixpkgs.legacyPackages.${system};
   in {
     packages.${system}.default = dream2nix.lib.evalModules {
       packageSets.nixpkgs = pkgs;
@@ -27,6 +27,13 @@
         }
       ];
     };
-    devShells.${system}.default = self.packages.${system}.default.devShell;
+    devShells.${system}.default = pkgs.mkShell {
+      # inherit from the dream2nix generated dev shell
+      inputsFrom = [self.packages.${system}.default.devShell];
+      # add extra packages
+      packages = [
+        pkgs.hello
+      ];
+    };
   };
 }

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -25,9 +25,6 @@
           paths.projectRootFile = "flake.nix";
           paths.package = ./.;
         }
-        {
-          pip.editables.my_tool = "/home/phaer/src/dream2nix/examples/packages/languages/python-local-development";
-        }
       ];
     };
     devShells.${system}.default = pkgs.mkShell {

--- a/examples/packages/languages/python-local-development/lock.json
+++ b/examples/packages/languages/python-local-development/lock.json
@@ -2,46 +2,61 @@
   "fetchPipMetadata": {
     "sources": {
       "certifi": {
-        "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
+        "is_direct": false,
+        "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
-        "version": "2023.7.22"
+        "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
+        "version": "2024.2.2"
       },
       "charset-normalizer": {
-        "sha256": "193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad",
+        "is_direct": false,
+        "sha256": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/a4/65/057bf29660aae6ade0816457f8db4e749e5c0bfa2366eb5f67db9912fa4c/charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-        "version": "3.2.0"
+        "url": "https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "version": "3.3.2"
+      },
+      "click": {
+        "is_direct": true,
+        "rev": "f8857cb03268b5b952b88b2acb3e11d9f0f7b6e4",
+        "sha256": "0pcapxavyn8fqxjkwdidl7cdy24cvysyqi9rbhfsfxivp9715bvf",
+        "type": "git",
+        "url": "https://github.com/pallets/click.git",
+        "version": "8.2.0.dev0"
       },
       "idna": {
-        "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        "is_direct": false,
+        "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
-        "version": "3.4"
+        "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
+        "version": "3.7"
       },
       "requests": {
+        "is_direct": false,
         "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
         "type": "url",
         "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
         "version": "2.31.0"
       },
       "setuptools": {
-        "sha256": "3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b",
+        "is_direct": false,
+        "sha256": "c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/4f/ab/0bcfebdfc3bfa8554b2b2c97a555569c4c1ebc74ea288741ea8326c51906/setuptools-68.1.2-py3-none-any.whl",
-        "version": "68.1.2"
+        "url": "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl",
+        "version": "69.5.1"
       },
       "urllib3": {
-        "sha256": "de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4",
+        "is_direct": false,
+        "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/9b/81/62fd61001fa4b9d0df6e31d47ff49cfa9de4af03adecf339c7bc30656b37/urllib3-2.0.4-py3-none-any.whl",
-        "version": "2.0.4"
+        "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
+        "version": "2.2.1"
       }
     },
     "targets": {
       "default": {
         "certifi": [],
         "charset-normalizer": [],
+        "click": [],
         "idna": [],
         "requests": [
           "certifi",
@@ -54,5 +69,5 @@
       }
     }
   },
-  "invalidationHash": "9d63b829115c1d449d6830377e4a586d684393b9b63a76a1f89f7486b6d0ed33"
+  "invalidationHash": "0b9e5e3dccfe479110aacf335f3d8f939c6fd18f6fbc03b850e196178b6897c3"
 }

--- a/examples/packages/languages/python-local-development/my_tool/__init__.py
+++ b/examples/packages/languages/python-local-development/my_tool/__init__.py
@@ -1,4 +1,5 @@
 import requests
 
+
 def main():
     print("Hello World!")

--- a/examples/packages/languages/python-local-development/my_tool/__init__.py
+++ b/examples/packages/languages/python-local-development/my_tool/__init__.py
@@ -1,4 +1,4 @@
 import requests
 
-
-print("Hello World!")
+def main():
+    print("Hello World!")

--- a/examples/packages/languages/python-local-development/pyproject.toml
+++ b/examples/packages/languages/python-local-development/pyproject.toml
@@ -7,5 +7,6 @@ name = "my-tool"
 description = "my tool"
 version = "1.0.0"
 dependencies = [
-  "requests"
+  "requests",
+  "click @ git+https://github.com/pallets/click.git@main"
 ]

--- a/examples/packages/languages/python-local-development/pyproject.toml
+++ b/examples/packages/languages/python-local-development/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = [
   "requests",
   "click @ git+https://github.com/pallets/click.git@main"
 ]
+
+[project.scripts]
+my-tool = "my_tool:main"

--- a/modules/dream2nix/buildPythonPackage/interface.nix
+++ b/modules/dream2nix/buildPythonPackage/interface.nix
@@ -87,6 +87,14 @@ in {
         '';
       };
 
+    editable =
+      boolOpt
+      // {
+        description = ''
+          Whether this package should be installed as an "editable install".
+        '';
+      };
+
     format = l.mkOption {
       type = t.str;
       default = "setuptools";

--- a/modules/dream2nix/buildPythonPackage/interface.nix
+++ b/modules/dream2nix/buildPythonPackage/interface.nix
@@ -87,14 +87,6 @@ in {
         '';
       };
 
-    editable =
-      boolOpt
-      // {
-        description = ''
-          Whether this package should be installed as an "editable install".
-        '';
-      };
-
     format = l.mkOption {
       type = t.str;
       default = "setuptools";

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -181,7 +181,7 @@ in {
       # This affects requirements such as "click @ git+https://github.com/pallets/click.git@main"
       l.genAttrs
       (l.filter (name: config.lock.content.fetchPipMetadata.sources.${name}.is_direct) (l.attrNames cfg.drvs))
-      (n: lib.mkDefault null);
+      (n: lib.mkDefault true);
     editablesShellHook = import ./editable.nix {
       inherit lib;
       inherit (config.deps) unzip writeText;
@@ -220,7 +220,7 @@ in {
         old.postBuild
         or ""
         + ''
-          # Nixpkgs ships a sitecustomize.py with all of it's pyEnvs to add suport for NIX_PYTHONPATH.
+          # Nixpkgs ships a sitecustomize.py with all of it's pyEnvs to add support for NIX_PYTHONPATH.
           # This is unfortunate as sitecustomize is a regular module, so there can only be one.
           # So we move nixpkgs to _sitecustomize.py, effectively removing it but allowing users
           # to re-activate it by doing "import _sitecustomize".
@@ -230,5 +230,11 @@ in {
         '';
     });
 
-  public.devShell = config.public.pyEnv.env;
+  # a shell hook for composition purposes
+  public.shellHook = config.pip.editablesShellHook;
+  # a dev shell for development
+  public.devShell = config.deps.mkShell {
+    packages = [config.public.pyEnv];
+    shellHook = config.public.shellHook;
+  };
 }

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -216,6 +216,18 @@ in {
     pyEnv' = config.deps.python.withPackages (ps: config.mkDerivation.propagatedBuildInputs);
   in
     pyEnv'.override (old: {
+      postBuild =
+        old.postBuild
+        or ""
+        + ''
+          # Nixpkgs ships a sitecustomize.py with all of it's pyEnvs to add suport for NIX_PYTHONPATH.
+          # This is unfortunate as sitecustomize is a regular module, so there can only be one.
+          # So we move nixpkgs to _sitecustomize.py, effectively removing it but allowing users
+          # to re-activate it by doing "import _sitecustomize".
+          # https://github.com/NixOS/nixpkgs/pull/297628 would fix this, but it was reverted for now in
+          # https://github.com/NixOS/nixpkgs/pull/302385
+          mv "$out/${pyEnv'.sitePackages}/sitecustomize.py" "$out/${pyEnv'.sitePackages}/_sitecustomize.py"
+        '';
     });
 
   public.devShell = config.public.pyEnv.env;

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -186,21 +186,10 @@ in {
       inherit lib;
       inherit (config.deps) unzip;
       inherit (config.paths) findRoot;
+      inherit (config.public) pyEnv;
       inherit (cfg) editables;
       # Add the top-level package to drvs here, so it can be editable as well.
       drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
-      # We add editables using a sitecustomize.py and site.addsitedir().
-      # The latter only supports appending to pythons path, not prepending.
-      # This means that the normal, non-editable instannce of a given package
-      # would end up in pythons bath *before* our editable, effectively overriding
-      # it. To avoid this, we build a python environment without those packages.
-      pyEnv = let
-        filterInputs = fn: drv:
-          lib.unique (lib.flatten ([drv] ++ (map (drv: filterInputs fn drv) (lib.filter fn drv.propagatedBuildInputs))));
-        depsWithoutEditables =
-          filterInputs (drv: !(lib.elem drv.pname (lib.attrNames cfg.editables)));
-      in
-        config.deps.python.withPackages (ps: depsWithoutEditables);
     };
   };
 

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -181,12 +181,7 @@ in {
       l.genAttrs (targets.default.${config.name} or []) (_: true);
     editables =
       # make root package always editable
-      {${config.name} = true;}
-      # Add all packages which have is_direct set to true in the lock files to editables.
-      # This affects requirements such as "click @ git+https://github.com/pallets/click.git@main"
-      // l.genAttrs
-      (l.filter (name: config.lock.content.fetchPipMetadata.sources.${name}.is_direct) (l.attrNames cfg.drvs))
-      (n: lib.mkDefault true);
+      {${config.name} = config.paths.package;};
     editablesShellHook = import ./editable.nix {
       inherit lib;
       inherit (config.deps) unzip writeText;
@@ -194,12 +189,6 @@ in {
       inherit (config.public) pyEnv;
       inherit (cfg) editables;
       rootName = config.name;
-      # Pass dependency sources to the editables hook.
-      # Whenever an editable is set to true instead of a path, the editable path
-      #   is created by copying its `mkDerivation.src` from the nix store.
-      sources =
-        lib.mapAttrs (_name: drv: drv.mkDerivation.src)
-        (lib.filterAttrs (name: _drv: config.pip.editables.${name} or null == true) config.pip.drvs);
     };
   };
 

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -182,15 +182,26 @@ in {
       l.genAttrs
       (l.filter (name: config.lock.content.fetchPipMetadata.sources.${name}.is_direct) (l.attrNames cfg.drvs))
       (n: lib.mkDefault null);
-    editablesShellHook =
-      (import ./editable.nix {
-        inherit lib;
-        inherit (config.deps) unzip;
-        inherit (config.paths) findRoot;
-        inherit (config.public) pyEnv;
-        inherit (config.pip) editables;
-        drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
-      });
+    editablesShellHook = import ./editable.nix {
+      inherit lib;
+      inherit (config.deps) unzip;
+      inherit (config.paths) findRoot;
+      inherit (cfg) editables;
+      # Add the top-level package to drvs here, so it can be editable as well.
+      drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
+      # We add editables using a sitecustomize.py and site.addsitedir().
+      # The latter only supports appending to pythons path, not prepending.
+      # This means that the normal, non-editable instannce of a given package
+      # would end up in pythons bath *before* our editable, effectively overriding
+      # it. To avoid this, we build a python environment without those packages.
+      pyEnv = let
+        filterInputs = fn: drv:
+          lib.unique (lib.flatten ([drv] ++ (map (drv: filterInputs fn drv) (lib.filter fn drv.propagatedBuildInputs))));
+        depsWithoutEditables =
+          filterInputs (drv: !(lib.elem drv.pname (lib.attrNames cfg.editables)));
+      in
+        config.deps.python.withPackages (ps: depsWithoutEditables);
+    };
   };
 
   mkDerivation = {

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -216,10 +216,6 @@ in {
     pyEnv' = config.deps.python.withPackages (ps: config.mkDerivation.propagatedBuildInputs);
   in
     pyEnv'.override (old: {
-      # TODO do we still need this with the new catchCollisonsHook?
-      # namespaced packages are triggering a collision error, but this can be
-      # safely ignored. They are still set up correctly and can be imported.
-      ignoreCollisions = true;
     });
 
   public.devShell = config.public.pyEnv.env;

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -190,8 +190,7 @@ in {
         inherit (config.public) pyEnv;
         inherit (config.pip) editables;
         drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
-      })
-      .shellHook;
+      });
   };
 
   mkDerivation = {

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -185,6 +185,7 @@ in {
     editablesShellHook =
       (import ./editable.nix {
         inherit lib;
+        inherit (config.deps) unzip;
         inherit (config.paths) findRoot;
         inherit (config.public) pyEnv;
         inherit (config.pip) editables;

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -179,7 +179,7 @@ in {
       l.genAttrs (targets.default.${config.name} or []) (_: true);
     editables =
       lib.mapAttrs
-      (name: value: {drv = value;})
+      (name: value: lib.mkDefault null)
       (lib.filterAttrs
         (name: value: value.buildPythonPackage.editable or false)
         cfg.drvs);
@@ -188,6 +188,7 @@ in {
         inherit lib;
         inherit (config.public) pyEnv;
         inherit (config.pip) editables;
+        drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
       })
       .shellHook;
   };

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -185,6 +185,7 @@ in {
     editablesShellHook =
       (import ./editable.nix {
         inherit lib;
+        inherit (config.paths) findRoot;
         inherit (config.public) pyEnv;
         inherit (config.pip) editables;
         drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -188,8 +188,9 @@ in {
       inherit (config.paths) findRoot;
       inherit (config.public) pyEnv;
       inherit (cfg) editables;
+      rootName = config.name;
       # Add the top-level package to drvs here, so it can be editable as well.
-      drvs = config.pip.drvs // {${l.replaceStrings ["-"] ["_"] config.name} = config;};
+      drvs = config.pip.drvs // {${config.name} = config;};
     };
   };
 

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -142,7 +142,7 @@ in {
         pythonInterpreter = "${python}/bin/python";
       };
       setuptools = config.deps.python.pkgs.setuptools;
-      inherit (nixpkgs) nix fetchgit;
+      inherit (nixpkgs) nix fetchgit writeText;
       inherit (writers) writePureShellScript;
     };
 
@@ -184,7 +184,7 @@ in {
       (n: lib.mkDefault null);
     editablesShellHook = import ./editable.nix {
       inherit lib;
-      inherit (config.deps) unzip;
+      inherit (config.deps) unzip writeText;
       inherit (config.paths) findRoot;
       inherit (config.public) pyEnv;
       inherit (cfg) editables;

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -6,17 +6,11 @@
   pyEnv,
   editables,
   rootName,
-  drvs,
+  sources,
 }: let
   args = writeText "args" (builtins.toJSON {
-    inherit findRoot unzip rootName pyEnv editables;
+    inherit findRoot unzip rootName pyEnv editables sources;
     inherit (pyEnv) sitePackages;
-    drvs =
-      lib.mapAttrs (n: v: {
-        inherit (v.public) out;
-        inherit (v.mkDerivation) src;
-      })
-      drvs;
   });
 in ''
   source <(${pyEnv}/bin/python ${./editable.py} ${args})

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -11,6 +11,12 @@
     local source="$2"
     local dist_info_installed="$3"
     local editable_dir="$editables_dir/$name"
+    if [ -e "$editable_dir" ]
+    then
+      echo "Skipping existing editable source in $editable_dir" >/dev/stderr
+      return
+    fi
+
     if [[ "$source" == /nix/store/*.whl ]]
     then
       echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
@@ -21,7 +27,7 @@
       cp --recursive --remove-destination "$source/." "$editable_dir/"
       chmod -R u+w "$editable_dir"
     else
-      echo "Linking editable source from $source to $editable_dir"
+      echo "Linking editable source from $source to $editable_dir" >/dev/stderr
       ln -sf "$source" "$editable_dir"
     fi
 

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -6,11 +6,11 @@
   pyEnv,
   editables,
   rootName,
-  sources,
 }: let
   args = writeText "args" (builtins.toJSON {
-    inherit findRoot unzip rootName pyEnv editables sources;
+    inherit findRoot unzip rootName pyEnv editables;
     inherit (pyEnv) sitePackages;
+    inherit (builtins) storeDir;
   });
 in ''
   source <(${pyEnv}/bin/python ${./editable.py} ${args})

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -5,100 +5,89 @@
   pyEnv,
   editables,
   drvs,
-}: let
-  # We add editables using a sitecustomize.py and site.addsitedir().
-  # The latter only supports appending to pythons path, not prepending.
-  # This means that the normal, non-editable instannce of a given package
-  # would end up in pythons bath *before* our editable, effectively overriding
-  # it. To avoid this, we build a python environment without those packages.
-  envWithoutEditables = pyEnv.override (old: {
-    extraLibs = builtins.filter (drv: !(lib.elem drv.pname (lib.attrNames editables))) old.extraLibs;
-  });
-in {
-  shellHook = ''
-    dream2nix-mkEditable() {
-      local name="$1"
-      local source="$2"
-      local dist_info_installed="$3"
-      local editable_dir="$editables_dir/$name"
-      if [[ "$source" == /nix/store/*.whl ]]
+}: ''
+  dream2nix-mkEditable() {
+    local name="$1"
+    local source="$2"
+    local dist_info_installed="$3"
+    local editable_dir="$editables_dir/$name"
+    if [[ "$source" == /nix/store/*.whl ]]
+    then
+      echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
+      unzip -q -d "$editable_dir" "$source" "$name/*"
+    elif [[ "$source" == /nix/store/* ]]
+    then
+      echo "Copying editable source from $source to $editable_dir" >/dev/stderr
+      cp --recursive --remove-destination "$source/." "$editable_dir/"
+      chmod -R u+w "$editable_dir"
+    else
+      echo "Linking editable source from $source to $editable_dir"
+      ln -sf "$source" "$editable_dir"
+    fi
+
+    if [ -e "$editable_dir/src" ]
+    then
+      echo "$editable_dir/src" > "$site_dir/$name.pth"
+    else
+      # TODO this approach is risky as it puts everything inside
+      # upstreams repo on $PYTHONPATH. Maybe we should try to
+      # get packages from toplevel.txt first and if found,
+      # create a dir with only them linked?
+      echo "$editable_dir" > "$site_dir/$name.pth"
+    fi
+
+    # Create a .dist-info directory based on the non-editable install
+    local dist_info_name="$(basename "$dist_info_installed")"
+    local dist_info_editable="$site_dir/$dist_info_name"
+    cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
+    chmod -R u+w "$dist_info_editable"
+
+    # Required by PEP-660
+    rm -f "$dist_info_editable/RECORD"
+    cat > "$dist_info_editable/direct_url.json" <<EOF
+  {
+    "url": "file://$editable_dir",
+    "dir_info": { "editable": true }
+  }
+  EOF
+  }
+
+  dream2nix-editablesHook() {
+    # Ensure the python env is realized.
+    nix build "${pyEnv.drvPath}^out"
+
+    local dream2nix_dir="''$(${findRoot})/.dream2nix"
+    local editables_dir="$dream2nix_dir/editables"
+    local site_dir="$dream2nix_dir/site"
+    mkdir -p "$editables_dir" "$site_dir"
+
+    ${lib.concatStrings ((lib.flip lib.mapAttrsToList) editables (
+    name: path: ''
+      # if it's not in /nix/store already. We need its
+      # .dist-info directory and might need it's unpackaged
+      # source below.
+      if [ ! -e "${drvs.${name}.public.out}" ]
       then
-        echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
-        unzip -q -d "$editable_dir" "$source" "$name/*"
-      elif [[ "$source" == /nix/store/* ]]
-      then
-        echo "Copying editable source from $source to $editable_dir" >/dev/stderr
-        cp --recursive --remove-destination "$source/." "$editable_dir/"
-        chmod -R u+w "$editable_dir"
-      else
-        echo "Linking editable source from $source to $editable_dir"
-        ln -sf "$source" "$editable_dir"
+        nix build "${drvs.${name}.public.drvPath}^out"
       fi
+      # Build the editable
+      dream2nix-mkEditable \
+        "${lib.replaceStrings ["-"] ["_"] name}" \
+        "${
+        if path != null
+        then path
+        else drvs.${name}.mkDerivation.src
+      }" \
+        "$(find ${drvs.${name}.public.out}/${pyEnv.sitePackages} -name '*.dist-info' -print -quit)"
+    ''
+  ))}
 
-      if [ -e "$editable_dir/src" ]
-      then
-        echo "$editable_dir/src" > "$site_dir/$name.pth"
-      else
-        # TODO this approach is risky as it puts everything inside
-        # upstreams repo on $PYTHONPATH. Maybe we should try to
-        # get packages from toplevel.txt first and if found,
-        # create a dir with only them linked?
-        echo "$editable_dir" > "$site_dir/$name.pth"
-      fi
-
-      # Create a .dist-info directory based on the non-editable install
-      local dist_info_name="$(basename "$dist_info_installed")"
-      local dist_info_editable="$site_dir/$dist_info_name"
-      cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
-      chmod -R u+w "$dist_info_editable"
-
-      # Required by PEP-660
-      rm -f "$dist_info_editable/RECORD"
-      cat > "$dist_info_editable/direct_url.json" <<EOF
-    {
-      "url": "file://$editable_dir",
-      "dir_info": { "editable": true }
-    }
-    EOF
-    }
-
-    dream2nix-editablesHook() {
-      # Ensure the python env is realized.
-      nix build "${envWithoutEditables.drvPath}^out"
-
-      local dream2nix_dir="''$(${findRoot})/.dream2nix"
-      local editables_dir="$dream2nix_dir/editables"
-      local site_dir="$dream2nix_dir/site"
-      mkdir -p "$editables_dir" "$site_dir"
-
-      ${lib.concatStrings ((lib.flip lib.mapAttrsToList) editables (
-      name: path: ''
-        # if it's not in /nix/store already. We need its
-        # .dist-info directory and might need it's unpackaged
-        # source below.
-        if [ ! -e "${drvs.${name}.public.out}" ]
-        then
-          nix build "${drvs.${name}.public.drvPath}^out"
-        fi
-        # Build the editable
-        dream2nix-mkEditable \
-          "${lib.replaceStrings ["-"] ["_"] name}" \
-          "${
-          if path != null
-          then path
-          else drvs.${name}.mkDerivation.src
-        }" \
-          "$(find ${drvs.${name}.public.out}/${envWithoutEditables.sitePackages} -name '*.dist-info' -print -quit)"
-      ''
-    ))}
-
-      cat > "$site_dir/sitecustomize.py" <<EOF
-    import site
-    site.addsitedir("$site_dir")
-    EOF
-      export PYTHONPATH="$site_dir:${envWithoutEditables}/${envWithoutEditables.sitePackages}:$PYTHONPATH"
-      export PATH="${envWithoutEditables}/bin:$PATH"
-    }
-    dream2nix-editablesHook
-  '';
-}
+    cat > "$site_dir/sitecustomize.py" <<EOF
+  import site
+  site.addsitedir("$site_dir")
+  EOF
+    export PYTHONPATH="$site_dir:${pyEnv}/${pyEnv.sitePackages}:$PYTHONPATH"
+    export PATH="${pyEnv}/bin:$PATH"
+  }
+  dream2nix-editablesHook
+''

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -89,9 +89,19 @@
   ))}
 
     cat > "$site_dir/sitecustomize.py" <<EOF
+  import sys
   import site
   site.addsitedir("$site_dir")
+
+  # addsitedir only supports appending to the path, not prepending.
+  # As we already include a non-editable instance of each package
+  # in our pyEnv, those would shadow the editables. So we move
+  # the editables to the front of sys.path.
+  for index, path in enumerate(sys.path):
+    if path.startswith("$editables_dir"):
+      sys.path.insert(0, sys.path.pop(index))
   EOF
+
     export PYTHONPATH="$site_dir:${pyEnv}/${pyEnv.sitePackages}:$PYTHONPATH"
     export PATH="${pyEnv}/bin:$PATH"
   }

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -103,6 +103,12 @@
     cat > "$site_dir/sitecustomize.py" <<EOF
   import sys
   import site
+
+  try:
+    import _sitecustomize
+  except ImportError:
+    pass
+
   site.addsitedir("$site_dir")
 
   # addsitedir only supports appending to the path, not prepending.

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  pyEnv,
+  editables,
+}: let
+  # TODO refactor
+  envWithoutEditables = pyEnv.override (old: {
+    extraLibs = builtins.filter (drv: !(lib.elem drv.pname (lib.attrNames editables))) old.extraLibs;
+  });
+
+  mkEditable = name: {
+    path,
+    drv,
+  }: ''
+    source="${
+      if path != null
+      then path
+      else ""
+    }"
+    editable_dir="$editables_dir/${name}"
+    mkdir -p "$editable_dir"
+
+    # Realize the non-editable variant of this package,
+    # if it's not in /nix/store already. We need its
+    # .dist-info directory and might need it's unpackaged
+    # source below.
+    if [ ! -e "${drv.public.out}" ]
+    then
+      nix build "${drv.public.drvPath}^out"
+    fi
+
+    if [ -z "$source" ]
+    then
+      source="${drv.mkDerivation.src}"
+      echo "Copying editable source from $source to $editable_dir" >/dev/stderr
+      cp --recursive --remove-destination "$source/." "$editable_dir/"
+      chmod -R u+w "$editable_dir"
+    else
+      echo "Linking editable source from $source to $editable_dir"
+      ln -sf $source "$editable_dir"
+    fi
+
+    if [ -e "$editable_dir/src" ]
+    then
+         echo "$editable_dir/src" > "$site_dir/${name}.pth"
+    else
+         echo "$editable_dir" > "$site_dir/${name}.pth"
+    fi
+
+    # Create a .dist-info directory based on the non-editable install
+    dist_info_installed="$(find ${drv.public.out}/${envWithoutEditables.sitePackages} -name '*.dist-info' -print -quit)"
+    dist_info_name="$(basename "$dist_info_installed")"
+    dist_info_editable="$site_dir/$dist_info_name"
+    cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
+    chmod -R u+w "$dist_info_editable"
+
+    rm -f "$dist_info_editable/RECORD"
+    cat > "$dist_info_editable/direct_url.json" <<EOF
+    {
+      "url": "file://$editable_dir",
+      "dir_info": { "editable": true }
+    }
+    EOF
+  '';
+in {
+  shellHook = ''
+    # TODO pre-build envWithoutEditables
+    nix build "${envWithoutEditables.drvPath}^out"
+
+    # TODO PWD might not be ideal, but PRJ_ROOT or such can't be assumed
+    editables_dir="''${PWD}/.dream2nix/editables"
+    site_dir="''${PWD}/.dream2nix/site"
+    mkdir -p "$editables_dir" "$site_dir"
+
+    ${lib.concatStrings (lib.mapAttrsToList mkEditable editables)}
+    cat > "$site_dir/sitecustomize.py" <<EOF
+    import site
+    site.addsitedir("$site_dir")
+    EOF
+
+    export PYTHONPATH="$site_dir:${envWithoutEditables}/${envWithoutEditables.sitePackages}:$PYTHONPATH"
+    export PATH="${envWithoutEditables}/bin:$PATH"
+  '';
+}

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -66,6 +66,10 @@
     local dream2nix_dir="''$(${findRoot})/.dream2nix"
     local editables_dir="$dream2nix_dir/editables"
     local site_dir="$dream2nix_dir/site"
+    # Reset the site dir every time, so that editables which are
+    # removed are removed from the path. Don't remove $editables_dir,
+    # as that might contain uncommited changes.
+    rm -rf "$site_dir"
     mkdir -p "$editables_dir" "$site_dir"
 
     ${lib.concatStrings ((lib.flip lib.mapAttrsToList) editables (
@@ -79,6 +83,9 @@
       fi
 
       local source="${
+        # If an explicit path is set, use that one.
+        # If not, use the current project root for the root package,
+        # and copy mkDerivation.src for other packages.
         if path != null
         then path
         else if name == rootName

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -1,127 +1,23 @@
 {
   lib,
   findRoot,
+  writeText,
   unzip,
   pyEnv,
   editables,
   rootName,
   drvs,
-}: ''
-  dream2nix-mkEditable() {
-    local name="$1"
-    local source="$2"
-    local dist_info_installed="$3"
-    local editable_dir="$editables_dir/$name"
-    if [ -e "$editable_dir" ]
-    then
-      echo "Skipping existing editable source in $editable_dir" >/dev/stderr
-      return
-    fi
-
-    if [[ "$source" == /nix/store/*.whl ]]
-    then
-      echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
-      unzip -q -d "$editable_dir" "$source" "$name/*"
-    elif [[ "$source" == /nix/store/* ]]
-    then
-      echo "Copying editable source from $source to $editable_dir" >/dev/stderr
-      cp --recursive --remove-destination "$source/." "$editable_dir/"
-      chmod -R u+w "$editable_dir"
-    else
-      echo "Linking editable source from $source to $editable_dir" >/dev/stderr
-      ln -sf "$source" "$editable_dir"
-    fi
-
-    if [ -e "$editable_dir/src" ]
-    then
-      echo "$editable_dir/src" > "$site_dir/$name.pth"
-    else
-      # TODO this approach is risky as it puts everything inside
-      # upstreams repo on $PYTHONPATH. Maybe we should try to
-      # get packages from toplevel.txt first and if found,
-      # create a dir with only them linked?
-      echo "$editable_dir" > "$site_dir/$name.pth"
-    fi
-
-    # Create a .dist-info directory based on the non-editable install
-    local dist_info_name="$(basename "$dist_info_installed")"
-    local dist_info_editable="$site_dir/$dist_info_name"
-    cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
-    chmod -R u+w "$dist_info_editable"
-
-    # Required by PEP-660
-    rm -f "$dist_info_editable/RECORD"
-    cat > "$dist_info_editable/direct_url.json" <<EOF
-  {
-    "url": "file://$editable_dir",
-    "dir_info": { "editable": true }
-  }
-  EOF
-  }
-
-  dream2nix-editablesHook() {
-    # Ensure the python env is realized.
-    nix build --no-link "${pyEnv.drvPath}^out"
-
-    local dream2nix_dir="''$(${findRoot})/.dream2nix"
-    local editables_dir="$dream2nix_dir/editables"
-    local site_dir="$dream2nix_dir/site"
-    # Reset the site dir every time, so that editables which are
-    # removed are removed from the path. Don't remove $editables_dir,
-    # as that might contain uncommited changes.
-    rm -rf "$site_dir"
-    mkdir -p "$editables_dir" "$site_dir"
-
-    ${lib.concatStrings ((lib.flip lib.mapAttrsToList) editables (
-    name: path: ''
-      # Build the non-editable package if it's not in /nix/store already.
-      # We need its .dist-info directory and might need it's unpackaged
-      # source below.
-      if [ ! -e "${drvs.${name}.public.out}" ]
-      then
-        nix build --no-link "${drvs.${name}.public.drvPath}^out"
-      fi
-
-      local source="${
-        # If an explicit path is set, use that one.
-        # If not, use the current project root for the root package,
-        # and copy mkDerivation.src for other packages.
-        if path != null
-        then path
-        else if name == rootName
-        then "$(${findRoot})"
-        else drvs.${name}.mkDerivation.src
-      }"
-      # Build the editable
-      dream2nix-mkEditable \
-        "${lib.replaceStrings ["-"] ["_"] name}" \
-         "$source" \
-        "$(find ${drvs.${name}.public.out}/${pyEnv.sitePackages} -name '*.dist-info' -print -quit)"
-    ''
-  ))}
-
-    cat > "$site_dir/sitecustomize.py" <<EOF
-  import sys
-  import site
-
-  try:
-    import _sitecustomize
-  except ImportError:
-    pass
-
-  site.addsitedir("$site_dir")
-
-  # addsitedir only supports appending to the path, not prepending.
-  # As we already include a non-editable instance of each package
-  # in our pyEnv, those would shadow the editables. So we move
-  # the editables to the front of sys.path.
-  for index, path in enumerate(sys.path):
-    if path.startswith("$editables_dir"):
-      sys.path.insert(0, sys.path.pop(index))
-  EOF
-
-    export PYTHONPATH="$site_dir:${pyEnv}/${pyEnv.sitePackages}:$PYTHONPATH"
-    export PATH="${pyEnv}/bin:$PATH"
-  }
-  dream2nix-editablesHook
+}: let
+  args = writeText "args" (builtins.toJSON {
+    inherit findRoot unzip rootName pyEnv editables;
+    inherit (pyEnv) sitePackages;
+    drvs =
+      lib.mapAttrs (n: v: {
+        inherit (v.public) out;
+        inherit (v.mkDerivation) src;
+      })
+      drvs;
+  });
+in ''
+  source <(${pyEnv}/bin/python ${./editable.py} ${args})
 ''

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -14,86 +14,91 @@
   envWithoutEditables = pyEnv.override (old: {
     extraLibs = builtins.filter (drv: !(lib.elem drv.pname (lib.attrNames editables))) old.extraLibs;
   });
+in {
+  shellHook = ''
+    dream2nix-mkEditable() {
+      local name="$1"
+      local source="$2"
+      local dist_info_installed="$3"
+      local editable_dir="$editables_dir/$name"
+      if [[ "$source" == /nix/store/*.whl ]]
+      then
+        echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
+        unzip -q -d "$editable_dir" "$source" "$name/*"
+      elif [[ "$source" == /nix/store/* ]]
+      then
+        echo "Copying editable source from $source to $editable_dir" >/dev/stderr
+        cp --recursive --remove-destination "$source/." "$editable_dir/"
+        chmod -R u+w "$editable_dir"
+      else
+        echo "Linking editable source from $source to $editable_dir"
+        ln -sf "$source" "$editable_dir"
+      fi
 
-  mkEditable = name: path: let
-    drv = drvs.${name};
-  in ''
-    name="${lib.replaceStrings ["-"] ["_"] name}"
-    source="${
-      if path != null
-      then path
-      else drv.mkDerivation.src
-    }"
-    editable_dir="$editables_dir/$name"
-    # Realize the non-editable variant of this package,
-    # if it's not in /nix/store already. We need its
-    # .dist-info directory and might need it's unpackaged
-    # source below.
-    if [ ! -e "${drv.public.out}" ]
-    then
-      nix build "${drv.public.drvPath}^out"
-    fi
+      if [ -e "$editable_dir/src" ]
+      then
+        echo "$editable_dir/src" > "$site_dir/$name.pth"
+      else
+        # TODO this approach is risky as it puts everything inside
+        # upstreams repo on $PYTHONPATH. Maybe we should try to
+        # get packages from toplevel.txt first and if found,
+        # create a dir with only them linked?
+        echo "$editable_dir" > "$site_dir/$name.pth"
+      fi
 
-    if [[ "$source" == /nix/store/*.whl ]]
-    then
-      echo "Extracting editable source from $source to $editable_dir" >/dev/stderr
-      unzip -q -d "$editable_dir" "$source" "$name/*"
-    elif [[ "$source" == /nix/store/* ]]
-    then
-      echo "Copying editable source from $source to $editable_dir" >/dev/stderr
-      cp --recursive --remove-destination "$source/." "$editable_dir/"
-      chmod -R u+w "$editable_dir"
-    else
-      echo "Linking editable source from $source to $editable_dir"
-      ln -sf "$source" "$editable_dir"
-    fi
+      # Create a .dist-info directory based on the non-editable install
+      local dist_info_name="$(basename "$dist_info_installed")"
+      local dist_info_editable="$site_dir/$dist_info_name"
+      cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
+      chmod -R u+w "$dist_info_editable"
 
-    if [ -e "$editable_dir/src" ]
-    then
-      echo "$editable_dir/src" > "$site_dir/$name.pth"
-    else
-      # TODO this approach is risky as it puts everything inside
-      # upstreams repo on $PYTHONPATH. Maybe we should try to
-      # get packages from toplevel.txt first and if found,
-      # create a dir with only them linked?
-      echo "$editable_dir" > "$site_dir/$name.pth"
-    fi
-
-    # Create a .dist-info directory based on the non-editable install
-    dist_info_installed="$(find ${drv.public.out}/${envWithoutEditables.sitePackages} -name '*.dist-info' -print -quit)"
-    dist_info_name="$(basename "$dist_info_installed")"
-    dist_info_editable="$site_dir/$dist_info_name"
-    cp --recursive --remove-destination "$dist_info_installed/." "$dist_info_editable/"
-    chmod -R u+w "$dist_info_editable"
-
-    # Required by PEP-660
-    rm -f "$dist_info_editable/RECORD"
-    cat > "$dist_info_editable/direct_url.json" <<EOF
+      # Required by PEP-660
+      rm -f "$dist_info_editable/RECORD"
+      cat > "$dist_info_editable/direct_url.json" <<EOF
     {
       "url": "file://$editable_dir",
       "dir_info": { "editable": true }
     }
     EOF
-  '';
-in {
-  shellHook = ''
-    # TODO wrap console_scripts.
+    }
 
-    # Ensure the python env is realized.
-    nix build "${envWithoutEditables.drvPath}^out"
+    dream2nix-editablesHook() {
+      # Ensure the python env is realized.
+      nix build "${envWithoutEditables.drvPath}^out"
 
-    dream2nix_dir="''$(${findRoot})/.dream2nix"
-    editables_dir="$dream2nix_dir/editables"
-    site_dir="$dream2nix_dir/site"
-    mkdir -p "$editables_dir" "$site_dir"
+      local dream2nix_dir="''$(${findRoot})/.dream2nix"
+      local editables_dir="$dream2nix_dir/editables"
+      local site_dir="$dream2nix_dir/site"
+      mkdir -p "$editables_dir" "$site_dir"
 
-    ${lib.concatStrings (lib.mapAttrsToList mkEditable editables)}
-    cat > "$site_dir/sitecustomize.py" <<EOF
+      ${lib.concatStrings ((lib.flip lib.mapAttrsToList) editables (
+      name: path: ''
+        # if it's not in /nix/store already. We need its
+        # .dist-info directory and might need it's unpackaged
+        # source below.
+        if [ ! -e "${drvs.${name}.public.out}" ]
+        then
+          nix build "${drvs.${name}.public.drvPath}^out"
+        fi
+        # Build the editable
+        dream2nix-mkEditable \
+          "${lib.replaceStrings ["-"] ["_"] name}" \
+          "${
+          if path != null
+          then path
+          else drvs.${name}.mkDerivation.src
+        }" \
+          "$(find ${drvs.${name}.public.out}/${envWithoutEditables.sitePackages} -name '*.dist-info' -print -quit)"
+      ''
+    ))}
+
+      cat > "$site_dir/sitecustomize.py" <<EOF
     import site
     site.addsitedir("$site_dir")
     EOF
-
-    export PYTHONPATH="$site_dir:${envWithoutEditables}/${envWithoutEditables.sitePackages}:$PYTHONPATH"
-    export PATH="${envWithoutEditables}/bin:$PATH"
+      export PYTHONPATH="$site_dir:${envWithoutEditables}/${envWithoutEditables.sitePackages}:$PYTHONPATH"
+      export PATH="${envWithoutEditables}/bin:$PATH"
+    }
+    dream2nix-editablesHook
   '';
 }

--- a/modules/dream2nix/pip/editable.nix
+++ b/modules/dream2nix/pip/editable.nix
@@ -42,9 +42,13 @@
 
     if [ -e "$editable_dir/src" ]
     then
-         echo "$editable_dir/src" > "$site_dir/${name}.pth"
+      echo "$editable_dir/src" > "$site_dir/${name}.pth"
     else
-         echo "$editable_dir" > "$site_dir/${name}.pth"
+      # TODO this approach is risky as it puts everything inside
+      # upstreams repo on $PYTHONPATH. Maybe we should try to
+      # get packages from toplevel.txt first and if found,
+      # create a dir with only them linked?
+      echo "$editable_dir" > "$site_dir/${name}.pth"
     fi
 
     # Create a .dist-info directory based on the non-editable install
@@ -64,6 +68,8 @@
   '';
 in {
   shellHook = ''
+    # TODO wrap console_scripts.
+
     # TODO pre-build envWithoutEditables
     nix build "${envWithoutEditables.drvPath}^out"
 

--- a/modules/dream2nix/pip/editable.py
+++ b/modules/dream2nix/pip/editable.py
@@ -1,0 +1,174 @@
+import sys
+import json
+import subprocess
+from pathlib import Path
+
+
+def run(args):
+    try:
+        proc = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            encoding="utf8",
+        )
+        return proc.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error while calling {' '.join(args)}", file=sys.stderr)
+        print(e.output, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    with open(sys.argv[1], "r") as f:
+        args = json.load(f)
+    # print(json.dumps(args, indent=2), file=sys.stderr)
+    unzip = args["unzip"]
+    find_root = args["findRoot"]
+    python_environment = Path(args["pyEnv"])
+    root_name = args["rootName"]
+    site_packages = args["sitePackages"]
+    drvs = args["drvs"]
+    editables = args["editables"]
+
+    # directories to use
+    root_dir = Path(run([find_root]))
+    dream2nix_dir = root_dir / ".dream2nix"
+    editables_dir = dream2nix_dir / "editables"
+    site_dir = dream2nix_dir / "site"
+
+    editables_dir.mkdir(parents=True, exist_ok=True)
+    site_dir.mkdir(parents=True, exist_ok=True)
+
+    # ensure the python env is realized
+    run(["nix", "build", "--no-link", python_environment])
+
+    for name, path in editables.items():
+        normalized_name = name.replace("-", "_")
+        editable_dir = editables_dir / name
+        drv_out = Path(drvs[name]["out"])
+        if editable_dir.exists():
+            print(
+                f"Skipping existing editable source in {editable_dir}", file=sys.stderr
+            )
+            continue
+
+        # Build the non-editable package if it's not in /nix/store already.
+        # We need its .dist-info directory and might need it's unpackaged
+        # source below.
+        if not drv_out.exists():
+            run(["nix", "build", "--no-link", drv_out])
+
+        if path != None:
+            source = path
+        elif name == root_name:
+            source = root_dir
+        else:
+            source = drvs[name]["src"]
+
+        # Create a copy of the source in editable_dir
+        if str(source).startswith("/nix/store") and str(source).endswith(".whl"):
+            print(
+                f"Extracting editable source from {source} to {editable_dir}",
+                file=sys.stderr,
+            )
+            run(
+                [
+                    f"{unzip}/bin/unzip",
+                    "-q",
+                    "-d",
+                    str(editable_dir),
+                    source,
+                    f"{normalized_name}/*",
+                ]
+            )
+        elif str(source).startswith("/nix/store"):
+            print(
+                f"Copying editable source from {source} to {editable_dir}",
+                file=sys.stderr,
+            )
+            run(
+                [
+                    "cp",
+                    "--recursive",
+                    "--remove-destination",
+                    f"{source}/.",
+                    f"{editable_dir}/",
+                ]
+            )
+            run(["chmod", "-R", "u+w", editable_dir])
+        else:
+            print(
+                f"Linking editable source from {source} to {editable_dir}",
+                file=sys.stderr,
+            )
+            run(["ln", "-sf", source, editable_dir])
+
+        # Check if source uses a "src"-layout or a flat-layout and
+        # write the .pth file
+        if (editable_dir / "src").exists():
+            pth = editable_dir / "src"
+        else:
+            # TODO this approach is risky as it puts everything inside
+            # upstreams repo on $PYTHONPATH. Maybe we should try to
+            # get packages from toplevel.txt first and if found,
+            # create a dir with only them linked?
+            pth = editable_dir
+        with open((site_dir / normalized_name).with_suffix(".pth"), "w") as f:
+            f.write(f"{pth}\n")
+
+        # Reuse dist_info from the non-editable derivation and make it editable
+        installed_dist_infos = list((drv_out / site_packages).glob("*.dist-info"))
+        assert len(installed_dist_infos) == 1
+        installed_dist_info = installed_dist_infos[0]
+        editable_dist_info = site_dir / installed_dist_info.name
+        run(
+            [
+                "cp",
+                "--recursive",
+                "--remove-destination",
+                f"{installed_dist_info}/.",
+                f"{editable_dist_info}/",
+            ]
+        )
+        run(["chmod", "-R", "u+w", editable_dist_info])
+
+        if (editable_dist_info / "RECORD").exists():
+            # PEP-660 says RECORD should not be included
+            (editable_dist_info / "RECORD").unlink()
+
+        with open(editable_dist_info / "direct_url.json", "w") as f:
+            json.dump(
+                {"url": f"file://{editable_dir}", "dir_info": {"editable": True}},
+                f,
+                indent=2,
+            )
+
+    with open(site_dir / "sitecustomize.py", "w") as f:
+        f.write(
+            f"""import sys
+import site
+
+try:
+  import _sitecustomize
+except ImportError:
+  pass
+
+site.addsitedir("{site_dir}")
+
+# addsitedir only supports appending to the path, not prepending.
+# As we already include a non-editable instance of each package
+# in our pyEnv, those would shadow the editables. So we move
+# the editables to the front of sys.path.
+for index, path in enumerate(sys.path):
+  if path.startswith("{editables_dir}"):
+    sys.path.insert(0, sys.path.pop(index))
+        """
+        )
+
+    print(
+        f"""
+export PYTHONPATH="{site_dir}:{python_environment / site_packages}:$PYTHONPATH"
+export PATH="${python_environment}/bin:$PATH"
+    """
+    )

--- a/modules/dream2nix/pip/editable.py
+++ b/modules/dream2nix/pip/editable.py
@@ -54,7 +54,7 @@ def make_editable(
 
 def make_editable_source(editable_dir, normalized_name, path):
     # If a(n absolute) path is found, we use that.
-    if path != None:
+    if path != True:
         source = path
     # For the root package, we default to as symlink to this projects root
     elif name == root_name:
@@ -193,16 +193,17 @@ if __name__ == "__main__":
     run(["nix", "build", "--no-link", python_environment])
 
     for name, path in editables.items():
-        make_editable(
-            python_environment,
-            bin_dir,
-            site_dir,
-            editables_dir,
-            site_packages,
-            drvs,
-            name,
-            path,
-        )
+        if path:
+            make_editable(
+                python_environment,
+                bin_dir,
+                site_dir,
+                editables_dir,
+                site_packages,
+                drvs,
+                name,
+                path,
+            )
 
     with open(site_dir / "sitecustomize.py", "w") as f:
         f.write(

--- a/modules/dream2nix/pip/editable.py
+++ b/modules/dream2nix/pip/editable.py
@@ -20,6 +20,100 @@ def run(args):
         sys.exit(1)
 
 
+def make_editable(site_dir, editables_dir, site_packages, drvs, name, path):
+    normalized_name = name.replace("-", "_")
+    editable_dir = editables_dir / name
+    drv_out = Path(drvs[name]["out"])
+    if editable_dir.exists():
+        print(f"Skipping existing editable source in {editable_dir}", file=sys.stderr)
+        return
+
+    # Build the non-editable package if it's not in /nix/store already.
+    # We need its .dist-info directory and might need it's unpackaged
+    # source below.
+    if not drv_out.exists():
+        run(["nix", "build", "--no-link", drv_out])
+
+    make_editable_source(editable_dir, normalized_name, path)
+    make_pth(site_dir, editable_dir, normalized_name)
+    make_dist_info(site_dir, editable_dir, site_packages, drv_out)
+
+
+def make_editable_source(editable_dir, normalized_name, path):
+    if path != None:
+        source = path
+    elif name == root_name:
+        source = root_dir
+    else:
+        source = drvs[name]["src"]
+
+    # Create a copy of the source in editable_dir
+    if str(source).startswith("/nix/store") and str(source).endswith(".whl"):
+        print(
+            f"Extracting editable source from {source} to {editable_dir}",
+            file=sys.stderr,
+        )
+        run(
+            [
+                f"{unzip}/bin/unzip",
+                "-q",
+                "-d",
+                str(editable_dir),
+                source,
+                f"{normalized_name}/*",
+            ]
+        )
+    elif str(source).startswith("/nix/store"):
+        print(
+            f"Copying editable source from {source} to {editable_dir}",
+            file=sys.stderr,
+        )
+        shutil.copytree(source, editable_dir, symlinks=True)
+        run(["chmod", "-R", "u+w", editable_dir])
+    else:
+        print(
+            f"Linking editable source from {source} to {editable_dir}",
+            file=sys.stderr,
+        )
+        run(["ln", "-sf", source, editable_dir])
+
+
+def make_pth(site_dir, editable_dir, normalized_name):
+    # Check if source uses a "src"-layout or a flat-layout and
+    # write the .pth file
+    if (editable_dir / "src").exists():
+        pth = editable_dir / "src"
+    else:
+        # TODO this approach is risky as it puts everything inside
+        # upstreams repo on $PYTHONPATH. Maybe we should try to
+        # get packages from toplevel.txt first and if found,
+        # create a dir with only them linked?
+        pth = editable_dir
+    with open((site_dir / normalized_name).with_suffix(".pth"), "w") as f:
+        f.write(f"{pth}\n")
+
+
+def make_dist_info(site_dir, editable_dir, site_packages, drv_out):
+    # Reuse dist_info from the non-editable derivation and make it editable
+    installed_dist_infos = list((drv_out / site_packages).glob("*.dist-info"))
+    assert len(installed_dist_infos) == 1
+    installed_dist_info = installed_dist_infos[0]
+    editable_dist_info = site_dir / installed_dist_info.name
+    shutil.copytree(installed_dist_info, editable_dist_info, symlinks=True)
+    run(["chmod", "-R", "u+w", editable_dist_info])
+
+    if (editable_dist_info / "RECORD").exists():
+        # PEP-660 says RECORD should not be included
+        (editable_dist_info / "RECORD").unlink()
+
+    with open(editable_dist_info / "direct_url.json", "w") as f:
+        json.dump(
+            {"url": f"file://{editable_dir}", "dir_info": {"editable": True}},
+            f,
+            indent=2,
+        )
+
+
 if __name__ == "__main__":
     with open(sys.argv[1], "r") as f:
         args = json.load(f)
@@ -45,89 +139,7 @@ if __name__ == "__main__":
     run(["nix", "build", "--no-link", python_environment])
 
     for name, path in editables.items():
-        normalized_name = name.replace("-", "_")
-        editable_dir = editables_dir / name
-        drv_out = Path(drvs[name]["out"])
-        if editable_dir.exists():
-            print(
-                f"Skipping existing editable source in {editable_dir}", file=sys.stderr
-            )
-            continue
-
-        # Build the non-editable package if it's not in /nix/store already.
-        # We need its .dist-info directory and might need it's unpackaged
-        # source below.
-        if not drv_out.exists():
-            run(["nix", "build", "--no-link", drv_out])
-
-        if path != None:
-            source = path
-        elif name == root_name:
-            source = root_dir
-        else:
-            source = drvs[name]["src"]
-
-        # Create a copy of the source in editable_dir
-        if str(source).startswith("/nix/store") and str(source).endswith(".whl"):
-            print(
-                f"Extracting editable source from {source} to {editable_dir}",
-                file=sys.stderr,
-            )
-            run(
-                [
-                    f"{unzip}/bin/unzip",
-                    "-q",
-                    "-d",
-                    str(editable_dir),
-                    source,
-                    f"{normalized_name}/*",
-                ]
-            )
-        elif str(source).startswith("/nix/store"):
-            print(
-                f"Copying editable source from {source} to {editable_dir}",
-                file=sys.stderr,
-            )
-            shutil.copytree(source, editable_dir, symlinks=True)
-            run(["chmod", "-R", "u+w", editable_dir])
-        else:
-            print(
-                f"Linking editable source from {source} to {editable_dir}",
-                file=sys.stderr,
-            )
-            run(["ln", "-sf", source, editable_dir])
-
-        # Check if source uses a "src"-layout or a flat-layout and
-        # write the .pth file
-        if (editable_dir / "src").exists():
-            pth = editable_dir / "src"
-        else:
-            # TODO this approach is risky as it puts everything inside
-            # upstreams repo on $PYTHONPATH. Maybe we should try to
-            # get packages from toplevel.txt first and if found,
-            # create a dir with only them linked?
-            pth = editable_dir
-        with open((site_dir / normalized_name).with_suffix(".pth"), "w") as f:
-            f.write(f"{pth}\n")
-
-        # Reuse dist_info from the non-editable derivation and make it editable
-        installed_dist_infos = list((drv_out / site_packages).glob("*.dist-info"))
-        assert len(installed_dist_infos) == 1
-        installed_dist_info = installed_dist_infos[0]
-        editable_dist_info = site_dir / installed_dist_info.name
-        shutil.copytree(installed_dist_info, editable_dist_info, symlinks=True)
-        run(["chmod", "-R", "u+w", editable_dist_info])
-
-        if (editable_dist_info / "RECORD").exists():
-            # PEP-660 says RECORD should not be included
-            (editable_dist_info / "RECORD").unlink()
-
-        with open(editable_dist_info / "direct_url.json", "w") as f:
-            json.dump(
-                {"url": f"file://{editable_dir}", "dir_info": {"editable": True}},
-                f,
-                indent=2,
-            )
+        make_editable(site_dir, editables_dir, site_packages, drvs, name, path)
 
     with open(site_dir / "sitecustomize.py", "w") as f:
         f.write(

--- a/modules/dream2nix/pip/editable.py
+++ b/modules/dream2nix/pip/editable.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -87,15 +88,7 @@ if __name__ == "__main__":
                 f"Copying editable source from {source} to {editable_dir}",
                 file=sys.stderr,
             )
-            run(
-                [
-                    "cp",
-                    "--recursive",
-                    "--remove-destination",
-                    f"{source}/.",
-                    f"{editable_dir}/",
-                ]
-            )
+            shutil.copytree(source, editable_dir, symlinks=True)
             run(["chmod", "-R", "u+w", editable_dir])
         else:
             print(
@@ -122,15 +115,7 @@ if __name__ == "__main__":
         assert len(installed_dist_infos) == 1
         installed_dist_info = installed_dist_infos[0]
         editable_dist_info = site_dir / installed_dist_info.name
-        run(
-            [
-                "cp",
-                "--recursive",
-                "--remove-destination",
-                f"{installed_dist_info}/.",
-                f"{editable_dist_info}/",
-            ]
-        )
+        shutil.copytree(installed_dist_info, editable_dist_info, symlinks=True)
         run(["chmod", "-R", "u+w", editable_dist_info])
 
         if (editable_dist_info / "RECORD").exists():

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -35,8 +35,7 @@ in {
       };
 
       editables = l.mkOption {
-        type = t.attrsOf (t.nullOr t.path);
-        internal = true;
+        type = t.attrsOf (t.either t.bool t.path);
       };
 
       editablesShellHook = l.mkOption {

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -35,29 +35,7 @@ in {
       };
 
       editables = l.mkOption {
-        type = t.attrsOf (t.submodule {
-          options = {
-            drv = l.mkOption {
-              type = t.nullOr t.package;
-              default = null;
-            };
-            path = l.mkOption {
-              default = null;
-              type = t.nullOr t.path;
-            };
-          };
-        });
-        # Automatically set drv for the top-level
-        # editable.
-        apply = l.mapAttrs (
-          name: args:
-            if args.drv == null
-            then
-              if name == (l.replaceStrings ["-"] ["_"] config.name)
-              then args // {drv = config;}
-              else throw "No drv set for editable ${name}"
-            else args
-        );
+        type = t.attrsOf (t.nullOr t.path);
         internal = true;
       };
 

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -34,6 +34,26 @@ in {
         description = "the names of the selected top-level dependencies";
       };
 
+      editables = l.mkOption {
+        type = t.attrsOf (t.submodule {
+          options = {
+            drv = l.mkOption {
+              type = t.package;
+            };
+            path = l.mkOption {
+              default = null;
+              type = t.nullOr t.path;
+            };
+          };
+        });
+        internal = true;
+      };
+
+      editablesShellHook = l.mkOption {
+        type = t.str;
+        readOnly = true;
+      };
+
       # user interface
       env = l.mkOption {
         type = t.attrsOf t.str;
@@ -47,6 +67,7 @@ in {
           }
         '';
       };
+
       pypiSnapshotDate = l.mkOption {
         type = t.nullOr t.str;
         description = ''

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -1,8 +1,6 @@
 {
-  config,
   lib,
   dream2nix,
-  packageSets,
   specialArgs,
   ...
 }: let
@@ -35,7 +33,7 @@ in {
       };
 
       editables = l.mkOption {
-        type = t.attrsOf (t.either t.bool t.path);
+        type = t.attrsOf t.str;
       };
 
       editablesShellHook = l.mkOption {

--- a/modules/dream2nix/pip/interface.nix
+++ b/modules/dream2nix/pip/interface.nix
@@ -38,7 +38,8 @@ in {
         type = t.attrsOf (t.submodule {
           options = {
             drv = l.mkOption {
-              type = t.package;
+              type = t.nullOr t.package;
+              default = null;
             };
             path = l.mkOption {
               default = null;
@@ -46,6 +47,17 @@ in {
             };
           };
         });
+        # Automatically set drv for the top-level
+        # editable.
+        apply = l.mapAttrs (
+          name: args:
+            if args.drv == null
+            then
+              if name == (l.replaceStrings ["-"] ["_"] config.name)
+              then args // {drv = config;}
+              else throw "No drv set for editable ${name}"
+            else args
+        );
         internal = true;
       };
 

--- a/pkgs/fetchPipMetadata/package.nix
+++ b/pkgs/fetchPipMetadata/package.nix
@@ -21,6 +21,8 @@
       python-dateutil
       pip
     ];
+
+    meta.mainProgram = "fetch_pip_metadata";
   };
 in
   package

--- a/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
+++ b/pkgs/fetchPipMetadata/src/fetch_pip_metadata/lock_file_from_report.py
@@ -157,6 +157,7 @@ def lock_entry_from_report_entry(install, project_root: Path):
         info = lock_info_fallback(download_info)
 
     return name, dict(
+        is_direct=install["is_direct"],
         version=install["metadata"]["version"],
         **info,
     )

--- a/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
+++ b/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
@@ -9,6 +9,7 @@ def metadata(**kwargs):
             name="test",
             version="0.0.0",
         ),
+        is_direct=False,
         **kwargs,
     )
 
@@ -19,6 +20,7 @@ def expect(install, sha256=None):
         url=install["download_info"]["url"],
         version=install["metadata"]["version"],
         sha256=sha256,
+        is_direct=install["is_direct"],
     )
 
 
@@ -90,6 +92,7 @@ def test_git(monkeypatch):
             "name": "mypy",
             "version": "1.7.0+dev.df4717ee2cbbeb9e47fbd0e60edcaa6f81bbd7bb",
         },
+        "is_direct": True,
     }
     expected = "mypy", {
         "rev": "df4717ee2cbbeb9e47fbd0e60edcaa6f81bbd7bb",
@@ -97,5 +100,6 @@ def test_git(monkeypatch):
         "type": "git",
         "url": "https://github.com/python/mypy",
         "version": "1.7.0+dev.df4717ee2cbbeb9e47fbd0e60edcaa6f81bbd7bb",
+        "is_direct": True,
     }
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected

--- a/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
+++ b/pkgs/fetchPipMetadata/src/tests/test_lock_entry_from_report_entry.py
@@ -1,100 +1,73 @@
 from pathlib import Path
 from packaging.requirements import Requirement
-
 import lock_file_from_report as l
 
 
-def test_url_no_hash():
-    install = dict(
+def metadata(**kwargs):
+    return dict(
         metadata=dict(
             name="test",
             version="0.0.0",
         ),
-        download_info=dict(url="https://example.com"),
+        **kwargs,
     )
-    expected = "test", dict(
+
+
+def expect(install, sha256=None):
+    return "test", dict(
         type="url",
         url=install["download_info"]["url"],
         version=install["metadata"]["version"],
-        sha256=None,
+        sha256=sha256,
     )
+
+
+def test_url_no_hash():
+    install = metadata(
+        download_info=dict(url="https://example.com"),
+    )
+    expected = expect(install)
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected
 
 
 def test_url_with_hash():
-    install = dict(
-        metadata=dict(
-            name="test",
-            version="0.0.0",
-        ),
+    install = metadata(
         download_info=dict(
             url="https://example.com",
             archive_info=dict(hash=f"sha256=example_hash"),
         ),
     )
-    expected = "test", dict(
-        type="url",
-        url=install["download_info"]["url"],
-        version=install["metadata"]["version"],
-        sha256="example_hash",
-    )
+    expected = expect(install, sha256="example_hash")
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected
 
 
 def test_path_external():
-    install = dict(
-        metadata=dict(
-            name="test",
-            version="0.0.0",
-        ),
+    install = metadata(
         download_info=dict(
             url="/foo/bar",
         ),
     )
-    expected = "test", dict(
-        type="url",
-        url=install["download_info"]["url"],
-        version=install["metadata"]["version"],
-        sha256=None,
-    )
+    expected = expect(install)
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected
 
 
 def test_path_in_repo(git_repo_path):
-    install = dict(
-        metadata=dict(
-            name="test",
-            version="0.0.0",
-        ),
+    install = metadata(
         download_info=dict(
             url=git_repo_path.name,
         ),
     )
-    expected = "test", dict(
-        type="url",
-        url=install["download_info"]["url"],
-        version=install["metadata"]["version"],
-        sha256=None,
-    )
+    expected = expect(install)
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected
 
 
 def test_path_in_nix_store():
-    install = dict(
-        metadata=dict(
-            name="test",
-            version="0.0.0",
-        ),
+    install = metadata(
         download_info=dict(
             url="/nix/store/test",
         ),
     )
-    expected = "test", dict(
-        type="url",
-        url=install["download_info"]["url"],
-        version=install["metadata"]["version"],
-        sha256=None,
-    )
+    expected = expect(install)
     assert l.lock_entry_from_report_entry(install, Path("foo")) == expected
 
 

--- a/pkgs/fetchPipMetadata/src/tests/test_lock_file_from_report.py
+++ b/pkgs/fetchPipMetadata/src/tests/test_lock_file_from_report.py
@@ -31,6 +31,7 @@ def test_simple():
                     name="test",
                     version="0.0.0",
                 ),
+                is_direct=False,
                 download_info=dict(url="https://example.com"),
             )
         ],
@@ -42,6 +43,7 @@ def test_simple():
                 sha256=None,
                 url="https://example.com",
                 version="0.0.0",
+                is_direct=False,
             )
         ),
         targets=dict(
@@ -64,6 +66,7 @@ def test_multiple_requested():
                     version="0.0.0",
                 ),
                 download_info=dict(url="https://example.com"),
+                is_direct=False,
             ),
             dict(
                 requested=True,
@@ -71,6 +74,7 @@ def test_multiple_requested():
                     name="bar",
                     version="0.0.0",
                 ),
+                is_direct=True,
                 download_info=dict(url="https://example.com"),
             ),
         ],
@@ -82,12 +86,14 @@ def test_multiple_requested():
                 sha256=None,
                 url="https://example.com",
                 version="0.0.0",
+                is_direct=False,
             ),
             bar=dict(
                 type="url",
                 sha256=None,
                 url="https://example.com",
                 version="0.0.0",
+                is_direct=True,
             ),
         ),
         targets=dict(


### PR DESCRIPTION
Hello,

This is a PR which implements devshells with support for console scripts and richer metadata then the approach in https://github.com/nix-community/dream2nix/pull/912. Its currently only implemented for the pip builder, but the idea should be portable to PDM as well. Planning to look into this soon.



*  users need to declare an the root package and/or dependencies of a given python project as editable. Consider a devshell for a package named `my-tool`:
```nix
{
  pip.editables.charset-normalizer = "/home/my-user/src/charset-normalizer";
  pip.editables.click = null;
  pip.editables.my-tool = null;
}
```
The first expression would link the editable `charset-normalizer` from the given absolute path, to `.dream2nix/editables/charset-normalizer` and install it.
The second line would default to copying `click` from the nix store to `.dream2nix/editables/click` and install it.
As the first one matches the root package, we would default to link our project root to `.dream2nix/editables/my-tool` and install it.

* We also implicitly adds dependencies which are "direct installs" in pips report to editables, e.g. "click @ git+https://github.com/pallets/click.git@main" for convenience.

* "Installing" here only affects the devshell, we don't touch the results of `nix build`, but instead run a python script (`editable.py`) in a shellHook to get the right PATH and PYTHONPATH for the shell setup and install wrapper scripts for console_scripts of our dependencies.

* We do change public.pyEnv by moving its upstream sitecustomize.py to _sitecustomize.py. It was recently re-introduced into nixpkgs as its removal caused a few pkgs to break, but it did work for the overwhelming majority without issues. Moving it, deactivates it by default but it can easily be re-included if needed. We do so in the devshell just in case in https://github.com/nix-community/dream2nix/compare/main...phaer:dream2nix:devshells?expand=1#diff-4f29741e77180e7c500ebe90ecaa8af18d8aede267e142bf2f83888073079c9eR213


* This PR includes commits from https://github.com/nix-community/dream2nix/pull/932. I can drop them if unwanted.
* The history includes my first attempt as a shell script. Should I squash this?

# Give it a try

Just add some `pip.editables` as above to your package and include 
`${your-pkg.config.pip.editablesShellHook} ` in your shellHook or see
[examples/packages/languages/python-local-development/default.nix](https://github.com/nix-community/dream2nix/compare/main...phaer:dream2nix:devshells?expand=1#diff-6f11abbf9307b968b92e57cb6cc4e6dbb316b730dc95440846a6e1ccc604bb5a) and the devShell there.

