### PR TITLE
fix(rust-crane): add mkRustToolchain to interface options, define a proper default, pass toolchain to vendor and devshell

### DIFF
--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -80,10 +80,8 @@
   _crane = import config.deps.craneSource {
     pkgs = config.deps.cranePkgs;
   };
-  crane =
-    if config.deps.mkRustToolchain != null
-    then _crane.overrideToolchain config.deps.mkRustToolchain
-    else _crane;
+  crane = _crane.overrideToolchain config.deps.mkRustToolchain;
+  rustToolchain = config.deps.mkRustToolchain config.deps.cranePkgs;
 
   vendoring = import ./vendor.nix {
     inherit dreamLock getSource lib;
@@ -94,13 +92,13 @@
       ;
     inherit
       (config.deps)
-      cargo
       jq
       moreutils
       python3Packages
       runCommandLocal
       writePython3
       ;
+    cargo = rustToolchain;
   };
 
   pname = config.name;
@@ -198,7 +196,8 @@ in {
       depsDrv = cfg.depsDrv.public;
       mainDrv = config.public;
       inherit lib;
-      inherit (config.deps) libiconv mkShell cargo;
+      inherit (config.deps) libiconv mkShell;
+      cargo = rustToolchain;
     };
     dependencies = cfg.depsDrv.public;
     meta = (utils.getMeta pname version) // config.mkDerivation.meta;
@@ -214,7 +213,7 @@ in {
           sha256 = "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=";
         };
         cranePkgs = nixpkgs.pkgs;
-        mkRustToolchain = null;
+        mkRustToolchain = pkgs: pkgs.cargo;
       })
       # maybe it would be better to put these under `options.rust-crane.deps` instead of this `deps`
       # since it conflicts with a lot of stuff?

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -8,23 +8,13 @@
   t = l.types;
 in {
   options.deps = {
-    cargo = l.mkOption {
-      type = t.package;
-      description = "The Cargo package to use";
-    };
     craneSource = l.mkOption {
       type = t.path;
       description = "Source to use for crane functions";
     };
-    crane = {
-      buildPackage = l.mkOption {
-        type = t.functionTo t.package;
-        description = "The function to use when building packages";
-      };
-      buildDepsOnly = l.mkOption {
-        type = t.functionTo t.package;
-        description = "The function to use when building dependencies of a package";
-      };
+    mkRustToolchain = l.mkOption {
+      type = t.functionTo t.package;
+      description = "Function to call that returns a rust toolchain using the provided nixpkgs instance";
     };
   };
 


### PR DESCRIPTION
removes the crane option because it was not used anymore, and doesn't make sense to keep regardless (can just override the package, there should not be any need to modify the crane functions other than changing the source used for crane)