### PR TITLE
fetchPipMetadata: set PKG_CONFIG_PATH...

### DIFF
--- a/pkgs/fetchPipMetadata/script.nix
+++ b/pkgs/fetchPipMetadata/script.nix
@@ -55,6 +55,12 @@
       ;
   });
 
+  env' =
+    {
+      PKG_CONFIG_PATH = lib.concatMapStringsSep ":" (n: "${n}/lib/pkgconfig") nativeBuildInputs;
+    }
+    // env;
+
   script =
     writePureShellScript
     path
@@ -63,7 +69,7 @@
         lib.foldlAttrs
         (acc: name: value: acc + "\nexport " + lib.toShellVar name value)
         ""
-        env
+        env'
       }
       ${package}/bin/fetch_pip_metadata \
         --json-args-file ${args} \


### PR DESCRIPTION
to nativeBuildInputs. We still need to run a setup.py for many packages at locking time. Those often try to find inputs via PKG_CONFIG_PATH so i think it's a reasonable default.