### PR TITLE
treewide: format = "pyproject" -> pyproject = true

### DIFF
--- a/examples/packages/languages/python-local-development-multiple-packages/default.nix
+++ b/examples/packages/languages/python-local-development-multiple-packages/default.nix
@@ -6,7 +6,7 @@
 }: let
   pyproject = lib.importTOML ./subpkg1/pyproject.toml;
   buildWithSetuptools = {
-    buildPythonPackage.format = "pyproject";
+    buildPythonPackage.pyproject = true;
     mkDerivation.buildInputs = [config.deps.python.pkgs.setuptools];
   };
 in {

--- a/examples/packages/languages/python-local-development-pdm/default.nix
+++ b/examples/packages/languages/python-local-development-pdm/default.nix
@@ -9,10 +9,6 @@
     dream2nix.modules.dream2nix.WIP-python-pdm
   ];
 
-  deps = {nixpkgs, ...}: {
-    python = nixpkgs.python3;
-  };
-
   mkDerivation = {
     src = lib.cleanSourceWith {
       src = lib.cleanSource ./.;
@@ -28,7 +24,6 @@
   pdm.pyproject = ./pyproject.toml;
 
   buildPythonPackage = {
-    format = lib.mkForce "pyproject";
     pythonImportsCheck = [
       "mytool"
     ];

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -50,6 +50,9 @@ in {
       ++ pyproject.project.dependencies;
     flattenDependencies = true;
 
-    overrides.click.mkDerivation.nativeBuildInputs = [config.deps.python.pkgs.flit-core];
+    overrides.click = {
+      buildPythonPackage.pyproject = true;
+      mkDerivation.nativeBuildInputs = [config.deps.python.pkgs.flit-core];
+    };
   };
 }

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -30,7 +30,7 @@ in {
   };
 
   buildPythonPackage = {
-    format = lib.mkForce "pyproject";
+    pyproject = true;
     pythonImportsCheck = [
       "mytool"
     ];

--- a/examples/packages/languages/python-packaging-apache-airflow/default.nix
+++ b/examples/packages/languages/python-packaging-apache-airflow/default.nix
@@ -54,7 +54,7 @@ in {
       # We include fixes from nixpkgs for pendulum, but keep
       # our dependencies to avoid version conflicts
       pendulum = {
-        env.pyproject = null;
+        buildPythonPackage.pyproject = true;
         mkDerivation.propagatedBuildInputs = [
           python.pkgs.poetry-core
         ];

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -105,7 +105,7 @@ in {
     };
   };
   buildPythonPackage = {
-    format = lib.mkDefault "pyproject";
+    pyproject = lib.mkDefault true;
   };
   mkDerivation = {
     buildInputs = map (name: config.deps.python.pkgs.${name}) buildSystemNames;
@@ -187,13 +187,14 @@ in {
           inherit name;
           version = lib.mkDefault pkg.version;
           sourceSelector = lib.mkOptionDefault config.pdm.sourceSelector;
-          buildPythonPackage = {
-            format = lib.mkDefault (
-              if lib.hasSuffix ".whl" source.file
-              then "wheel"
-              else "pyproject"
-            );
-          };
+          buildPythonPackage =
+            if lib.hasSuffix ".whl" source.file
+            then {
+              format = lib.mkDefault "wheel";
+            }
+            else {
+              pyproject = lib.mkDefault true;
+            };
           mkDerivation = {
             # TODO: handle sources outside pypi.org
             src = lib.mkDefault (libpyproject-fetchers.fetchFromLegacy {

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -84,7 +84,6 @@ in {
       writeText
       unzip
       ;
-    python = lib.mkDefault config.deps.python3;
   };
   overrideType = {
     imports = [commonModule];

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -186,14 +186,11 @@ in {
           inherit name;
           version = lib.mkDefault pkg.version;
           sourceSelector = lib.mkOptionDefault config.pdm.sourceSelector;
-          buildPythonPackage =
+          buildPythonPackage.format = lib.mkDefault (
             if lib.hasSuffix ".whl" source.file
-            then {
-              format = lib.mkDefault "wheel";
-            }
-            else {
-              pyproject = lib.mkDefault true;
-            };
+            then "wheel"
+            else null
+          );
           mkDerivation = {
             # TODO: handle sources outside pypi.org
             src = lib.mkDefault (libpyproject-fetchers.fetchFromLegacy {

--- a/modules/dream2nix/WIP-python-pyproject/default.nix
+++ b/modules/dream2nix/WIP-python-pyproject/default.nix
@@ -19,7 +19,7 @@ in {
   };
 
   buildPythonPackage = {
-    format = "pyproject";
+    pyproject = true;
   };
 
   name = pyproject.project.name;

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -56,11 +56,14 @@
     # deps.python cannot be defined in commonModule as this would trigger an
     #   infinite recursion.
     deps = {inherit python;};
-    buildPythonPackage.format = l.mkDefault (
-      if l.hasSuffix ".whl" cfg.mkDerivation.src
-      then "wheel"
-      else "pyproject"
-    );
+    buildPythonPackage =
+      if lib.hasSuffix ".whl" cfg.mkDerivation.src
+      then {
+        format = lib.mkDefault "wheel";
+      }
+      else {
+        pyproject = lib.mkDefault true;
+      };
     mkDerivation.buildInputs =
       lib.optionals
       (! lib.hasSuffix ".whl" cfg.mkDerivation.src)

--- a/modules/dream2nix/pip/default.nix
+++ b/modules/dream2nix/pip/default.nix
@@ -56,14 +56,12 @@
     # deps.python cannot be defined in commonModule as this would trigger an
     #   infinite recursion.
     deps = {inherit python;};
-    buildPythonPackage =
+    buildPythonPackage.format = lib.mkDefault (
       if lib.hasSuffix ".whl" cfg.mkDerivation.src
-      then {
-        format = lib.mkDefault "wheel";
-      }
-      else {
-        pyproject = lib.mkDefault true;
-      };
+      then "wheel"
+      else null
+    );
+
     mkDerivation.buildInputs =
       lib.optionals
       (! lib.hasSuffix ".whl" cfg.mkDerivation.src)

--- a/modules/dream2nix/pip/tests/packages/can-build-setuptools/default.nix
+++ b/modules/dream2nix/pip/tests/packages/can-build-setuptools/default.nix
@@ -25,7 +25,7 @@ in {
   };
 
   buildPythonPackage = {
-    format = lib.mkForce "pyproject";
+    pyproject = true;
     pythonImportsCheck = [
       "my_tool"
     ];

--- a/modules/dream2nix/pip/tests/packages/can-handle-setuptools-runtime-dep/default.nix
+++ b/modules/dream2nix/pip/tests/packages/can-handle-setuptools-runtime-dep/default.nix
@@ -25,7 +25,7 @@ in {
   };
 
   buildPythonPackage = {
-    format = lib.mkForce "pyproject";
+    pyproject = true;
     pythonImportsCheck = [
       "my_tool"
     ];

--- a/pkgs/fetchPipMetadata/package.nix
+++ b/pkgs/fetchPipMetadata/package.nix
@@ -7,7 +7,7 @@
 }: let
   package = python3.pkgs.buildPythonPackage {
     name = "fetch-pip-metadata";
-    format = "pyproject";
+    pyproject = true;
     src = ./src;
     nativeBuildInputs = [
       gitMinimal


### PR DESCRIPTION
It's important to get the default in our PDM module fixed, because upstream documentation recommends using pyproject = true; and ships an assertion assertion '((pyproject != null) -> (format == null))' that fails with the current default in pdm.