### PR TITLE
docs: improve table of contents for options

### DIFF
--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -10,3 +10,14 @@
 .md-typeset td pre {
     margin: 0;
 }
+
+/* increase the width of the while site */
+.md-grid {
+    max-width: 80rem;
+}
+
+/* increase the width of the right hand side bar to display long option names better*/
+.md-sidebar--secondary {
+    width: 25rem !important;
+    left: -25rem !important;
+}

--- a/docs/theme/partials/toc-item.html
+++ b/docs/theme/partials/toc-item.html
@@ -1,56 +1,16 @@
-<!--
-     Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
-
-     Permission is hereby granted, free of charge, to any person obtaining a copy
-     of this software and associated documentation files (the "Software"), to
-     deal in the Software without restriction, including without limitation the
-     rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-     sell copies of the Software, and to permit persons to whom the Software is
-     furnished to do so, subject to the following conditions:
-
-     The above copyright notice and this permission notice shall be included in
-     all copies or substantial portions of the Software.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-     IN THE SOFTWARE.
--->
-
-<!-- Table of contents item -->
 <li class="md-nav__item">
-    {%- set should_collapse = toc_item.level > 2 and toc_item.children -%}
-    {% if should_collapse -%}
-    <details>
-        <summary>
-            {%- endif %}
-            <a href="{{ toc_item.url }}" class="md-nav__link">
-                <span class="md-ellipsis">
-                    {%- if page.url.split("/")[-3] == "reference" -%}
-                    {{ toc_item.title.split(".")[-1] }}
-                    {%- else -%}
-                    {{ toc_item.title }}
-                    {%- endif -%}
-                </span>
-            </a>
-         {% if should_collapse -%}
-        </summary>
-        {%- endif %}
-
-        <!-- Table of contents list -->
-        {% if toc_item.children %}
-        <nav class="md-nav" aria-label="{{ toc_item.title | striptags }}">
-            <ul class="md-nav__list">
-                {% for toc_item in toc_item.children %}
-                {% include "partials/toc-item.html" %}
-                {% endfor %}
-            </ul>
-        </nav>
-        {% endif %}
-        {% if should_collapse -%}
-    </details>
-    {%- endif %}
+    <a href="{{ toc_item.url }}" class="md-nav__link">
+      <span class="md-ellipsis">
+        {{ toc_item.title | replace(".", ".<wbr>")}}
+      </span>
+    </a>
+    {% if toc_item.children %}
+      <nav class="md-nav" aria-label="{{ toc_item.title | striptags }}">
+        <ul class="md-nav__list">
+          {% for toc_item in toc_item.children %}
+            {% include "partials/toc-item.html" %}
+          {% endfor %}
+        </ul>
+      </nav>
+    {% endif %}
 </li>


### PR DESCRIPTION
- increase width of toc
- show full option path in toc
- no nesting

This simplifies navigation on option pages a lot.
