### PR TITLE
feat(rust-crane): expose the crane lib that is created from craneSource as a read-only option

### DIFF
--- a/modules/dream2nix/rust-crane/default.nix
+++ b/modules/dream2nix/rust-crane/default.nix
@@ -140,6 +140,7 @@ in {
         cargo = l.mkOverride 1001 rustToolchain;
       }
       (l.mapAttrs (_: l.mkDefault) {
+        inherit crane;
         craneSource = config.deps.fetchFromGitHub {
           owner = "ipetkov";
           repo = "crane";

--- a/modules/dream2nix/rust-crane/interface.nix
+++ b/modules/dream2nix/rust-crane/interface.nix
@@ -8,6 +8,11 @@
   t = l.types;
 in {
   options.deps = {
+    crane = l.mkOption {
+      type = t.attrs;
+      readOnly = true;
+      description = "The crane lib that was instantiated from `craneSource`";
+    };
     craneSource = l.mkOption {
       type = t.path;
       description = "Source to use for crane functions";


### PR DESCRIPTION
exposing this is useful since downstream can just use the crane lib dream2nix creates instead of using their own if they want to do something with it