### PR TITLE
Allow not setting version in package.json

### DIFF
--- a/modules/dream2nix/nodejs-granular-v3/default.nix
+++ b/modules/dream2nix/nodejs-granular-v3/default.nix
@@ -34,7 +34,7 @@
   pdefs = config.nodejs-package-lock-v3.pdefs;
 
   defaultPackageName = config.nodejs-package-lock-v3.packageLock.name;
-  defaultPackageVersion = config.nodejs-package-lock-v3.packageLock.version;
+  defaultPackageVersion = config.nodejs-package-lock-v3.packageLock.version or "";
 
   nodejs = config.deps.nodejs;
 

--- a/modules/dream2nix/nodejs-package-lock-v3/default.nix
+++ b/modules/dream2nix/nodejs-package-lock-v3/default.nix
@@ -54,7 +54,7 @@
       # Root level package
       name = entry.name;
       value = {
-        ${entry.version} = {
+        ${entry.version or ""} = {
           dependencies = getDependencies lock path entry;
         };
       };


### PR DESCRIPTION
This is in fact the default behavior with e.g. npx create-remix. Previously, if you created a package with that command and tried running dream2nix, you'd get a missing attribute error.