### PR TITLE
Adds uv resolver for pdm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1729850857,
+        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1724504251,
-        "narHash": "sha256-TIw+sac0NX0FeAneud+sQZT+ql1G/WEb7/Vb436rUXM=",
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "988b09676c2a0e6a46dfa3589aa6763c90476b8a",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
         "type": "github"
       },
       "original": {

--- a/modules/dream2nix/WIP-python-pdm/default.nix
+++ b/modules/dream2nix/WIP-python-pdm/default.nix
@@ -78,6 +78,7 @@ in {
       jq
       mkShell
       pdm
+      uv
       runCommand
       stdenvNoCC
       stdenv

--- a/modules/dream2nix/WIP-python-pdm/lock.nix
+++ b/modules/dream2nix/WIP-python-pdm/lock.nix
@@ -6,6 +6,7 @@
 }: let
   pdmConfig = config.deps.writeText "pdm-config.toml" ''
     check_update = false
+    use_uv = true
     [python]
     use_venv = false
   '';
@@ -18,6 +19,7 @@
       config.deps.coreutils
       config.deps.pdm
       config.deps.yq
+      config.deps.uv
     ]}"
     export TMPDIR=$(${config.deps.coreutils}/bin/mktemp -d)
     trap "${config.deps.coreutils}/bin/chmod -R +w '$TMPDIR'; ${config.deps.coreutils}/bin/rm -rf '$TMPDIR'" EXIT


### PR DESCRIPTION
PDM now experimentally supports a [uv resolver](https://github.com/pdm-project/pdm/pull/3144). This is significantly faster(even on the examples with very few dependencies, resolve times go from a few seconds to a few hundred milliseconds). This PR enables the use of that resolver. 

note that nixpkgs needs to be updated due to only the newer versions of pdm supporting it.

@DavHau @phaer 