### PR TITLE
fix(fetchPipMetadata): quote path arguments to fetch_pip_metadata script

### DIFF
--- a/pkgs/fetchPipMetadata/script.nix
+++ b/pkgs/fetchPipMetadata/script.nix
@@ -66,8 +66,8 @@
         env
       }
       ${package}/bin/fetch_pip_metadata \
-        --json-args-file ${args} \
-        --project-root $(${findRoot})
+        --json-args-file "${args}" \
+        --project-root "$(${findRoot})"
     '';
 in
   script


### PR DESCRIPTION
Allows user to have spaces in the project root path, fixes #795