### PR TITLE
Redirect "To the docs" link to "Getting Started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If your organization wants to support the project with extra funding in order to
 
 ### Documentation
 
-[👉 To the docs](https://dream2nix.dev)
+[👉 To the docs](https://dream2nix.dev/guides/getting-started/)
 
 ### Presentations
 


### PR DESCRIPTION
This link is dead when clicked from dream2nix.dev. Make it point to actual documentation. Closes #842