### PR TITLE
editables: fix path ordering, remove relics...

### DIFF
--- a/docs/src/guides/pip.md
+++ b/docs/src/guides/pip.md
@@ -6,7 +6,7 @@ title: Build a python project with pip
 
     We recommend reading our [Getting Started](./getting-started.md) guide first if you have not done so yet!
 
-this guide we are going to take a look at two annotated examples using the [pip module](../reference/pip/index.md):
+In this guide we are going to take a look at two annotated examples using the [pip module](../reference/pip/index.md):
 
 - The first one builds [Pillow](https://python-pillow.org/) from upstream sources fetched from PyPi.
 - The second one builds a fictional python project living in the same repository as the nix sources

--- a/docs/src/guides/pip.md
+++ b/docs/src/guides/pip.md
@@ -317,8 +317,10 @@ see where they are imported from:
 
 ```shell-session
 $ nix develop
-Some python dependencies of my-tool are installed in editable mode
-To disable editable mode for a package, remove the corresponding entry from the 'editables' field in the dream2nix configuration file.
+evaluating derivation 'git+file://[path_to_your_repo]#devShells.x86_64-linux.default'
+Some python dependencies of /Users/phaer/src/dream2nix/examples/packages/languages/python-local-development are installed in editable mode
+  my-tool
+    installed at: .
 $ ipython
 [...]
 In [1]: import my_tool

--- a/examples/packages/languages/python-local-development/default.nix
+++ b/examples/packages/languages/python-local-development/default.nix
@@ -38,9 +38,9 @@ in {
 
   paths.lockFile = "lock.${config.deps.stdenv.system}.json";
   pip = {
-    # Setting editables.$pkg to an absolute path will link this path as an editable
-    # install to .dream2nix/editables in devShells. The root package is always installed
-    # as editable.
+    # Setting editables.$pkg to a relative or absolute path, as a string, will
+    # link this path as an editable install to .dream2nix/editables in
+    # devShells. The root package is always installed as editable.
     # editables.charset-normalizer = "/home/my-user/src/charset-normalizer";
 
     requirementsList =

--- a/modules/dream2nix/python-editables/interface.nix
+++ b/modules/dream2nix/python-editables/interface.nix
@@ -8,15 +8,21 @@ in {
   options = {
     editables = lib.mkOption {
       description = ''
-        An attribute set mapping package names to absolute paths of source directories
-        which should be installed in editable mode in [editablesShellHook](#pipeditablesshellhook).
+        An attribute set mapping package names to a path, absolute or relative,
+        of source directories which should be installed in editable mode in
+        [editablesShellHook](#pipeditablesshellhook).
         i.e.
 
         ```
           pip.editables.charset-normalizer = "/home/user/src/charset-normalizer".
         ```
 
-        The top-level package is added automatically.
+        The top-level package is included automatically.
+
+        This must be a string, as otherwise content would be copied to the nix store
+        and loaded from there, voiding the benefits of editable installs.
+        For the same reason, it is advised to use source filtering if you
+        use a path inside the current repo to avoid unecessary rebuilds.
       '';
       type = t.attrsOf t.str;
     };


### PR DESCRIPTION
...of the former feature which linked sources in .dream2nix/editables.
This was uncleanly removed before.

Also fix a typo in pip.md, thanks @purepani 