### PR TITLE
docs: open options in new tab

### DIFF
--- a/modules/flake-parts/reference-website/default.nix
+++ b/modules/flake-parts/reference-website/default.nix
@@ -72,7 +72,7 @@
 
     optionsReference = modules: let
       linkOptionsDocs = name: sourcePath: ''
-        [Browse Options](/options/?scope=${name})
+        <a href="/options/?scope=${name}" target="_blank">Browse Options</a>
       '';
 
       createReference = name: sourcePath: ''


### PR DESCRIPTION
This is better, as people might want to keep the original docs website open
