### PR TITLE
referece docs: categorize modules

### DIFF
--- a/docs/hooks/render_options.py
+++ b/docs/hooks/render_options.py
@@ -104,19 +104,23 @@ def on_nav(nav: Navigation, config: MkDocsConfig, files: Files) -> Navigation | 
         # a reference section
         return nav
 
-    released = []
     experimental = []
+    internal = []
+    released = []
     for page in reference_section.children:
         # to have metadata from the yaml front-matter available
         page.read_source(config)
         state = page.meta.get("state")
-        if state == "released":
+        if state == "internal":
+            internal.append(page)
+        elif state == "released":
             released.append(page)
         else:
             experimental.append(page)
 
     experimental_section = Section("Experimental Modules", experimental)
-    reference_section.children = released + [experimental_section]
+    internal_section = Section("Internal Modules", internal)
+    reference_section.children = released + [experimental_section, internal_section]
 
     nav.items[reference_index] = reference_section
     return nav

--- a/docs/theme/reference_options.html
+++ b/docs/theme/reference_options.html
@@ -1,7 +1,7 @@
 ## Options
 {%- for name, option in options.items() recursive %}
 
-##{{loop.depth * "#"}} {{ ((option.loc | join (".")) or name).replace("<", "&lt;").replace(">", "&gt;") }}
+##{{"##"}} {{ ((option.loc | join (".")) or name).replace("<", "&lt;").replace(">", "&gt;") }}
 
 {% if (option.description or '') != "This option has no description." -%}
 {{ option.description or '' }}

--- a/modules/dream2nix/WIP-groups/README.md
+++ b/modules/dream2nix/WIP-groups/README.md
@@ -1,6 +1,6 @@
 ---
 title: "groups"
-state: experimental
+state: internal
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/buildPythonPackage/README.md
+++ b/modules/dream2nix/buildPythonPackage/README.md
@@ -1,6 +1,6 @@
 ---
 title: "buildPythonPackage"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/buildRustPackage/README.md
+++ b/modules/dream2nix/buildRustPackage/README.md
@@ -1,6 +1,6 @@
 ---
 title: "buildRustPackage"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/builtins-derivation/README.md
+++ b/modules/dream2nix/builtins-derivation/README.md
@@ -1,6 +1,6 @@
 ---
 title: "builtins-derivation"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/core/README.md
+++ b/modules/dream2nix/core/README.md
@@ -1,6 +1,6 @@
 ---
 title: "core"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/mkDerivation/README.md
+++ b/modules/dream2nix/mkDerivation/README.md
@@ -1,6 +1,6 @@
 ---
 title: "mkDerivation"
-state: released
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/multi-derivation-package/README.md
+++ b/modules/dream2nix/multi-derivation-package/README.md
@@ -1,6 +1,6 @@
 ---
 title: "multi-derivation-package"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nixpkgs-overrides/README.md
+++ b/modules/dream2nix/nixpkgs-overrides/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nixpkgs-overrides"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-devshell-v3/README.md
+++ b/modules/dream2nix/nodejs-devshell-v3/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-devshell-v3"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-devshell/README.md
+++ b/modules/dream2nix/nodejs-devshell/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-devshell"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-granular/README.md
+++ b/modules/dream2nix/nodejs-granular/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-granular"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-node-modules-v3/README.md
+++ b/modules/dream2nix/nodejs-node-modules-v3/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-node-modules-v3"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-node-modules/README.md
+++ b/modules/dream2nix/nodejs-node-modules/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-node-modules"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-package-json/README.md
+++ b/modules/dream2nix/nodejs-package-json/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-package-json"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/nodejs-package-lock/README.md
+++ b/modules/dream2nix/nodejs-package-lock/README.md
@@ -1,6 +1,6 @@
 ---
 title: "nodejs-package-lock"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/overrides/README.md
+++ b/modules/dream2nix/overrides/README.md
@@ -1,6 +1,6 @@
 ---
 title: "overrides"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/package-func/README.md
+++ b/modules/dream2nix/package-func/README.md
@@ -1,6 +1,6 @@
 ---
 title: "package-func"
-state: "released"
+state: "internal"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/rust-cargo-lock/README.md
+++ b/modules/dream2nix/rust-cargo-lock/README.md
@@ -1,6 +1,6 @@
 ---
 title: "rust-cargo-lock"
-state: "released"
+state: "experimental"
 maintainers:
   - DavHau
 ---

--- a/modules/dream2nix/rust-crane/README.md
+++ b/modules/dream2nix/rust-crane/README.md
@@ -1,6 +1,6 @@
 ---
 title: "rust-crane"
-state: "released"
+state: "experimental"
 maintainers:
   - DavHau
 ---


### PR DESCRIPTION
- **reference website: render all options with same heading size**
- **reference website: categorize into released/experimental/internal**
