### PR TITLE
natural sort extras in mkDepEntry

### DIFF
--- a/modules/dream2nix/WIP-python-pdm/lib.nix
+++ b/modules/dream2nix/WIP-python-pdm/lib.nix
@@ -206,7 +206,7 @@
     extras,
     ...
   }: {
-    extras = extras;
+    extras = lib.naturalSort extras;
     sources = parsed_lock_data.${name}.${mkExtrasKey {inherit extras;}}.sources;
     version = parsed_lock_data.${name}.${mkExtrasKey {inherit extras;}}.version;
   };


### PR DESCRIPTION
Fixes key error where natural sort from `sources` & `version` doesn't match the original `extras` key order