### PR TITLE
php-semver: expect '=' prefix in semver spec

### DIFF
--- a/lib/internal/php-semver.nix
+++ b/lib/internal/php-semver.nix
@@ -40,12 +40,12 @@
       operators.">=" version v && operators."<" version upper;
   in {
     # Prefix operators
-    "==" = mkComparison 0;
+    "=" = mkComparison 0;
     ">" = mkComparison 1;
     "<" = mkComparison (-1);
-    "!=" = v: c: !operators."==" v c;
-    ">=" = v: c: operators."==" v c || operators.">" v c;
-    "<=" = v: c: operators."==" v c || operators."<" v c;
+    "!=" = v: c: !operators."=" v c;
+    ">=" = v: c: operators."=" v c || operators.">" v c;
+    "<=" = v: c: operators."=" v c || operators."<" v c;
     # Semver specific operators
     "~" = mkTildeComparison;
     "^" = mkCaretComparison;
@@ -104,7 +104,7 @@
     }
     else if mNone != null
     then {
-      ops.t = "==";
+      ops.t = "=";
       v = orBlank (l.elemAt mNone 0);
     }
     else throw ''Constraint "${constraintStr}" could not be parsed''


### PR DESCRIPTION
https://getcomposer.org/doc/articles/versions.md#stability-constraints

not fully tested