### PR TITLE
pdm: sort extras before making the key

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/lib.nix
+++ b/modules/dream2nix/WIP-python-pdm/lib.nix
@@ -196,7 +196,7 @@
   mkExtrasKey = dep @ {extras ? [], ...}:
     if extras == []
     then "default"
-    else lib.concatStringsSep "," extras;
+    else lib.concatStringsSep "," (lib.naturalSort extras);
 
   # Constructs dependency entry for internal use.
   # We could use the pyproject.nix representation directly instead, but it seems


### PR DESCRIPTION
...otherwise we seem to get them in the order they are declared in in pyproject.toml, which seemingly might not be the same as in the lock file where they are sorted