### PR TITLE
filter-pypi-responses: stream package requests that hit the proxy

### DIFF
--- a/pkgs/fetchPipMetadata/filter-pypi-responses.py
+++ b/pkgs/fetchPipMetadata/filter-pypi-responses.py
@@ -85,6 +85,11 @@ Response format:
 """
 
 
+def responseheaders(flow: http.HTTPFlow) -> None:
+    if "/simple/" not in flow.request.url:
+        flow.response.stream = True
+
+
 def response(flow: http.HTTPFlow) -> None:
     if not "/simple/" in flow.request.url:
         return


### PR DESCRIPTION
mitmproxy was buffering all requests (except pythonhosted.*), causing pip to time out when getting big packages from custom URLs.

Setting flow.response.stream in the responseheaders hook fixes this.