### PR TITLE
pdm: support additional index/source URLs

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -192,12 +192,15 @@ in {
             else null
           );
           mkDerivation = {
-            # TODO: handle sources outside pypi.org
             src = lib.mkDefault (libpyproject-fetchers.fetchFromLegacy {
               pname = name;
               file = source.file;
               hash = source.hash;
-              url = "https://pypi.org/simple";
+              urls =
+                [
+                  "https://pypi.org/simple"
+                ]
+                ++ lib.optionals (lib.hasAttrByPath ["tool" "pdm" "source"] pyproject.pyproject) (builtins.map (source: source.url) pyproject.pyproject.tool.pdm.source);
             });
             propagatedBuildInputs =
               lib.mapAttrsToList


### PR DESCRIPTION
I doubt this is an ideal implementation, but I'm hoping that an imperfect incremental improvement to a WIP module is acceptable :) 

When I took a look at switching a project that uses a private package from the pip to WIP pdm module, I noticed that pdm did pick up the alternate index when I imported the requirements. They look something like:

```toml
[[tool.pdm.source]]
name = "some hash or random identifier pdm generated"
url = "https://some-other-index.example.com/"
verify_ssl = true
``` 

I looked into how to leverage it in dream2nix and saw at least two paths:
1. Let pdm deal with this at lock time by using the `static_urls` locking strategy so that it locks a full index-specific url for each ~file.
2. Since `fetchFromLegacy` already supports a single url or a list of urls, just aggregate extra sources and pass them to the fetcher.

The branch name here betrays that I started with the first approach, but I backed off of that for two reasons:
- I was already unsure whether locking the files down to a single index is broadly desirable for our use of pdm or if it will just end up trading one set of problems for another.
- I initially thought I might be able to just drop either the `file` or `url` arguments to `fetchFromLegacy` and pass the fully resolved `source.url` to the other argument, but that didn't work. Since the fetcher's in another repo, I was either going to need to go change it upstream first or introduce a variant there or figure out where to put a variant of it local to this repo. Working around it started to smell like a yak shave--especially since I'm not sure locking the files down to each index is even acceptable.

Falling back to the second approach was straightforward and I've confirmed it works for my fairly simple case--getting a package that is not on pypi.org from some other index--but I imagine there are more complex cases that will require refining this support. 

(But I'm not sure if that'll be by doing the second approach in a more rigorous way, or adopting the first approach?)