### PR TITLE
php-granular: pass sourceRoot

### DIFF
--- a/modules/dream2nix/php-granular/default.nix
+++ b/modules/dream2nix/php-granular/default.nix
@@ -40,6 +40,7 @@
     inherit defaultPackageName defaultPackageVersion;
     inherit (dreamLockLoaded.lock) sources;
     inherit fetchers;
+    sourceRoot = "${config.mkDerivation.src}";
   };
 
   getSource = getDreamLockSource fetchedSources;


### PR DESCRIPTION
to make path repositories/dependencies in the root project work

not fully tested