### PR TITLE
override: python certifi

### DIFF
--- a/overrides/python/certifi/default.nix
+++ b/overrides/python/certifi/default.nix
@@ -1,0 +1,13 @@
+{
+  config,
+  lib,
+  dream2nix,
+  ...
+}: let
+  isSdist = lib.hasSuffix ".tar.gz" config.mkDerivation.src;
+in {
+  # enable overrides from nixpkgs
+  imports = [dream2nix.modules.dream2nix.nixpkgs-overrides];
+  nixpkgs-overrides.enable = isSdist;
+  nixpkgs-overrides.exclude = ["propagatedBuildInputs"];
+}


### PR DESCRIPTION
python / certifi comes with its own certificate store. nixpkgs applies a patch by default to use NIX_SSL_CERT_FILE instead

https://github.com/NixOS/nixpkgs/blob/ad331efcaf680eb1c838cb339472399ea7b3cdab/pkgs/development/python-modules/certifi/default.nix#L25-L34