### PR TITLE
fix: python torch override for mac - no cuda on mac

### DIFF
--- a/overrides/python/torch/default.nix
+++ b/overrides/python/torch/default.nix
@@ -9,12 +9,14 @@
   # use the autoAddOpenGLRunpathHook to add /run/opengl-driver/lib to the RPATH
   #   of all ELF files
   deps = {nixpkgs, ...}: {
-    inherit (nixpkgs.cudaPackages) autoAddOpenGLRunpathHook;
+    inherit (nixpkgs.stdenv) isLinux;
+    autoAddOpenGLRunpathHook = lib.optionalAttribute nixpkgs.stdenv.isLinux nixpkgs.cudaPackages.autoAddOpenGLRunpathHook;
   };
-  mkDerivation.nativeBuildInputs = [
+
+  mkDerivation.nativeBuildInputs = lib.mkIf config.deps.isLinux [
     config.deps.autoAddOpenGLRunpathHook
   ];
 
   # this file is patched manually, so ignore it in autoPatchelf
-  env.autoPatchelfIgnoreMissingDeps = ["libcuda.so.1"];
+  env.autoPatchelfIgnoreMissingDeps = lib.mkIf config.deps.isLinux ["libcuda.so.1"];
 }


### PR DESCRIPTION
Adding torch to a project on mac failed as there are no cudaPackages.

The fix should only enable cuda if Linux is detected.