### PR TITLE
feat(rust-crane): add options for changing build, check and test cargo subcommands

### DIFF
--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -53,15 +53,19 @@
     cargoVendorDir = "$TMPDIR/nix-vendor";
     installCargoArtifactsMode = "use-zstd";
 
+    checkCargoCommand = cfg.checkCommand;
+    buildCargoCommand = cfg.buildCommand;
     cargoBuildProfile = cfg.buildProfile;
-    cargoTestProfile = cfg.testProfile;
     cargoBuildFlags = cfg.buildFlags;
+    testCargoCommand = cfg.testCommand;
+    cargoTestProfile = cfg.testProfile;
     cargoTestFlags = cfg.testFlags;
     doCheck = cfg.runTests;
 
-    # Make sure cargo only builds & tests the package we want
-    cargoBuildCommand = "cargo build \${cargoBuildFlags:-} --profile \${cargoBuildProfile} --package ${pname}";
-    cargoTestCommand = "cargo test \${cargoTestFlags:-} --profile \${cargoTestProfile} --package ${pname}";
+    # Make sure cargo only checks & builds & tests the package we want
+    cargoCheckCommand = "cargo \${checkCargoCommand} \${cargoBuildFlags:-} --profile \${cargoBuildProfile} --package ${pname}";
+    cargoBuildCommand = "cargo \${buildCargoCommand} \${cargoBuildFlags:-} --profile \${cargoBuildProfile} --package ${pname}";
+    cargoTestCommand = "cargo \${testCargoCommand} \${cargoTestFlags:-} --profile \${cargoTestProfile} --package ${pname}";
   };
 
   # The deps-only derivation will use this as a prefix to the `pname`
@@ -79,8 +83,6 @@
     inherit (config.rust-cargo-lock) cargoLock;
     pname = l.mkOverride 99 pname;
     pnameSuffix = depsNameSuffix;
-    # Make sure cargo only checks the package we want
-    cargoCheckCommand = "cargo check \${cargoBuildFlags:-} --profile \${cargoBuildProfile} --package ${pname}";
     dream2nixVendorDir = config.rust-cargo-vendor.vendoredSources;
   };
 

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -24,24 +24,40 @@ in {
       description = "Whether to run tests via `cargo test`";
       default = true;
     };
+    checkCommand = {
+      type = t.str;
+      description = "The cargo subcommand to use when checking the crate (instead of 'check' in 'cargo check')";
+      default = "check";
+      example = "clippy";
+    };
+    buildCommand = {
+      type = t.str;
+      description = "The cargo subcommand to use when building the crate (instead of 'build' in 'cargo build')";
+      default = "build";
+    };
     buildProfile = {
       type = t.str;
-      description = "The profile to use when running `cargo build` and `cargo check`";
-      default = "release";
-    };
-    testProfile = {
-      type = t.str;
-      description = "The profile to use when running `cargo test`";
+      description = "The profile to use when building & checking";
       default = "release";
     };
     buildFlags = {
       type = t.listOf t.str;
-      description = "Flags to add when running `cargo build` and `cargo check`";
+      description = "Flags to add when building & checking";
       default = [];
+    };
+    testCommand = {
+      type = t.str;
+      description = "The cargo subcommand to use when testing the crate (instead of 'test' in 'cargo test')";
+      default = "test";
+    };
+    testProfile = {
+      type = t.str;
+      description = "The profile to use when testing the crate";
+      default = "release";
     };
     testFlags = {
       type = t.listOf t.str;
-      description = "Flags to add when running `cargo test`";
+      description = "Flags to add when testing the crate";
       default = [];
     };
     depsDrv = {


### PR DESCRIPTION
- adds `buildCommand`, `checkCommand` and `testCommand` for changing the cargo subcommands used