### PR TITLE
pdm: group name

### DIFF
--- a/modules/dream2nix/python-pdm/default.nix
+++ b/modules/dream2nix/python-pdm/default.nix
@@ -42,8 +42,8 @@
     setuptools =
       if cfg.name == "setuptools"
       then config.deps.python.pkgs.setuptools
-      else if config.groups.default.packages ? setuptools
-      then (lib.head (lib.attrValues config.groups.default.packages.setuptools)).public
+      else if (config.groups.${config.pdm.group}.packages) ? setuptools
+      then (lib.head (lib.attrValues (config.groups.${config.pdm.group}.packages.setuptools))).public
       else config.deps.python.pkgs.setuptools;
   in {
     imports = [
@@ -113,7 +113,7 @@ in {
       map
       (x: (lib.head (lib.attrValues x)).public)
       # all packages attrs prefixed with version
-      (lib.attrValues config.groups.default.packages);
+      (lib.attrValues (config.groups.${config.pdm.group}.packages));
   };
 
   public.pyEnv = let
@@ -140,16 +140,16 @@ in {
     ];
     buildInputs =
       [
-        config.groups.default.packages.tomli.public or config.deps.python.pkgs.tomli
+        (config.groups.${config.pdm.group}.packages.tomli.public or config.deps.python.pkgs.tomli)
       ]
       ++ lib.flatten (
         lib.mapAttrsToList
-        (name: _path: config.groups.default.packages.${name}.evaluated.mkDerivation.buildInputs or [])
+        (name: _path: config.groups.${config.pdm.group}.packages.${name}.evaluated.mkDerivation.buildInputs or [])
         config.pdm.editables
       );
     nativeBuildInputs = lib.flatten (
       lib.mapAttrsToList
-      (name: _path: config.groups.default.packages.${name}.evaluated.mkDerivation.nativeBuildInputs or [])
+      (name: _path: config.groups.${config.pdm.group}.packages.${name}.evaluated.mkDerivation.nativeBuildInputs or [])
       config.pdm.editables
     );
   };

--- a/modules/dream2nix/python-pdm/interface.nix
+++ b/modules/dream2nix/python-pdm/interface.nix
@@ -24,6 +24,10 @@ in {
         type = t.bool;
         default = false;
       };
+      group = l.mkOption {
+        type = t.str;
+        default = "default";
+      };
 
       sourceSelector = import ./sourceSelectorOption.nix {inherit lib;};
     };

--- a/modules/dream2nix/python-pdm/tests/packages/python-local-development/default.nix
+++ b/modules/dream2nix/python-pdm/tests/packages/python-local-development/default.nix
@@ -13,6 +13,7 @@
   };
   pdm.lockfile = ./pdm.lock;
   pdm.pyproject = ./pyproject.toml;
+  pdm.group = "dev";
   mkDerivation = {
     src = ./.;
     buildInputs = [

--- a/modules/dream2nix/python-pdm/tests/packages/python-local-development/pyproject.toml
+++ b/modules/dream2nix/python-pdm/tests/packages/python-local-development/pyproject.toml
@@ -4,7 +4,7 @@ name = "my-project"
 version = "0.1.0"
 description = ""
 dependencies = [
-    "requests>=2.31.0",
+    "pi>=0.1.2",
 ]
 requires-python = ">=3.10"
 readme = "README.md"
@@ -15,7 +15,7 @@ my-script = "my_project:main"
 
 [project.optional-dependencies]
 dev = [
-    "pi>=0.1.2",
+    "requests>=2.31.0",
 ]
 
 [build-system]


### PR DESCRIPTION
the advantage of PDM and its single lockfile is a single point of truth, for multiple architectures and multiple use cases (groups).

The groups feature should get leveraged, in order to have different types of python, e.g. python used for tests, python used for runtime only.

Therefore the group which should get used should be configurable. Closes https://github.com/nix-community/dream2nix/issues/1093

modules/dream2nix/python-pdm/tests/packages/python-local-development:

![image](https://github.com/user-attachments/assets/446ef875-c4bc-4e88-a636-e37fd29a483c)
