### PR TITLE
added jack-sys dependency override for rust

### DIFF
--- a/overrides/rust/jack-sys/default.nix
+++ b/overrides/rust/jack-sys/default.nix
@@ -1,0 +1,12 @@
+{
+  config,
+  lib,
+  ...
+}: {
+  deps = {nixpkgs, ...}: {
+    inherit (nixpkgs) pkg-config libjack2;
+  };
+
+  mkDerivation.buildInputs = [ config.deps.libjack2 ];
+  mkDerivation.nativeBuildInputs = [ config.deps.pkg-config ];
+}

--- a/overrides/rust/jack-sys/default.nix
+++ b/overrides/rust/jack-sys/default.nix
@@ -7,6 +7,6 @@
     inherit (nixpkgs) pkg-config libjack2;
   };
 
-  mkDerivation.buildInputs = [ config.deps.libjack2 ];
-  mkDerivation.nativeBuildInputs = [ config.deps.pkg-config ];
+  mkDerivation.buildInputs = [config.deps.libjack2];
+  mkDerivation.nativeBuildInputs = [config.deps.pkg-config];
 }


### PR DESCRIPTION
I added a dependency override for the `jack-sys` rust crate. Let me know if I did something wrong because I'm pretty new to dream2nix (and also contributing to open source) but I think this is correct as far as I can tell.
