### PR TITLE
tree-wide: make examples eval on all platforms...

### DIFF
--- a/examples/packages/basics/derivation/default.nix
+++ b/examples/packages/basics/derivation/default.nix
@@ -15,6 +15,5 @@
   builtins-derivation = {
     builder = "/bin/sh";
     args = ["-c" "echo $name > $out"];
-    system = "x86_64-linux";
   };
 }

--- a/examples/packages/basics/derivation/flake.nix
+++ b/examples/packages/basics/derivation/flake.nix
@@ -1,32 +1,53 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            builtins-derivation = {inherit system;};
+          }
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/basics/htop-with-flags/flake.nix
+++ b/examples/packages/basics/htop-with-flags/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/basics/mkDerivation/flake.nix
+++ b/examples/packages/basics/mkDerivation/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/haskell-local-development-cabal/flake.nix
+++ b/examples/packages/languages/haskell-local-development-cabal/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/nodejs-local-development-nextjs/flake.nix
+++ b/examples/packages/languages/nodejs-local-development-nextjs/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/nodejs-local-development-no-lock-file/flake.nix
+++ b/examples/packages/languages/nodejs-local-development-no-lock-file/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/nodejs-packaging-devshell-only/flake.nix
+++ b/examples/packages/languages/nodejs-packaging-devshell-only/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/nodejs-packaging/flake.nix
+++ b/examples/packages/languages/nodejs-packaging/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/php-packaging/flake.nix
+++ b/examples/packages/languages/php-packaging/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-local-development-machine-learning/flake.nix
+++ b/examples/packages/languages/python-local-development-machine-learning/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-local-development-multiple-packages/flake.nix
+++ b/examples/packages/languages/python-local-development-multiple-packages/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-local-development-pdm/flake.nix
+++ b/examples/packages/languages/python-local-development-pdm/flake.nix
@@ -1,39 +1,60 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = pkgs;
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
-    devShells.${system}.default = pkgs.mkShell {
-      # inherit from the dream2nix generated dev shell
-      inputsFrom = [self.packages.${system}.default.devShell];
-      # add extra packages
-      packages = [
-        pkgs.hello
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
+    devShells = eachSystem (system: {
+      default = nixpkgs.legacyPackages.${system}.mkShell {
+        # inherit from the dream2nix generated dev shell
+        inputsFrom = [self.packages.${system}.default.devShell];
+        # add extra packages
+        packages = [
+          nixpkgs.legacyPackages.${system}.hello
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-local-development/flake.nix
+++ b/examples/packages/languages/python-local-development/flake.nix
@@ -1,39 +1,60 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = pkgs;
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
-    devShells.${system}.default = pkgs.mkShell {
-      # inherit from the dream2nix generated dev shell
-      inputsFrom = [self.packages.${system}.default.devShell];
-      # add extra packages
-      packages = [
-        pkgs.hello
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
+    devShells = eachSystem (system: {
+      default = nixpkgs.legacyPackages.${system}.mkShell {
+        # inherit from the dream2nix generated dev shell
+        inputsFrom = [self.packages.${system}.default.devShell];
+        # add extra packages
+        packages = [
+          nixpkgs.legacyPackages.${system}.hello
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-packaging-ansible/flake.nix
+++ b/examples/packages/languages/python-packaging-ansible/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-packaging-apache-airflow/flake.nix
+++ b/examples/packages/languages/python-packaging-apache-airflow/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-packaging-odoo/flake.nix
+++ b/examples/packages/languages/python-packaging-odoo/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/python-packaging-pillow/flake.nix
+++ b/examples/packages/languages/python-packaging-pillow/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/rust-local-development-workspace/flake.nix
+++ b/examples/packages/languages/rust-local-development-workspace/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/rust-packaging-buildRustPackage/flake.nix
+++ b/examples/packages/languages/rust-packaging-buildRustPackage/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/rust-packaging/default.nix
+++ b/examples/packages/languages/rust-packaging/default.nix
@@ -10,7 +10,7 @@
   ];
 
   deps = {nixpkgs, ...}: {
-    inherit (nixpkgs) fetchFromGitHub;
+    inherit (nixpkgs) fetchFromGitHub iconv;
   };
 
   name = lib.mkForce "ripgrep";
@@ -25,6 +25,7 @@
       rev = config.version;
       sha256 = "sha256-udEh+Re2PeO3DnX4fQThsaT1Y3MBHFfrX5Q5EN2XrF0=";
     };
+    buildInputs = lib.optionals config.deps.stdenv.isDarwin [config.deps.iconv];
   };
 
   rust-crane = {

--- a/examples/packages/languages/rust-packaging/flake.nix
+++ b/examples/packages/languages/rust-packaging/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/packages/languages/spago-local-development/flake.nix
+++ b/examples/packages/languages/spago-local-development/flake.nix
@@ -1,32 +1,50 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system}.default = dream2nix.lib.evalModules {
-      packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
-      modules = [
-        ./default.nix
-        {
-          paths.projectRoot = ./.;
-          # can be changed to ".git" or "flake.nix" to get rid of .project-root
-          paths.projectRootFile = "flake.nix";
-          paths.package = ./.;
-        }
-      ];
-    };
+    packages = eachSystem (system: {
+      # For each system, we define our default package
+      # by passing in our desired nixpkgs revision plus
+      # any dream2nix modules needed by it.
+      default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+        modules = [
+          # Import our actual package definiton as a dream2nix module from ./default.nix
+          ./default.nix
+          {
+            # Aid dream2nix to find the project root. This setup should also works for mono
+            # repos. If you only have a single project, the defaults should be good enough.
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+    });
   };
 }

--- a/examples/repo-with-packages-flake/flake.nix
+++ b/examples/repo-with-packages-flake/flake.nix
@@ -1,27 +1,40 @@
 {
-  description = "My flake with dream2nix packages";
+  # This example flake.nix is pretty generic and the same for all
+  # examples, except when they define devShells or extra packages.
+  description = "Dream2nix example flake";
 
+  # We import the latest commit of dream2nix main branch and instruct nix to
+  # re-use the nixpkgs revision referenced by dream2nix.
+  # This is what we test in CI with, but you can generally refer to any
+  # recent nixpkgs commit here.
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
     dream2nix,
     nixpkgs,
-    ...
   }: let
-    system = "x86_64-linux";
+    # A helper that helps us define the attributes below for
+    # all systems we care about.
+    eachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   in {
-    # All packages defined in ./packages/<name> are automatically added to the flake outputs
-    # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
-    packages.${system} = dream2nix.lib.importPackages {
-      projectRoot = ./.;
-      # can be changed to ".git" or "flake.nix" to get rid of .project-root
-      projectRootFile = "flake.nix";
-      packagesDir = ./packages;
-      packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
-    };
+    packages = eachSystem (system:
+      dream2nix.lib.importPackages {
+        # All packages defined in ./packages/<name> are automatically added to the flake outputs
+        # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
+        projectRoot = ./.;
+        # can be changed to ".git" or "flake.nix" to get rid of .project-root
+        projectRootFile = "flake.nix";
+        packagesDir = ./packages;
+        packageSets.nixpkgs = nixpkgs.legacyPackages.${system};
+      });
   };
 }

--- a/modules/dream2nix/WIP-spago/default.nix
+++ b/modules/dream2nix/WIP-spago/default.nix
@@ -78,7 +78,6 @@ in {
       spago-unstable
       purs
       config.deps.git
-      config.deps.breakpointHook
       config.deps.esbuild
       config.deps.yq-go
     ];
@@ -139,7 +138,6 @@ in {
         git
         esbuild # used by spago bundle
         fetchFromGitHub
-        breakpointHook
         runCommand
         nodejs
         ;

--- a/modules/dream2nix/WIP-spago/default.nix
+++ b/modules/dream2nix/WIP-spago/default.nix
@@ -50,10 +50,15 @@
       tar -cvzf $out .
     '';
 
+  cacheDir =
+    if config.deps.stdenv.isDarwin
+    then "$HOME/Library/Caches/spago-nodejs"
+    else "$HOME/.cache/spago-nodejs";
+
   installSource = depName: dep: ''
     ln -s ${dep} .spago/packages/${depName}-${lock.${depName}.version}
-    mkdir -p $HOME/.cache/spago-nodejs/packages/${depName}
-    cp ${mkTarball depName} $HOME/.cache/spago-nodejs/packages/${depName}/${l.removePrefix "v" lock.${depName}.version}.tar.gz
+    mkdir -p ${cacheDir}/packages/${depName}
+    cp ${mkTarball depName} ${cacheDir}/packages/${depName}/${l.removePrefix "v" lock.${depName}.version}.tar.gz
   '';
 
   installSources = l.mapAttrsToList installSource cfg.sources;
@@ -86,9 +91,9 @@ in {
     ];
     buildPhase = ''
       export HOME="$(realpath .)"
-      mkdir -p "$HOME/.cache/spago-nodejs"
-      ln -s ${registry} "$HOME/.cache/spago-nodejs/registry"
-      ln -s ${registry-index} "$HOME/.cache/spago-nodejs/registry-index"
+      mkdir -p "${cacheDir}"
+      ln -s ${registry} "${cacheDir}/registry"
+      ln -s ${registry-index} "${cacheDir}/registry-index"
       mkdir -p .spago/packages
       ${toString installSources}
       spago bundle --verbose

--- a/modules/flake-parts/examples.nix
+++ b/modules/flake-parts/examples.nix
@@ -84,24 +84,20 @@ in {
 
     # map all modules in /examples to a package output in the flake.
     checks =
-      lib.optionalAttrs
-      (system == "x86_64-linux")
-      (
-        (lib.mapAttrs (_: flakeFile: getPackage flakeFile) allExamples)
-        // {
-          repo-with-packages = let
-            imported =
-              (import ../../examples/repo-with-packages {
-                dream2nixSource = ../..;
-                inherit pkgs;
-              })
-              .hello;
-          in
-            imported;
-          repo-with-packages-flake =
-            (importFlake ../../examples/repo-with-packages-flake/flake.nix).packages.${system}.hello;
-        }
-      );
+      (lib.mapAttrs (_: flakeFile: getPackage flakeFile) allExamples)
+      // {
+        repo-with-packages = let
+          imported =
+            (import ../../examples/repo-with-packages {
+              dream2nixSource = ../..;
+              inherit pkgs;
+            })
+            .hello;
+        in
+          imported;
+        repo-with-packages-flake =
+          (importFlake ../../examples/repo-with-packages-flake/flake.nix).packages.${system}.hello;
+      };
 
     # work around a bug in nix-fast-build / nix-eval jobs
     # TODO: remove this


### PR DESCRIPTION
all 4 default platforms of nixpkgs that is.

This looks like a huge change, but it's just the same boilerplate flake.nix all over. Except for the python-local-development-(pdm) examples, which include a devshell, the repo-with-packages-examples and the builtins-mkderivation example. 

It does at least evaluate on x86_64-linux and aarch64-darwin. We might not want to let buildbot run all checks on all platforms on each commit for capacity reasons, but it would be nice to be able run the locally on different platforms. :) 