### PR TITLE
package-func: select first output in outputs for multi-output derivations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 #### Unified override interface across languages
 
 New options `overrides.${name}` and `overrideAll` for all language modules that manage a dependency tree.
+
+### Changed
+
+#### Modified choice of output used as top-level output in package-func
+
+Changed the top-level output selected for multi-output derivations to be  the first output declared in `package-func.outputs` or the default output (if the attribute `outputSpecified` is true) instead of 'out'.

--- a/modules/dream2nix/package-func/README.md
+++ b/modules/dream2nix/package-func/README.md
@@ -4,3 +4,25 @@ state: "internal"
 maintainers:
   - DavHau
 ---
+
+Module to provide an interface for integrating derivation builder functions like mkDerivation, buildPythonPackage, etc...
+
+## Package format
+
+package-func calls the derivation builder function `package-func.func` with arguments supplied in `package-func.args` and wraps the result into the a package that is exposed under `config.public`. The raw result is avaliable as `package-func.result`.
+
+The final package contains the following attributes:
+
+- `config`: the config used to product the existing package
+- `extendModules`: a helper function that allows to extend an existing package with another module
+- `outputPath`: the store path of the result of the default top-level output
+- `drvPath`; the store path of the instantiated derivation of top-level output
+- `outputName`: the name of the default top-level output
+
+In addition, it contains an attribute of the same name for each output declared in `package-func.outputs`, mapping the output name to the corresponding output of evaluated result.
+
+## Top-level output
+
+The top-level output exposed in the final package is selected from `package-func.outputs`.
+
+For a single-output derivations, the sole output is used as the top-level output. For multi-output derivations, the first output specified in outputs or the default output (if the attribute `outputSpecified` is true) is used as the top-level output.


### PR DESCRIPTION
This commit modifies the package-func module to use the first output in
`package-func.outputs` or the default output (if the attribute `outputSpecified`
is true) as the top-level output in the final package instead of throwing
an error for multi-output derivations. Documentation for structure of the
assembled package and the selection criterion for the top-level output added
to the README.md under the module directory. In addition, a changelog entry
was appended to CHANGELOG.md to record this change.