### PR TITLE
use upstream fetchPypiLegacy & meta pURL support for fetcher

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,18 +55,21 @@
       }
     },
     "pyproject-nix": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1702448246,
-        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
-        "owner": "davhau",
+        "lastModified": 1752481895,
+        "narHash": "sha256-luVj97hIMpCbwhx3hWiRwjP2YvljWy8FM+4W9njDhLA=",
+        "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "rev": "16ee295c25107a94e59a7fc7f2e5322851781162",
         "type": "github"
       },
       "original": {
-        "owner": "davhau",
-        "ref": "dream2nix",
+        "owner": "pyproject-nix",
         "repo": "pyproject.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    # TODO: go back to upstream after PRs are merged
-    pyproject-nix.url = "github:davhau/pyproject.nix/dream2nix";
-    pyproject-nix.flake = false;
+    pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+    pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     purescript-overlay.url = "github:thomashoneyman/purescript-overlay";
     purescript-overlay.inputs.nixpkgs.follows = "nixpkgs";

--- a/tests/nix-unit/test_python-pdm-lib/default.nix
+++ b/tests/nix-unit/test_python-pdm-lib/default.nix
@@ -197,6 +197,7 @@ in {
                   post = null;
                   pre = null;
                   release = [1 0 0];
+                  str = "1.0.0";
                 };
               }
             ];


### PR DESCRIPTION
1:1 pURL support for fetcher, to be introduced through https://github.com/NixOS/nixpkgs/pull/421125

all fetchers have been removed from pyproject.nix: https://github.com/pyproject-nix/pyproject.nix/pull/55 & https://github.com/pyproject-nix/pyproject.nix/pull/56