### PR TITLE
replace explicit php81 references

### DIFF
--- a/examples/packages/languages/php-packaging/default.nix
+++ b/examples/packages/languages/php-packaging/default.nix
@@ -15,6 +15,7 @@
       fetchFromGitHub
       stdenv
       ;
+    php = nixpkgs.php81;
   };
 
   name = "cowsay";

--- a/modules/dream2nix/php-granular/default.nix
+++ b/modules/dream2nix/php-granular/default.nix
@@ -68,10 +68,10 @@
 
   # php with required extensions
   php =
-    if satisfies config.deps.php81.version subsystemAttrs.phpSemver
+    if satisfies config.deps.php.version subsystemAttrs.phpSemver
     then
-      # config.deps.php81
-      config.deps.php81.withExtensions
+      # config.deps.php
+      config.deps.php.withExtensions
       (
         {
           all,
@@ -84,7 +84,7 @@
         Error: incompatible php versions.
         Package "${defaultPackageName}" defines required php version:
           "php": "${subsystemAttrs.phpSemver}"
-        Using php version "${config.deps.php81.version}" from attribute "config.deps.php81".
+        Using php version "${config.deps.php.version}" from attribute "config.deps.php".
       '';
   composer = php.packages.composer;
 


### PR DESCRIPTION
as php81 is EOL - promote picking your php version explicitly

not fully tested